### PR TITLE
Tkurth/cleanup

### DIFF
--- a/examples/segmentation/train.py
+++ b/examples/segmentation/train.py
@@ -429,7 +429,7 @@ def main(
 
     # print dataset info
     img_size = dataset.input_shape[1:]
-    class_histogram = torch.from_numpy(dataset.class_histogram)
+    class_histogram = torch.as_tensor(dataset.class_histogram)
 
     # various class weights where tried such as inverse frequency
     # No class weights seem to work best

--- a/torch_harmonics/attention.py
+++ b/torch_harmonics/attention.py
@@ -273,7 +273,6 @@ class NeighborhoodAttentionS2(nn.Module):
             transpose_normalization=False,
             basis_norm_mode="none",
             merge_quadrature=True,
-            support_only=True,
         )
 
         # this is kept for legacy resons in case we want to resuse sorting of these entries

--- a/torch_harmonics/convolution.py
+++ b/torch_harmonics/convolution.py
@@ -67,6 +67,10 @@ def _normalize_convolution_tensor_s2(
     - "mean": the norm is computed for each output latitude and then averaged over the output latitudes. Each basis function is then normalized by this mean.
     """
 
+    # exit here if no normalization is needed
+    if basis_norm_mode == "none":
+        return psi_vals
+
     # reshape the indices implicitly to be ikernel, out_shape[0], in_shape[0], in_shape[1]
     idx = torch.stack([psi_idx[0], psi_idx[1], psi_idx[2] // in_shape[1], psi_idx[2] % in_shape[1]], dim=0)
 
@@ -147,7 +151,6 @@ def _precompute_convolution_tensor_s2(
     transpose_normalization: Optional[bool]=False,
     basis_norm_mode: Optional[str]="mean",
     merge_quadrature: Optional[bool]=False,
-    support_only: Optional[bool]=False,
 ):
     """
     Precomputes the rotated filters at positions $R^{-1}_j \omega_i = R^{-1}_j R_i \nu = Y(-\theta_j)Z(\phi_i - \phi_j)Y(\theta_j)\nu$.
@@ -230,7 +233,7 @@ def _precompute_convolution_tensor_s2(
         phi = torch.where(phi < 0.0, phi + 2 * torch.pi, phi)
 
         # find the indices where the rotated position falls into the support of the kernel
-        iidx, vals = filter_basis.compute_support_vals(theta, phi, r_cutoff=theta_cutoff_eff, support_only=support_only)
+        iidx, vals = filter_basis.compute_support_vals(theta, phi, r_cutoff=theta_cutoff_eff)
 
         # add the output latitude and reshape such that psi has dimensions kernel_shape x nlat_out x (nlat_in*nlon_in)
         idx = torch.stack([iidx[:, 0], t * torch.ones_like(iidx[:, 0]), iidx[:, 1] * nlon_in + iidx[:, 2]], dim=0)
@@ -244,18 +247,17 @@ def _precompute_convolution_tensor_s2(
     out_idx = torch.cat(out_idx, dim=-1)
     out_vals = torch.cat(out_vals, dim=-1)
 
-    if not support_only:
-        out_vals = _normalize_convolution_tensor_s2(
-            out_idx,
-            out_vals,
-            in_shape,
-            out_shape,
-            kernel_size,
-            quad_weights,
-            transpose_normalization=transpose_normalization,
-            basis_norm_mode=basis_norm_mode,
-            merge_quadrature=merge_quadrature,
-        )
+    out_vals = _normalize_convolution_tensor_s2(
+        out_idx,
+        out_vals,
+        in_shape,
+        out_shape,
+        kernel_size,
+        quad_weights,
+        transpose_normalization=transpose_normalization,
+        basis_norm_mode=basis_norm_mode,
+        merge_quadrature=merge_quadrature,
+    )
 
     out_idx = out_idx.contiguous()
     out_vals = out_vals.to(dtype=torch.float32).contiguous()

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -249,6 +249,8 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
     Discrete-continuous transpose convolutions (DISCO) on the 2-Sphere as described in [1].
 
     [1] Ocampo, Price, McEwen, Scalable and equivariant spherical CNNs by discrete-continuous (DISCO) convolutions, ICLR (2023), arXiv:2209.13603
+
+    We assume the data can be splitted in polar and azimuthal directions.
     """
 
     def __init__(

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -166,7 +166,6 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
             transpose_normalization=False,
             basis_norm_mode=basis_norm_mode,
             merge_quadrature=True,
-            support_only=False,
         )
 
         # split the convolution tensor along latitude
@@ -313,14 +312,13 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
             transpose_normalization=True,
             basis_norm_mode=basis_norm_mode,
             merge_quadrature=True,
-            support_only=False,
         )
 
         # split the convolution tensor along latitude, again, we need to swap the meaning
         # of in_shape and out_shape
         idx, vals = _split_distributed_convolution_tensor_s2(idx, vals, out_shape, in_shape)
 
-        # sort the values   
+        # sort the values
         ker_idx = idx[0, ...].contiguous()
         row_idx = idx[1, ...].contiguous()
         col_idx = idx[2, ...].contiguous()

--- a/torch_harmonics/filter_basis.py
+++ b/torch_harmonics/filter_basis.py
@@ -78,9 +78,9 @@ class FilterBasis(metaclass=abc.ABCMeta):
     #     raise NotImplementedError
 
     @abc.abstractmethod
-    def compute_support_vals(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float, support_only: bool):
+    def compute_support_vals(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float):
         """
-        Computes the index set that falls into the kernel's support and returns both indices and values (if support_only is False, otherwise it will return 1 as values).
+        Computes the index set that falls into the kernel's support and returns both indices and values.
         This routine is designed for sparse evaluations of the filter basis.
         """
         raise NotImplementedError
@@ -123,9 +123,9 @@ class PiecewiseLinearFilterBasis(FilterBasis):
     def kernel_size(self):
         return (self.kernel_shape[0] // 2) * self.kernel_shape[1] + self.kernel_shape[0] % 2
 
-    def _compute_support_vals_isotropic(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float, support_only: bool):
+    def _compute_support_vals_isotropic(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float):
         """
-        Computes the index set that falls into the isotropic kernel's support and returns both indices and values (if support_only is False, otherwise it will return 1 as values).
+        Computes the index set that falls into the isotropic kernel's support and returns both indices and values.
         """
 
         # enumerator for basis function
@@ -143,17 +143,13 @@ class PiecewiseLinearFilterBasis(FilterBasis):
 
         # find the indices where the rotated position falls into the support of the kernel
         iidx = torch.argwhere(((r - ir).abs() <= dr) & (r <= r_cutoff))
-
-        if not support_only:
-            vals = 1 - (r[iidx[:, 1], iidx[:, 2]] - ir[iidx[:, 0], 0, 0]).abs() / dr
-        else:
-            vals = torch.ones_like(iidx[:, 0])
+        vals = 1 - (r[iidx[:, 1], iidx[:, 2]] - ir[iidx[:, 0], 0, 0]).abs() / dr
 
         return iidx, vals
 
-    def _compute_support_vals_anisotropic(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float, support_only: bool):
+    def _compute_support_vals_anisotropic(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float):
         """
-        Computes the index set that falls into the anisotropic kernel's support and returns both indices and values (if support_only is False, otherwise it will return 1 as values).
+        Computes the index set that falls into the anisotropic kernel's support and returns both indices and values.
         """
 
         # enumerator for basis function
@@ -180,16 +176,12 @@ class PiecewiseLinearFilterBasis(FilterBasis):
             cond_phi = (ikernel == 0) | (_circle_dist(phi, iphi).abs() <= dphi)
             # find indices where conditions are met
             iidx = torch.argwhere(cond_r & cond_phi)
-
-            if not support_only:
-                # compute the distance to the collocation points
-                dist_r = (r[iidx[:, 1], iidx[:, 2]] - ir[iidx[:, 0], 0, 0]).abs()
-                dist_phi = _circle_dist(phi[iidx[:, 1], iidx[:, 2]], iphi[iidx[:, 0], 0, 0])
-                # compute the value of the basis functions
-                vals  = 1 - dist_r / dr
-                vals *= torch.where((iidx[:, 0] > 0), (1 - dist_phi / dphi), 1.0)
-            else:
-                vals = torch.ones_like(iidx[:, 0])
+            # compute the distance to the collocation points
+            dist_r = (r[iidx[:, 1], iidx[:, 2]] - ir[iidx[:, 0], 0, 0]).abs()
+            dist_phi = _circle_dist(phi[iidx[:, 1], iidx[:, 2]], iphi[iidx[:, 0], 0, 0])
+            # compute the value of the basis functions
+            vals  = 1 - dist_r / dr
+            vals *= torch.where((iidx[:, 0] > 0), (1 - dist_phi / dphi), 1.0)
 
         else:
             # in the even case, the inner basis functions overlap into areas with a negative areas
@@ -203,28 +195,25 @@ class PiecewiseLinearFilterBasis(FilterBasis):
             # find indices where conditions are met
             iidx = torch.argwhere((cond_r & cond_phi) | (cond_rn & cond_phin))
 
-            if not support_only:
-                dist_r = (r[iidx[:, 1], iidx[:, 2]] - ir[iidx[:, 0], 0, 0]).abs()
-                dist_phi = _circle_dist(phi[iidx[:, 1], iidx[:, 2]], iphi[iidx[:, 0], 0, 0])
-                dist_rn = (rn[iidx[:, 1], iidx[:, 2]] - ir[iidx[:, 0], 0, 0]).abs()
-                dist_phin = _circle_dist(phin[iidx[:, 1], iidx[:, 2]], iphi[iidx[:, 0], 0, 0])
-                # compute the value of the basis functions
-                vals = cond_r[iidx[:, 0], iidx[:, 1], iidx[:, 2]] * (1 - dist_r / dr)
-                vals *= cond_phi[iidx[:, 0], iidx[:, 1], iidx[:, 2]] * (1 - dist_phi / dphi)
-                valsn = cond_rn[iidx[:, 0], iidx[:, 1], iidx[:, 2]] * (1 - dist_rn / dr)
-                valsn *= cond_phin[iidx[:, 0], iidx[:, 1], iidx[:, 2]] * (1 - dist_phin / dphi)
-                vals += valsn
-            else:
-                vals = torch.ones_like(iidx[:, 0])
+            dist_r = (r[iidx[:, 1], iidx[:, 2]] - ir[iidx[:, 0], 0, 0]).abs()
+            dist_phi = _circle_dist(phi[iidx[:, 1], iidx[:, 2]], iphi[iidx[:, 0], 0, 0])
+            dist_rn = (rn[iidx[:, 1], iidx[:, 2]] - ir[iidx[:, 0], 0, 0]).abs()
+            dist_phin = _circle_dist(phin[iidx[:, 1], iidx[:, 2]], iphi[iidx[:, 0], 0, 0])
+            # compute the value of the basis functions
+            vals = cond_r[iidx[:, 0], iidx[:, 1], iidx[:, 2]] * (1 - dist_r / dr)
+            vals *= cond_phi[iidx[:, 0], iidx[:, 1], iidx[:, 2]] * (1 - dist_phi / dphi)
+            valsn = cond_rn[iidx[:, 0], iidx[:, 1], iidx[:, 2]] * (1 - dist_rn / dr)
+            valsn *= cond_phin[iidx[:, 0], iidx[:, 1], iidx[:, 2]] * (1 - dist_phin / dphi)
+            vals += valsn
 
         return iidx, vals
 
-    def compute_support_vals(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float, support_only: Optional[bool] = False):
+    def compute_support_vals(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float):
 
         if self.kernel_shape[1] > 1:
-            return self._compute_support_vals_anisotropic(r, phi, r_cutoff=r_cutoff, support_only=support_only)
+            return self._compute_support_vals_anisotropic(r, phi, r_cutoff=r_cutoff)
         else:
-            return self._compute_support_vals_isotropic(r, phi, r_cutoff=r_cutoff, support_only=support_only)
+            return self._compute_support_vals_isotropic(r, phi, r_cutoff=r_cutoff)
 
 
 class MorletFilterBasis(FilterBasis):
@@ -254,9 +243,9 @@ class MorletFilterBasis(FilterBasis):
     def hann_window(self, r: torch.Tensor, width: float = 1.0):
         return torch.cos(0.5 * torch.pi * r / width) ** 2
 
-    def compute_support_vals(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float, width: float = 1.0, support_only: Optional[bool] = False):
+    def compute_support_vals(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float, width: float = 1.0):
         """
-        Computes the index set that falls into the isotropic kernel's support and returns both indices and values (if support_only is False, otherwise it will return 1 as values).
+        Computes the index set that falls into the isotropic kernel's support and returns both indices and values.
         """
 
         # enumerator for basis function
@@ -267,22 +256,19 @@ class MorletFilterBasis(FilterBasis):
         # get relevant indices
         iidx = torch.argwhere((r <= r_cutoff) & torch.full_like(ikernel, True, dtype=torch.bool))
 
-        if not support_only:
-            # get corresponding r, phi, x and y coordinates
-            r = r[iidx[:, 1], iidx[:, 2]] / r_cutoff
-            phi = phi[iidx[:, 1], iidx[:, 2]]
-            x = r * torch.sin(phi)
-            y = r * torch.cos(phi)
-            n = nkernel[iidx[:, 0], 0, 0]
-            m = mkernel[iidx[:, 0], 0, 0]
+        # get corresponding r, phi, x and y coordinates
+        r = r[iidx[:, 1], iidx[:, 2]] / r_cutoff
+        phi = phi[iidx[:, 1], iidx[:, 2]]
+        x = r * torch.sin(phi)
+        y = r * torch.cos(phi)
+        n = nkernel[iidx[:, 0], 0, 0]
+        m = mkernel[iidx[:, 0], 0, 0]
 
-            harmonic = torch.where(n % 2 == 1, torch.sin(torch.ceil(n / 2) * math.pi * x / width), torch.cos(torch.ceil(n / 2) * math.pi * x / width))
-            harmonic *= torch.where(m % 2 == 1, torch.sin(torch.ceil(m / 2) * math.pi * y / width), torch.cos(torch.ceil(m / 2) * math.pi * y / width))
+        harmonic = torch.where(n % 2 == 1, torch.sin(torch.ceil(n / 2) * math.pi * x / width), torch.cos(torch.ceil(n / 2) * math.pi * x / width))
+        harmonic *= torch.where(m % 2 == 1, torch.sin(torch.ceil(m / 2) * math.pi * y / width), torch.cos(torch.ceil(m / 2) * math.pi * y / width))
 
-            # computes the envelope. To ensure that the curve is roughly 0 at the boundary, we rescale the Gaussian by 0.25
-            vals = self.hann_window(r, width=width) * harmonic
-        else:
-            vals = torch.ones_like(iidx[:, 0])
+        # computes the envelope. To ensure that the curve is roughly 0 at the boundary, we rescale the Gaussian by 0.25
+        vals = self.hann_window(r, width=width) * harmonic
 
         return iidx, vals
 
@@ -324,9 +310,9 @@ class ZernikeFilterBasis(FilterBasis):
         m = 2 * l - n
         return torch.where(m < 0, self.zernikeradial(r, n, -m) * torch.sin(m * phi), self.zernikeradial(r, n, m) * torch.cos(m * phi))
 
-    def compute_support_vals(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float, width: float = 0.25, support_only: Optional[bool] = False):
+    def compute_support_vals(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float, width: float = 0.25):
         """
-        Computes the index set that falls into the isotropic kernel's support and returns both indices and values (if support_only is False, otherwise it will return 1 as values).
+        Computes the index set that falls into the isotropic kernel's support and returns both indices and values.
         """
 
         # enumerator for basis function
@@ -335,26 +321,23 @@ class ZernikeFilterBasis(FilterBasis):
         # get relevant indices
         iidx = torch.argwhere((r <= r_cutoff) & torch.full_like(ikernel, True, dtype=torch.bool))
 
-        if not support_only:
-            # indexing logic for zernike polynomials
-            # the total index is given by (n * (n + 2) + l ) // 2 which needs to be reversed
-            # precompute shifts in the level of the "pyramid"
-            nshifts = torch.arange(self.kernel_shape, device=r.device)
-            nshifts = (nshifts + 1) * nshifts // 2
-            # find the level and position within the pyramid
-            nkernel = torch.searchsorted(nshifts, ikernel, right=True) - 1
-            lkernel = ikernel - nshifts[nkernel]
-            # mkernel = 2 * ikernel - nkernel * (nkernel + 2)
+        # indexing logic for zernike polynomials
+        # the total index is given by (n * (n + 2) + l ) // 2 which needs to be reversed
+        # precompute shifts in the level of the "pyramid"
+        nshifts = torch.arange(self.kernel_shape, device=r.device)
+        nshifts = (nshifts + 1) * nshifts // 2
+        # find the level and position within the pyramid
+        nkernel = torch.searchsorted(nshifts, ikernel, right=True) - 1
+        lkernel = ikernel - nshifts[nkernel]
+        # mkernel = 2 * ikernel - nkernel * (nkernel + 2)
 
-            # get corresponding coordinates and n and l indices
-            r = r[iidx[:, 1], iidx[:, 2]] / r_cutoff
-            phi = phi[iidx[:, 1], iidx[:, 2]]
-            n = nkernel[iidx[:, 0], 0, 0]
-            l = lkernel[iidx[:, 0], 0, 0]
+        # get corresponding coordinates and n and l indices
+        r = r[iidx[:, 1], iidx[:, 2]] / r_cutoff
+        phi = phi[iidx[:, 1], iidx[:, 2]]
+        n = nkernel[iidx[:, 0], 0, 0]
+        l = lkernel[iidx[:, 0], 0, 0]
 
-            # computes the Zernike polynomials using helper functions
-            vals = self.zernikepoly(r, phi, n, l)
-        else:
-            vals = torch.ones_like(iidx[:, 0])
+        # computes the Zernike polynomials using helper functions
+        vals = self.zernikepoly(r, phi, n, l)
 
         return iidx, vals

--- a/torch_harmonics/filter_basis.py
+++ b/torch_harmonics/filter_basis.py
@@ -80,7 +80,8 @@ class FilterBasis(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def compute_support_vals(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float, support_only: bool):
         """
-        Computes the index set that falls into the kernel's support and returns both indices and values. This routine is designed for sparse evaluations of the filter basis
+        Computes the index set that falls into the kernel's support and returns both indices and values (if support_only is False, otherwise it will return 1 as values).
+        This routine is designed for sparse evaluations of the filter basis.
         """
         raise NotImplementedError
 
@@ -124,7 +125,7 @@ class PiecewiseLinearFilterBasis(FilterBasis):
 
     def _compute_support_vals_isotropic(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float, support_only: bool):
         """
-        Computes the index set that falls into the isotropic kernel's support and returns both indices and values.
+        Computes the index set that falls into the isotropic kernel's support and returns both indices and values (if support_only is False, otherwise it will return 1 as values).
         """
 
         # enumerator for basis function
@@ -152,7 +153,7 @@ class PiecewiseLinearFilterBasis(FilterBasis):
 
     def _compute_support_vals_anisotropic(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float, support_only: bool):
         """
-        Computes the index set that falls into the isotropic kernel's support and returns both indices and values.
+        Computes the index set that falls into the anisotropic kernel's support and returns both indices and values (if support_only is False, otherwise it will return 1 as values).
         """
 
         # enumerator for basis function
@@ -255,7 +256,7 @@ class MorletFilterBasis(FilterBasis):
 
     def compute_support_vals(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float, width: float = 1.0, support_only: Optional[bool] = False):
         """
-        Computes the index set that falls into the isotropic kernel's support and returns both indices and values.
+        Computes the index set that falls into the isotropic kernel's support and returns both indices and values (if support_only is False, otherwise it will return 1 as values).
         """
 
         # enumerator for basis function
@@ -325,7 +326,7 @@ class ZernikeFilterBasis(FilterBasis):
 
     def compute_support_vals(self, r: torch.Tensor, phi: torch.Tensor, r_cutoff: float, width: float = 0.25, support_only: Optional[bool] = False):
         """
-        Computes the index set that falls into the isotropic kernel's support and returns both indices and values.
+        Computes the index set that falls into the isotropic kernel's support and returns both indices and values (if support_only is False, otherwise it will return 1 as values).
         """
 
         # enumerator for basis function

--- a/torch_harmonics/filter_basis.py
+++ b/torch_harmonics/filter_basis.py
@@ -279,7 +279,7 @@ class MorletFilterBasis(FilterBasis):
             harmonic *= torch.where(m % 2 == 1, torch.sin(torch.ceil(m / 2) * math.pi * y / width), torch.cos(torch.ceil(m / 2) * math.pi * y / width))
 
             # computes the envelope. To ensure that the curve is roughly 0 at the boundary, we rescale the Gaussian by 0.25
-            vals = self.gaussian_window(r, width=width) * harmonic
+            vals = self.hann_window(r, width=width) * harmonic
         else:
             vals = torch.ones_like(iidx[:, 0])
 

--- a/torch_harmonics/quadrature.py
+++ b/torch_harmonics/quadrature.py
@@ -88,7 +88,7 @@ def trapezoidal_weights(n: int, a: Optional[float]=-1.0, b: Optional[float]=1.0,
     on the interval [a, b]
     """
 
-    xlg = torch.from_numpy(np.linspace(a, b, n, endpoint=periodic))
+    xlg = torch.as_tensor(np.linspace(a, b, n, endpoint=periodic))
     wlg = (b - a) / (n - periodic * 1) * torch.ones(n, requires_grad=False)
 
     if not periodic:
@@ -105,8 +105,8 @@ def legendre_gauss_weights(n: int, a: Optional[float]=-1.0, b: Optional[float]=1
     """
 
     xlg, wlg = np.polynomial.legendre.leggauss(n)
-    xlg = torch.from_numpy(xlg).clone()
-    wlg = torch.from_numpy(wlg).clone()
+    xlg = torch.as_tensor(xlg).clone()
+    wlg = torch.as_tensor(wlg).clone()
     xlg = (b - a) * 0.5 * xlg + (b + a) * 0.5
     wlg = wlg * (b - a) * 0.5
 


### PR DESCRIPTION
Simplifying the precompute convolution tensor routine, re-using the single rank one for distributed as well. 
Re-writing parts of the code to assure that the routine can be called with device tenors as well.