### PR TITLE
fixing docstrings in examples

### DIFF
--- a/torch_harmonics/examples/models/s2segformer.py
+++ b/torch_harmonics/examples/models/s2segformer.py
@@ -612,11 +612,12 @@ class SphericalSegformer(nn.Module):
 
     Parameters
     -----------
-    img_shape : tuple, optional
+    img_size : tuple, optional
         Shape of the input channels, by default (128, 256)
-    kernel_shape: tuple, int
-    scale_factor: int, optional
-        Scale factor to use, by default 2
+    grid : str, optional
+        Grid type for input/output, by default "equiangular"
+    grid_internal : str, optional
+        Grid type for internal processing, by default "legendre-gauss"
     in_chans : int, optional
         Number of input channels, by default 3
     out_chans : int, optional
@@ -625,38 +626,41 @@ class SphericalSegformer(nn.Module):
         Dimension of the embeddings for each block, has to be the same length as heads
     heads : List[int], optional
         Number of heads for each block in the network, has to be the same length as embed_dims
-    depths: List[in], optional
+    depths: List[int], optional
         Number of repetitions of attentions blocks and ffn mixers per layer. Has to be the same length as embed_dims and heads
+    scale_factor: int, optional
+        Scale factor to use, by default 2
     activation_function : str, optional
         Activation function to use, by default "gelu"
-    embedder_kernel_shape : int, optional
-        size of the encoder kernel
-    filter_basis_type: Optional[str]: str, optional
-        filter basis type
-    use_mlp : int, optional
-        Whether to use MLPs in the SFNO blocks, by default True
-    mlp_ratio : int, optional
+    kernel_shape : tuple, optional
+        Kernel shape for convolutions, by default (3, 3)
+    filter_basis_type : str, optional
+        Filter basis type, by default "morlet"
+    mlp_ratio : float, optional
         Ratio of MLP to use, by default 2.0
-    drop_rate : float, optional
-        Dropout rate, by default 0.0
+    att_drop_rate : float, optional
+        Dropout rate for attention, by default 0.0
     drop_path_rate : float, optional
-        Dropout path rate, by default 0.0
-    normalization_layer : str, optional
-        Type of normalization layer to use ("layer_norm", "instance_norm", "none"), by default "instance_norm"
-    hard_thresholding_fraction : float, optional
-        Fraction of hard thresholding (frequency cutoff) to apply, by default 1.0
-    upsampling_method : str
-        Conv, bilinear
+        Dropout path rate, by default 0.1
+    attention_mode : str, optional
+        Attention mode ("neighborhood" or "global"), by default "neighborhood"
+    theta_cutoff : float, optional
+        Cutoff radius for neighborhood attention, by default None
+    upsampling_method : str, optional
+        Upsampling method ("conv" or "bilinear"), by default "bilinear"
+    bias : bool, optional
+        Whether to use bias, by default True
 
     Example
     -----------
-    >>> model = SphericalTransformer(
-    ...         img_shape=(128, 256),
+    >>> model = SphericalSegformer(
+    ...         img_size=(128, 256),
     ...         scale_factor=4,
     ...         in_chans=2,
     ...         out_chans=2,
-    ...         embed_dim=16,
-    ...         num_layers=4,
+    ...         embed_dims=[16, 32, 64, 128],
+    ...         heads=[1, 2, 4, 8],
+    ...         depths=[3, 4, 6, 3],
     ...         use_mlp=True,)
     >>> model(torch.randn(1, 2, 128, 256)).shape
     torch.Size([1, 2, 128, 256])

--- a/torch_harmonics/examples/models/s2transformer.py
+++ b/torch_harmonics/examples/models/s2transformer.py
@@ -373,9 +373,12 @@ class SphericalTransformer(nn.Module):
 
     Parameters
     -----------
-    img_shape : tuple, optional
+    img_size : tuple, optional
         Shape of the input channels, by default (128, 256)
-    kernel_shape: tuple, int
+    grid : str, optional
+        Grid type for input/output, by default "equiangular"
+    grid_internal : str, optional
+        Grid type for internal processing, by default "legendre-gauss"
     scale_factor : int, optional
         Scale factor to use, by default 3
     in_chans : int, optional
@@ -388,37 +391,41 @@ class SphericalTransformer(nn.Module):
         Number of layers in the network, by default 4
     activation_function : str, optional
         Activation function to use, by default "gelu"
-    encoder_kernel_shape : int, optional
-        size of the encoder kernel
-    filter_basis_type: str, optional
-        filter basis type
-    num_heads: int, optional
-        number of attention heads
-    use_mlp : int, optional
+    encoder_kernel_shape : tuple, optional
+        Kernel shape for encoder, by default (3, 3)
+    filter_basis_type : str, optional
+        Filter basis type, by default "morlet"
+    num_heads : int, optional
+        Number of attention heads, by default 1
+    use_mlp : bool, optional
         Whether to use MLPs in the SFNO blocks, by default True
-    mlp_ratio : int, optional
+    mlp_ratio : float, optional
         Ratio of MLP to use, by default 2.0
     drop_rate : float, optional
         Dropout rate, by default 0.0
     drop_path_rate : float, optional
         Dropout path rate, by default 0.0
     normalization_layer : str, optional
-        Type of normalization layer to use ("layer_norm", "instance_norm", "none"), by default "instance_norm"
+        Type of normalization layer to use ("layer_norm", "instance_norm", "none"), by default "none"
     hard_thresholding_fraction : float, optional
         Fraction of hard thresholding (frequency cutoff) to apply, by default 1.0
     residual_prediction : bool, optional
-        Whether to add a single large skip connection, by default True
-    pos_embed : bool, optional
-        Whether to use positional embedding, by default True
+        Whether to add a single large skip connection, by default False
+    pos_embed : str, optional
+        Type of positional embedding to use, by default "spectral"
     upsample_sht : bool, optional
-        Use SHT upsampling if true, else linear interpolation
+        Use SHT upsampling if true, else linear interpolation, by default False
+    attention_mode : str, optional
+        Attention mode ("neighborhood" or "global"), by default "neighborhood"
     bias : bool, optional
-        Whether to use a bias, by default False
+        Whether to use bias, by default False
+    theta_cutoff : float, optional
+        Cutoff radius for neighborhood attention, by default None
 
     Example
     -----------
     >>> model = SphericalTransformer(
-    ...         img_shape=(128, 256),
+    ...         img_size=(128, 256),
     ...         scale_factor=4,
     ...         in_chans=2,
     ...         out_chans=2,

--- a/torch_harmonics/examples/models/s2unet.py
+++ b/torch_harmonics/examples/models/s2unet.py
@@ -411,53 +411,54 @@ class UpsamplingBlock(nn.Module):
 
 class SphericalUNet(nn.Module):
     """
-    Spherical segformer model designed to approximate mappings from spherical signals to spherical segmentation masks
+    Spherical U-Net model designed to approximate mappings from spherical signals to spherical segmentation masks
 
     Parameters
     -----------
-    img_shape : tuple, optional
+    img_size : tuple, optional
         Shape of the input channels, by default (128, 256)
-    kernel_shape: tuple, int
-    scale_factor: int, optional
-        Scale factor to use, by default 2
+    grid : str, optional
+        Grid type for input/output, by default "equiangular"
+    grid_internal : str, optional
+        Grid type for internal processing, by default "legendre-gauss"
     in_chans : int, optional
         Number of input channels, by default 3
     out_chans : int, optional
         Number of classes, by default 3
     embed_dims : List[int], optional
         Dimension of the embeddings for each block, has to be the same length as depths
-    depths: List[in], optional
+    depths : List[int], optional
         Number of repetitions of conv blocks and ffn mixers per layer. Has to be the same length as embed_dims
+    scale_factor : int, optional
+        Scale factor to use, by default 2
     activation_function : str, optional
         Activation function to use, by default "relu"
-    embedder_kernel_shape : int, optional
-        size of the encoder kernel
-    filter_basis_type: Optional[str]: str, optional
-        filter basis type
-    use_mlp : int, optional
-        Whether to use MLPs in the SFNO blocks, by default True
-    mlp_ratio : int, optional
-        Ratio of MLP to use, by default 2.0
-    drop_rate : float, optional
-        Dropout rate, by default 0.0
+    kernel_shape : tuple, optional
+        Kernel shape for convolutions, by default (3, 3)
+    filter_basis_type : str, optional
+        Filter basis type, by default "morlet"
+    transform_skip : bool, optional
+        Whether to transform skip connection, by default False
+    drop_conv_rate : float, optional
+        Dropout rate for convolutions, by default 0.1
     drop_path_rate : float, optional
-        Dropout path rate, by default 0.0
-    normalization_layer : str, optional
-        Type of normalization layer to use ("layer_norm", "instance_norm", "none"), by default "instance_norm"
-    hard_thresholding_fraction : float, optional
-        Fraction of hard thresholding (frequency cutoff) to apply, by default 1.0
-    upsample_sht : bool, optional
-        Use SHT upsampling if true, else linear interpolation
+        Dropout path rate, by default 0.1
+    drop_dense_rate : float, optional
+        Dropout rate for dense layers, by default 0.5
+    downsampling_mode : str, optional
+        Downsampling mode ("bilinear", "conv"), by default "bilinear"
+    upsampling_mode : str, optional
+        Upsampling mode ("bilinear", "conv"), by default "bilinear"
 
     Example
     -----------
-    >>> model = SphericalTransformer(
-    ...         img_shape=(128, 256),
+    >>> model = SphericalUNet(
+    ...         img_size=(128, 256),
     ...         scale_factor=4,
     ...         in_chans=2,
     ...         out_chans=2,
-    ...         embed_dim=16,
-    ...         num_layers=4,
+    ...         embed_dims=[16, 32, 64, 128],
+    ...         depths=[2, 2, 2, 2],
     ...         use_mlp=True,)
     >>> model(torch.randn(1, 2, 128, 256)).shape
     torch.Size([1, 2, 128, 256])

--- a/torch_harmonics/examples/models/sfno.py
+++ b/torch_harmonics/examples/models/sfno.py
@@ -35,7 +35,7 @@ import torch.nn as nn
 
 from torch_harmonics import RealSHT, InverseRealSHT
 
-from torch_harmonics.examples.models._layers import MLP, SpectralConvS2, SequencePositionEmbedding, SpectralPositionEmbedding, LearnablePositionEmbedding
+from torch_harmonics.examples.models._layers import MLP, SpectralConvS2, SequencePositionEmbedding, SpectralPositionEmbedding, LearnablePositionEmbedding, DropPath
 
 from functools import partial
 


### PR DESCRIPTION
This MR fixes some docstrings in the examples. Especially argument naming and ordering.