### PR TITLE
torch.set_default_device fixes.

### DIFF
--- a/torch_harmonics/convolution.py
+++ b/torch_harmonics/convolution.py
@@ -170,7 +170,8 @@ def _precompute_convolution_tensor_s2(
     kernel_size = filter_basis.kernel_size
 
     nlat_in, nlon_in = in_shape
-    nlat_out, nlon_out = out_shape    
+    nlat_out, nlon_out = out_shape
+
     # precompute input and output grids
     lats_in, win = _precompute_latitudes(nlat_in, grid=grid_in)
     lats_out, wout = _precompute_latitudes(nlat_out, grid=grid_out)
@@ -178,7 +179,7 @@ def _precompute_convolution_tensor_s2(
     # compute the phi differences
     # It's imporatant to not include the 2 pi point in the longitudes, as it is equivalent to lon=0
     lons_in = _precompute_longitudes(nlon_in)
-    
+
     # compute quadrature weights and merge them into the convolution tensor.
     # These quadrature integrate to 1 over the sphere.
     if transpose_normalization:
@@ -221,7 +222,7 @@ def _precompute_convolution_tensor_s2(
 
         # add the output latitude and reshape such that psi has dimensions kernel_shape x nlat_out x (nlat_in*nlon_in)
         idx = torch.stack([iidx[:, 0], t * torch.ones_like(iidx[:, 0]), iidx[:, 1] * nlon_in + iidx[:, 2]], dim=0)
-        
+
         # append indices and values to the COO datastructure
         out_idx.append(idx)
         out_vals.append(vals)

--- a/torch_harmonics/quadrature.py
+++ b/torch_harmonics/quadrature.py
@@ -78,7 +78,7 @@ def _precompute_latitudes(nlat: int, grid: Optional[str]="equiangular") -> Tuple
     # is formulated in the cosine theta domain, which is designed to integrate functions of cos theta
     lats = torch.flip(torch.arccos(xlg), dims=(0,)).clone()
     wlg = torch.flip(wlg, dims=(0,)).clone()
-    
+
     return lats, wlg
 
 
@@ -88,7 +88,7 @@ def trapezoidal_weights(n: int, a: Optional[float]=-1.0, b: Optional[float]=1.0,
     on the interval [a, b]
     """
 
-    xlg = torch.from_numpy(np.linspace(a, b, n, endpoint=periodic))
+    xlg = torch.as_tensor(np.linspace(a, b, n, endpoint=periodic))
     wlg = (b - a) / (n - periodic * 1) * torch.ones(n, requires_grad=False)
 
     if not periodic:
@@ -105,8 +105,8 @@ def legendre_gauss_weights(n: int, a: Optional[float]=-1.0, b: Optional[float]=1
     """
 
     xlg, wlg = np.polynomial.legendre.leggauss(n)
-    xlg = torch.from_numpy(xlg).clone()
-    wlg = torch.from_numpy(wlg).clone()
+    xlg = torch.as_tensor(xlg).clone()
+    wlg = torch.as_tensor(wlg).clone()
     xlg = (b - a) * 0.5 * xlg + (b + a) * 0.5
     wlg = wlg * (b - a) * 0.5
 

--- a/torch_harmonics/quadrature.py
+++ b/torch_harmonics/quadrature.py
@@ -78,7 +78,7 @@ def _precompute_latitudes(nlat: int, grid: Optional[str]="equiangular") -> Tuple
     # is formulated in the cosine theta domain, which is designed to integrate functions of cos theta
     lats = torch.flip(torch.arccos(xlg), dims=(0,)).clone()
     wlg = torch.flip(wlg, dims=(0,)).clone()
-
+    
     return lats, wlg
 
 


### PR DESCRIPTION
When setting `torch.set_default_device('cuda:0')` I ran into several errors because some devices are initialized `.from_numpy`, which automatically sets them on the cpu. This MR fixes those few places.

Furthermore, I ran into the following code that produces a segmentation fault:

```python
import torch_harmonics as th
import torch

torch.set_default_device('cuda:0')
th.convolution.DiscreteContinuousConvS2(
    in_channels = 1,
    out_channels = 1,
    in_shape = (180, 360),
    out_shape = (90, 180),
    kernel_shape = (3, 3),
    basis_type = "morlet",
    basis_norm_mode = "mean",
)
```

I included a fix, which ensures that the data going into `preprocess_psi` is located on the cpu.