### PR TITLE
Small fix so torch_harmonics.distributed gets installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 nlat = 512
 nlon = 2*nlat
 batch_size = 32
-signal = torch.randn(batch_size, nlat, nlon)
+signal = torch.randn(batch_size, nlat, nlon).to(device)
 
 # transform data on an equiangular grid
 sht = harmonics.RealSHT(nlat, nlon, grid="equiangular").to(device).float()

--- a/setup.py
+++ b/setup.py
@@ -29,14 +29,14 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
    name='torch_harmonics',
    version='0.4',
    author='Boris Bonev',
    author_email='bbonev@nvidia.com',
-   packages=['torch_harmonics',],
+   packages=find_packages(),
    scripts=[],
    url='https://github.com/NVIDIA/torch-harmonics',
    license='LICENSE.md',


### PR DESCRIPTION
Was running into an issue with installing the package using `pip install .` or including this as a dependency in other repos using a `pyproject.toml`:

```
import torch_harmonics as harmonics
...
ModuleNotFoundError: No module named 'torch_harmonics.distributed'

ls /usr/local/lib/python3.8/dist-packages/torch_harmonics
__init__.py  __pycache__/  legendre.py  quadrature.py  sht.py  test_torch_harmonics.py
```

Using `find_packages()` fixes the issue for me by recursively adding package directories that have `__init__.py` files.