### PR TITLE
Tkurth/distributed memory reduction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@
 # build after cloning in directoy torch_harmonics via
 # docker build . -t torch_harmonics
 
-FROM nvcr.io/nvidia/pytorch:24.05-py3
+FROM nvcr.io/nvidia/pytorch:24.07-py3
 
 COPY . /workspace/torch_harmonics
 

--- a/torch_harmonics/_disco_convolution.py
+++ b/torch_harmonics/_disco_convolution.py
@@ -32,7 +32,7 @@
 import math
 
 import torch
-from torch.cuda.amp import custom_fwd, custom_bwd
+from torch.amp import custom_fwd, custom_bwd
 
 try:
     import disco_cuda_extension
@@ -44,7 +44,7 @@ except ImportError as err:
 
 class _DiscoS2ContractionCuda(torch.autograd.Function):
     @staticmethod
-    @custom_fwd(device_type='cuda', cast_inputs=torch.float32)
+    @custom_fwd(device_type="cuda", cast_inputs=torch.float32)
     def forward(ctx, x: torch.Tensor, roff_idx: torch.Tensor, ker_idx: torch.Tensor,
                 row_idx: torch.Tensor, col_idx: torch.Tensor, vals: torch.Tensor,
                 kernel_size: int, nlat_out: int, nlon_out: int):
@@ -57,7 +57,7 @@ class _DiscoS2ContractionCuda(torch.autograd.Function):
         return output
 
     @staticmethod
-    @custom_bwd(device_type='cuda')
+    @custom_bwd(device_type="cuda")
     def backward(ctx, grad_output):
         roff_idx, ker_idx, row_idx, col_idx, vals = ctx.saved_tensors
         grad_input = disco_cuda_extension.backward(grad_output.contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals,
@@ -68,7 +68,7 @@ class _DiscoS2ContractionCuda(torch.autograd.Function):
 
 class _DiscoS2TransposeContractionCuda(torch.autograd.Function):
     @staticmethod
-    @custom_fwd(device_type='cuda', cast_inputs=torch.float32)
+    @custom_fwd(device_type="cuda", cast_inputs=torch.float32)
     def forward(ctx, x: torch.Tensor, roff_idx: torch.Tensor, ker_idx: torch.Tensor,
                 row_idx: torch.Tensor, col_idx: torch.Tensor, vals: torch.Tensor,
                 kernel_size: int, nlat_out: int, nlon_out: int):
@@ -81,7 +81,7 @@ class _DiscoS2TransposeContractionCuda(torch.autograd.Function):
         return output
 
     @staticmethod
-    @custom_bwd(device_type='cuda')
+    @custom_bwd(device_type="cuda")
     def backward(ctx, grad_output):
         roff_idx, ker_idx, row_idx, col_idx, vals = ctx.saved_tensors
         inp_type = grad_output.dtype

--- a/torch_harmonics/_disco_convolution.py
+++ b/torch_harmonics/_disco_convolution.py
@@ -85,7 +85,7 @@ class _DiscoS2TransposeContractionCuda(torch.autograd.Function):
     def backward(ctx, grad_output):
         roff_idx, ker_idx, row_idx, col_idx, vals = ctx.saved_tensors
         inp_type = grad_output.dtype
-        grad_input = disco_cuda_extension.forward(grad_output.to(torch.float32).contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals,
+        grad_input = disco_cuda_extension.forward(grad_output.contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals,
                                         ctx.kernel_size, ctx.nlat_in, ctx.nlon_in)
         grad_input = grad_input.to(dtype=inp_type)
 

--- a/torch_harmonics/_disco_convolution.py
+++ b/torch_harmonics/_disco_convolution.py
@@ -32,6 +32,7 @@
 import math
 
 import torch
+from torch.cuda.amp import custom_fwd, custom_bwd
 
 try:
     import disco_cuda_extension
@@ -43,6 +44,7 @@ except ImportError as err:
 
 class _DiscoS2ContractionCuda(torch.autograd.Function):
     @staticmethod
+    @custom_fwd(device_type='cuda', cast_inputs=torch.float32)
     def forward(ctx, x: torch.Tensor, roff_idx: torch.Tensor, ker_idx: torch.Tensor,
                 row_idx: torch.Tensor, col_idx: torch.Tensor, vals: torch.Tensor,
                 kernel_size: int, nlat_out: int, nlon_out: int):
@@ -50,25 +52,23 @@ class _DiscoS2ContractionCuda(torch.autograd.Function):
         ctx.kernel_size = kernel_size
         ctx.nlat_in = x.shape[-2]
         ctx.nlon_in = x.shape[-1]
-        inp_type = x.dtype
-        output = disco_cuda_extension.forward(x.to(torch.float32).contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out)
-        output = output.to(dtype=inp_type)
+        output = disco_cuda_extension.forward(x.contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out)
 
         return output
 
     @staticmethod
+    @custom_bwd(device_type='cuda')
     def backward(ctx, grad_output):
         roff_idx, ker_idx, row_idx, col_idx, vals = ctx.saved_tensors
-        inp_type = grad_output.dtype
-        grad_input = disco_cuda_extension.backward(grad_output.to(torch.float32).contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals,
+        grad_input = disco_cuda_extension.backward(grad_output.contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals,
                                          ctx.kernel_size, ctx.nlat_in, ctx.nlon_in)
-        grad_input = grad_input.to(dtype=inp_type)
 
         return grad_input, None, None, None, None, None, None, None, None
 
 
 class _DiscoS2TransposeContractionCuda(torch.autograd.Function):
     @staticmethod
+    @custom_fwd(device_type='cuda', cast_inputs=torch.float32)
     def forward(ctx, x: torch.Tensor, roff_idx: torch.Tensor, ker_idx: torch.Tensor,
                 row_idx: torch.Tensor, col_idx: torch.Tensor, vals: torch.Tensor,
                 kernel_size: int, nlat_out: int, nlon_out: int):
@@ -76,13 +76,12 @@ class _DiscoS2TransposeContractionCuda(torch.autograd.Function):
         ctx.kernel_size = kernel_size
         ctx.nlat_in = x.shape[-2]
         ctx.nlon_in = x.shape[-1]
-        inp_type = x.dtype
-        output = disco_cuda_extension.backward(x.to(torch.float32).contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out)
-        output = output.to(dtype=inp_type)
+        output = disco_cuda_extension.backward(x.contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out)
 
         return output
 
     @staticmethod
+    @custom_bwd(device_type='cuda')
     def backward(ctx, grad_output):
         roff_idx, ker_idx, row_idx, col_idx, vals = ctx.saved_tensors
         inp_type = grad_output.dtype

--- a/torch_harmonics/_disco_convolution.py
+++ b/torch_harmonics/_disco_convolution.py
@@ -50,14 +50,19 @@ class _DiscoS2ContractionCuda(torch.autograd.Function):
         ctx.kernel_size = kernel_size
         ctx.nlat_in = x.shape[-2]
         ctx.nlon_in = x.shape[-1]
+        inp_type = x.dtype
+        output = disco_cuda_extension.forward(x.to(torch.float32).contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out)
+        output = output.to(dtype=inp_type)
 
-        return disco_cuda_extension.forward(x.contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out)
+        return output
 
     @staticmethod
     def backward(ctx, grad_output):
         roff_idx, ker_idx, row_idx, col_idx, vals = ctx.saved_tensors
-        grad_input = disco_cuda_extension.backward(grad_output.contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals,
+        inp_type = grad_output.dtype
+        grad_input = disco_cuda_extension.backward(grad_output.to(torch.float32).contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals,
                                          ctx.kernel_size, ctx.nlat_in, ctx.nlon_in)
+        grad_input = grad_input.to(dtype=inp_type)
 
         return grad_input, None, None, None, None, None, None, None, None
 
@@ -71,14 +76,19 @@ class _DiscoS2TransposeContractionCuda(torch.autograd.Function):
         ctx.kernel_size = kernel_size
         ctx.nlat_in = x.shape[-2]
         ctx.nlon_in = x.shape[-1]
+        inp_type = x.dtype
+        output = disco_cuda_extension.backward(x.to(torch.float32).contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out)
+        output = output.to(dtype=inp_type)
 
-        return disco_cuda_extension.backward(x.contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out)
+        return output
 
     @staticmethod
     def backward(ctx, grad_output):
         roff_idx, ker_idx, row_idx, col_idx, vals = ctx.saved_tensors
-        grad_input = disco_cuda_extension.forward(grad_output.contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals,
+        inp_type = grad_output.dtype
+        grad_input = disco_cuda_extension.forward(grad_output.to(torch.float32).contiguous(), roff_idx, ker_idx, row_idx, col_idx, vals,
                                         ctx.kernel_size, ctx.nlat_in, ctx.nlon_in)
+        grad_input = grad_input.to(dtype=inp_type)
 
         return grad_input, None, None, None, None, None, None, None, None
 

--- a/torch_harmonics/convolution.py
+++ b/torch_harmonics/convolution.py
@@ -376,6 +376,7 @@ class DiscreteContinuousConvS2(DiscreteContinuousConv):
         ker_idx = idx[0, ...].contiguous()
         row_idx = idx[1, ...].contiguous()
         col_idx = idx[2, ...].contiguous()
+        vals = vals.contiguous()
         roff_idx = preprocess_psi(self.kernel_size, out_shape[0], ker_idx, row_idx, col_idx, vals)
 
         # preprocessed data-structure for GPU kernel
@@ -466,6 +467,7 @@ class DiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
         ker_idx = idx[0, ...].contiguous()
         row_idx = idx[1, ...].contiguous()
         col_idx = idx[2, ...].contiguous()
+        vals = vals.contiguous()
         roff_idx = preprocess_psi(self.kernel_size, in_shape[0], ker_idx, row_idx, col_idx, vals)
 
         # preprocessed data-structure for GPU kernel

--- a/torch_harmonics/convolution.py
+++ b/torch_harmonics/convolution.py
@@ -377,7 +377,7 @@ class DiscreteContinuousConvS2(DiscreteContinuousConv):
         row_idx = idx[1, ...].contiguous()
         col_idx = idx[2, ...].contiguous()
         vals = vals.contiguous()
-        roff_idx = preprocess_psi(self.kernel_size, out_shape[0], ker_idx, row_idx, col_idx, vals)
+        roff_idx = preprocess_psi(self.kernel_size, out_shape[0], ker_idx, row_idx, col_idx, vals).contiguous()
 
         # preprocessed data-structure for GPU kernel
         self.register_buffer("psi_roff_idx", roff_idx, persistent=False)
@@ -468,7 +468,7 @@ class DiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
         row_idx = idx[1, ...].contiguous()
         col_idx = idx[2, ...].contiguous()
         vals = vals.contiguous()
-        roff_idx = preprocess_psi(self.kernel_size, in_shape[0], ker_idx, row_idx, col_idx, vals)
+        roff_idx = preprocess_psi(self.kernel_size, in_shape[0], ker_idx, row_idx, col_idx, vals).contiguous()
 
         # preprocessed data-structure for GPU kernel
         self.register_buffer("psi_roff_idx", roff_idx, persistent=False)

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -422,7 +422,7 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
             x = distributed_transpose_azimuth.apply(x, (1, -1), self.lon_in_shapes)
 
         # gather input tensor and set up backward reduction hooks
-        if True:
+        if False:
             x = gather_from_copy_to_polar_region(x, -2, self.lat_in_shapes)
         else:
             x = gather_from_polar_region(x, -2, self.lat_in_shapes)

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -285,7 +285,7 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
             x = _disco_s2_contraction_torch(x, psi, self.nlon_out)
 
         # perform reduce scatter in polar region
-        if True:
+        if False:
             x = reduce_from_scatter_to_polar_region(x, -2)
         else:
             x = reduce_from_polar_region(x)
@@ -422,7 +422,7 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
             x = distributed_transpose_azimuth.apply(x, (1, -1), self.lon_in_shapes)
 
         # gather input tensor and set up backward reduction hooks
-        if False:
+        if True:
             x = gather_from_copy_to_polar_region(x, -2, self.lat_in_shapes)
         else:
             x = gather_from_polar_region(x, -2, self.lat_in_shapes)

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -54,8 +54,7 @@ from torch_harmonics.convolution import (
 
 from torch_harmonics.distributed import polar_group_size, azimuth_group_size
 from torch_harmonics.distributed import distributed_transpose_azimuth, distributed_transpose_polar
-from torch_harmonics.distributed import gather_from_polar_region, copy_to_polar_region
-from torch_harmonics.distributed import reduce_from_scatter_to_polar_region, gather_from_copy_to_polar_region
+from torch_harmonics.distributed import reduce_from_polar_region, scatter_to_polar_region, gather_from_polar_region, copy_to_polar_region
 from torch_harmonics.distributed import polar_group_rank, azimuth_group_rank
 from torch_harmonics.distributed import compute_split_shapes, split_tensor_along_dim
 
@@ -286,7 +285,8 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
             x = _disco_s2_contraction_torch(x, psi, self.nlon_out)
 
         # perform reduce scatter in polar region
-        x = reduce_from_scatter_to_polar_region(x, -2)
+        x = reduce_from_polar_region(x)
+        x = scatter_to_polar_region(x, -2)
 
         # now we can transpose back the result, so that lon is split and channels are local
         if self.comm_size_azimuth > 1:

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -54,7 +54,6 @@ from torch_harmonics.convolution import (
 
 from torch_harmonics.distributed import polar_group_size, azimuth_group_size
 from torch_harmonics.distributed import distributed_transpose_azimuth, distributed_transpose_polar
-from torch_harmonics.distributed import reduce_from_polar_region, scatter_to_polar_region, gather_from_polar_region, copy_to_polar_region
 from torch_harmonics.distributed import reduce_from_scatter_to_polar_region, gather_from_copy_to_polar_region
 from torch_harmonics.distributed import polar_group_rank, azimuth_group_rank
 from torch_harmonics.distributed import compute_split_shapes, split_tensor_along_dim
@@ -286,11 +285,7 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
             x = _disco_s2_contraction_torch(x, psi, self.nlon_out)
 
         # perform reduce scatter in polar region
-        if True:
-            x = reduce_from_scatter_to_polar_region(x, -2)
-        else:
-            x = reduce_from_polar_region(x)
-            x = scatter_to_polar_region(x, -2)
+        x = reduce_from_scatter_to_polar_region(x, -2)
 
         # now we can transpose back the result, so that lon is split and channels are local
         if self.comm_size_azimuth > 1:
@@ -424,11 +419,7 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
             x = distributed_transpose_azimuth.apply(x, (1, -1), self.lon_in_shapes)
 
         # gather input tensor and set up backward reduction hooks
-        if True:
-            x = gather_from_copy_to_polar_region(x, -2, self.lat_in_shapes)
-        else:
-            x = gather_from_polar_region(x, -2, self.lat_in_shapes)
-            x = copy_to_polar_region(x)
+        x = gather_from_copy_to_polar_region(x, -2, self.lat_in_shapes)
 
         if x.is_cuda and _cuda_extension_available:
             out = _disco_s2_transpose_contraction_cuda(

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -54,6 +54,7 @@ from torch_harmonics.convolution import (
 
 from torch_harmonics.distributed import polar_group_size, azimuth_group_size
 from torch_harmonics.distributed import distributed_transpose_azimuth, distributed_transpose_polar
+from torch_harmonics.distributed import reduce_from_polar_region, scatter_to_polar_region, gather_from_polar_region, copy_to_polar_region
 from torch_harmonics.distributed import reduce_from_scatter_to_polar_region, gather_from_copy_to_polar_region
 from torch_harmonics.distributed import polar_group_rank, azimuth_group_rank
 from torch_harmonics.distributed import compute_split_shapes, split_tensor_along_dim
@@ -285,7 +286,11 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
             x = _disco_s2_contraction_torch(x, psi, self.nlon_out)
 
         # perform reduce scatter in polar region
-        x = reduce_from_scatter_to_polar_region(x, -2)
+        if True:
+            x = reduce_from_scatter_to_polar_region(x, -2)
+        else:
+            x = reduce_from_polar_region(x)
+            x = scatter_to_polar_region(x, -2)
 
         # now we can transpose back the result, so that lon is split and channels are local
         if self.comm_size_azimuth > 1:
@@ -419,7 +424,11 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
             x = distributed_transpose_azimuth.apply(x, (1, -1), self.lon_in_shapes)
 
         # gather input tensor and set up backward reduction hooks
-        x = gather_from_copy_to_polar_region(x, -2, self.lat_in_shapes)
+        if False:
+            x = gather_from_copy_to_polar_region(x, -2, self.lat_in_shapes)
+        else:
+            x = gather_from_polar_region(x, -2, self.lat_in_shapes)
+            x = copy_to_polar_region(x)
 
         if x.is_cuda and _cuda_extension_available:
             out = _disco_s2_transpose_contraction_cuda(

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -55,6 +55,7 @@ from torch_harmonics.convolution import (
 from torch_harmonics.distributed import polar_group_size, azimuth_group_size
 from torch_harmonics.distributed import distributed_transpose_azimuth, distributed_transpose_polar
 from torch_harmonics.distributed import reduce_from_polar_region, scatter_to_polar_region, gather_from_polar_region, copy_to_polar_region
+from torch_harmonics.distributed import reduce_from_scatter_to_polar_region, gather_from_copy_to_polar_region
 from torch_harmonics.distributed import polar_group_rank, azimuth_group_rank
 from torch_harmonics.distributed import compute_split_shapes, split_tensor_along_dim
 
@@ -284,8 +285,11 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
             x = _disco_s2_contraction_torch(x, psi, self.nlon_out)
 
         # perform reduce scatter in polar region
-        x = reduce_from_polar_region (x)
-        x = scatter_to_polar_region(x, -2)
+        if True:
+            x = reduce_from_scatter_to_polar_region(x, -2)
+        else:
+            x = reduce_from_polar_region(x)
+            x = scatter_to_polar_region(x, -2)
 
         # now we can transpose back the result, so that lon is split and channels are local
         if self.comm_size_azimuth > 1:
@@ -418,8 +422,11 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
             x = distributed_transpose_azimuth.apply(x, (1, -1), self.lon_in_shapes)
 
         # gather input tensor and set up backward reduction hooks
-        x = gather_from_polar_region(x, -2, self.lat_in_shapes)
-        x = copy_to_polar_region(x)
+        if True:
+            x = gather_from_copy_to_polar_region(x, -2, self.lat_in_shapes)
+        else:
+            x = gather_from_polar_region(x, -2, self.lat_in_shapes)
+            x = copy_to_polar_region(x)
 
         if x.is_cuda and _cuda_extension_available:
             out = _disco_s2_transpose_contraction_cuda(

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -424,7 +424,7 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
             x = distributed_transpose_azimuth.apply(x, (1, -1), self.lon_in_shapes)
 
         # gather input tensor and set up backward reduction hooks
-        if True:
+        if False:
             x = gather_from_copy_to_polar_region(x, -2, self.lat_in_shapes)
         else:
             x = gather_from_polar_region(x, -2, self.lat_in_shapes)

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -424,7 +424,7 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
             x = distributed_transpose_azimuth.apply(x, (1, -1), self.lon_in_shapes)
 
         # gather input tensor and set up backward reduction hooks
-        if False:
+        if True:
             x = gather_from_copy_to_polar_region(x, -2, self.lat_in_shapes)
         else:
             x = gather_from_polar_region(x, -2, self.lat_in_shapes)

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -240,7 +240,8 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
         ker_idx = idx[0, ...].contiguous()
         row_idx = idx[1, ...].contiguous()
         col_idx = idx[2, ...].contiguous()
-        roff_idx = preprocess_psi(self.kernel_size, self.nlat_out_local, ker_idx, row_idx, col_idx, vals)
+        vals = vals.contiguous()
+        roff_idx = preprocess_psi(self.kernel_size, self.nlat_out_local, ker_idx, row_idx, col_idx, vals).contiguous()
 
         # preprocessed data-structure for GPU kernel
         self.register_buffer("psi_roff_idx", roff_idx, persistent=False)
@@ -285,7 +286,7 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
             x = _disco_s2_contraction_torch(x, psi, self.nlon_out)
 
         # perform reduce scatter in polar region
-        if False:
+        if True:
             x = reduce_from_scatter_to_polar_region(x, -2)
         else:
             x = reduce_from_polar_region(x)
@@ -372,7 +373,8 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
         ker_idx = idx[0, ...].contiguous()
         row_idx = idx[1, ...].contiguous()
         col_idx = idx[2, ...].contiguous()
-        roff_idx = preprocess_psi(self.kernel_size, self.nlat_in_local, ker_idx, row_idx, col_idx, vals)
+        vals = vals.contiguous()
+        roff_idx = preprocess_psi(self.kernel_size, self.nlat_in_local, ker_idx, row_idx, col_idx, vals).contiguous()
 
         # preprocessed data-structure for GPU kernel
         self.register_buffer("psi_roff_idx", roff_idx, persistent=False)

--- a/torch_harmonics/distributed/primitives.py
+++ b/torch_harmonics/distributed/primitives.py
@@ -194,15 +194,10 @@ def _gather(input_, dim_, shapes_, group=None):
     input_shape = list(input_.shape)
 
     if shapes_ is not None:
-        input_list = [None] * comm_size
-
+        input_list = []
         for src in range(comm_size):
             input_shape[dim_] = shapes_[src]
-            input_list[src] = torch.empty(
-                input_shape,
-                dtype=input_.dtype,
-                device=input_.device,
-            )
+            input_list.append(torch.empty(input_shape, dtype=input_.dtype, device=input_.device))
     else:
         # assume equal shape on all ranks
         input_list = [torch.empty_like(input_) for _ in range(comm_size)]

--- a/torch_harmonics/distributed/primitives.py
+++ b/torch_harmonics/distributed/primitives.py
@@ -32,6 +32,7 @@ from typing import List
 
 import torch
 import torch.distributed as dist
+from torch.cuda.amp import custom_fwd, custom_bwd
 
 from .utils import polar_group, azimuth_group, polar_group_size
 from .utils import is_initialized, is_distributed_polar
@@ -96,6 +97,7 @@ def _transpose(tensor, dim0, dim1, dim1_split_sizes, group=None, async_op=False)
 class distributed_transpose_azimuth(torch.autograd.Function):
 
     @staticmethod
+    @custom_fwd
     def forward(ctx, x, dims, dim1_split_sizes):
         # WAR for a potential contig check torch bug for channels last contig tensors
         xlist, dim0_split_sizes, _ = _transpose(x, dims[0], dims[1], dim1_split_sizes, group=azimuth_group())
@@ -106,6 +108,7 @@ class distributed_transpose_azimuth(torch.autograd.Function):
         return x
 
     @staticmethod
+    @custom_bwd
     def backward(ctx, go):
         dims = ctx.dims
         dim0_split_sizes = ctx.dim0_split_sizes
@@ -119,6 +122,7 @@ class distributed_transpose_azimuth(torch.autograd.Function):
 class distributed_transpose_polar(torch.autograd.Function):
 
     @staticmethod
+    @custom_fwd
     def forward(ctx, x, dim, dim1_split_sizes):
         # WAR for a potential contig check torch bug for channels last contig tensors 
         xlist, dim0_split_sizes, _ = _transpose(x, dim[0], dim[1], dim1_split_sizes, group=polar_group())
@@ -128,6 +132,7 @@ class distributed_transpose_polar(torch.autograd.Function):
         return x
 
     @staticmethod
+    @custom_bwd
     def backward(ctx, go):
         dim = ctx.dim
         dim0_split_sizes = ctx.dim0_split_sizes
@@ -246,10 +251,12 @@ class _CopyToPolarRegion(torch.autograd.Function):
         return input_
     
     @staticmethod
+    @custom_fwd
     def forward(ctx, input_):
         return input_
     
     @staticmethod
+    @custom_bwd
     def backward(ctx, grad_output):
         if is_distributed_polar():
             return _reduce(grad_output, group=polar_group())
@@ -265,6 +272,7 @@ class _ScatterToPolarRegion(torch.autograd.Function):
         return _split(input_, dim_, group=polar_group())
 
     @staticmethod
+    @custom_fwd
     def forward(ctx, input_, dim_):
         if is_distributed_polar():
             ctx.dim = dim_
@@ -276,6 +284,7 @@ class _ScatterToPolarRegion(torch.autograd.Function):
             return input_
 
     @staticmethod
+    @custom_bwd
     def backward(ctx, grad_output):
         if is_distributed_polar():
             return _gather(grad_output, ctx.dim, ctx.split_shapes, polar_group()), None
@@ -291,6 +300,7 @@ class _GatherFromPolarRegion(torch.autograd.Function):
         return _gather(input_, dim_, shapes_, polar_group())
 
     @staticmethod
+    @custom_fwd
     def forward(ctx, input_, dim_, shapes_):
         if is_distributed_polar():
             ctx.dim = dim_
@@ -299,6 +309,7 @@ class _GatherFromPolarRegion(torch.autograd.Function):
             return input_
 
     @staticmethod
+    @custom_bwd
     def backward(ctx, grad_output):
         if is_distributed_polar():
             return _split(grad_output, ctx.dim, group=polar_group()), None, None
@@ -317,6 +328,7 @@ class _ReduceFromPolarRegion(torch.autograd.Function):
             return input_
 
     @staticmethod
+    @custom_fwd
     def forward(ctx, input_):
         if is_distributed_polar():
             return _reduce(input_, group=polar_group())
@@ -324,6 +336,7 @@ class _ReduceFromPolarRegion(torch.autograd.Function):
             return input_
 
     @staticmethod
+    @custom_bwd
     def backward(ctx, grad_output):
         return grad_output
 
@@ -339,6 +352,7 @@ class _ReduceFromScatterToPolarRegion(torch.autograd.Function):
             return input_
 
     @staticmethod
+    @custom_fwd
     def forward(ctx, input_, dim_):
         if is_distributed_polar():
             ctx.dim = dim_
@@ -350,6 +364,7 @@ class _ReduceFromScatterToPolarRegion(torch.autograd.Function):
             return input_
 
     @staticmethod
+    @custom_bwd
     def backward(ctx, grad_output):
         if is_distributed_polar():
             return _gather(grad_output, ctx.dim, ctx.split_shapes, polar_group()), None
@@ -368,6 +383,7 @@ class _GatherFromCopyToPolarRegion(torch.autograd.Function):
             return input_
 
     @staticmethod
+    @custom_fwd
     def forward(ctx, input_, dim_, shapes_):
         if is_distributed_polar():
             ctx.dim = dim_
@@ -376,6 +392,7 @@ class _GatherFromCopyToPolarRegion(torch.autograd.Function):
             return input_
 
     @staticmethod
+    @custom_bwd
     def backward(ctx, grad_output):
         if is_distributed_polar():
             return _reduce_scatter(grad_output, ctx.dim, use_fp32=True, group=polar_group()), None, None


### PR DESCRIPTION
This MR fixes some issues with the fused reduce-scatter backward pass. Also, it ensures that activations should only be stored in requested AMP precision, and not in FP32 as was done accidentally previously. 