### PR TITLE
Fix __init__.py file to import from local "examples" dir.

### DIFF
--- a/torch_harmonics/__init__.py
+++ b/torch_harmonics/__init__.py
@@ -34,4 +34,4 @@ __version__ = '0.6.1'
 from .sht import RealSHT, InverseRealSHT, RealVectorSHT, InverseRealVectorSHT
 from . import quadrature
 from . import random_fields
-import examples
+from . import examples


### PR DESCRIPTION
Without this fix, importing torch_harmonics had run into a module import error when trying to execute:
> [37] `import examples`