### PR TITLE
Add FFT-based DISCO S2 contraction for faster spherical convolutions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 *.so
 checkpoints
+*benchmark_results

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -223,6 +223,25 @@ class TestDiscreteContinuousConvolution(unittest.TestCase):
             # transpose convolution
             [8, 4, 2, (16, 32), (16, 32), (3), "piecewise linear", "mean", "equiangular", "equiangular", torch.bfloat16, True, 5e-2, 5e-2],
             [8, 4, 2, (12, 24), (24, 48), (2, 2), "morlet", "mean", "equiangular", "equiangular", torch.bfloat16, True, 5e-2, 5e-2],
+            # FFT contraction tests (fp32 only)
+            # regular convolution
+            [8, 4, 2, (16, 32), (16, 32), (3), "piecewise linear", "mean", "equiangular", "equiangular", torch.float32, False, 1e-4, 1e-4, True],
+            [8, 4, 2, (16, 32), (8, 16), (3), "piecewise linear", "mean", "equiangular", "equiangular", torch.float32, False, 1e-4, 1e-4, True],
+            [8, 4, 2, (24, 48), (12, 24), (3, 3), "piecewise linear", "mean", "equiangular", "equiangular", torch.float32, False, 1e-4, 1e-4, True],
+            [8, 4, 2, (24, 48), (12, 24), (2, 2), "morlet", "mean", "equiangular", "equiangular", torch.float32, False, 1e-4, 1e-4, True],
+            [8, 4, 2, (24, 48), (12, 24), (3), "zernike", "mean", "equiangular", "equiangular", torch.float32, False, 1e-4, 1e-4, True],
+            [8, 4, 2, (18, 36), (6, 12), (7), "piecewise linear", "mean", "equiangular", "equiangular", torch.float32, False, 1e-4, 1e-4, True],
+            [8, 4, 2, (16, 32), (8, 16), (5), "piecewise linear", "mean", "equiangular", "legendre-gauss", torch.float32, False, 1e-4, 1e-4, True],
+            [8, 4, 2, (16, 32), (8, 16), (5), "piecewise linear", "mean", "legendre-gauss", "equiangular", torch.float32, False, 1e-4, 1e-4, True],
+            # transpose convolution
+            [8, 4, 2, (16, 32), (16, 32), (3), "piecewise linear", "mean", "equiangular", "equiangular", torch.float32, True, 1e-4, 1e-4, True],
+            [8, 4, 2, (8, 16), (16, 32), (5), "piecewise linear", "mean", "equiangular", "equiangular", torch.float32, True, 1e-4, 1e-4, True],
+            [8, 4, 2, (12, 24), (24, 48), (3, 3), "piecewise linear", "mean", "equiangular", "equiangular", torch.float32, True, 1e-4, 1e-4, True],
+            [8, 4, 2, (12, 24), (24, 48), (2, 2), "morlet", "mean", "equiangular", "equiangular", torch.float32, True, 1e-4, 1e-4, True],
+            [8, 4, 2, (12, 24), (24, 48), (3), "zernike", "mean", "equiangular", "equiangular", torch.float32, True, 1e-4, 1e-4, True],
+            [8, 4, 2, (6, 12), (18, 36), (7), "piecewise linear", "mean", "equiangular", "equiangular", torch.float32, True, 1e-4, 1e-4, True],
+            [8, 4, 2, (8, 16), (16, 32), (5), "piecewise linear", "mean", "equiangular", "legendre-gauss", torch.float32, True, 1e-4, 1e-4, True],
+            [8, 4, 2, (8, 16), (16, 32), (5), "piecewise linear", "mean", "legendre-gauss", "equiangular", torch.float32, True, 1e-4, 1e-4, True],
         ],
         skip_on_empty=True,
     )
@@ -242,6 +261,7 @@ class TestDiscreteContinuousConvolution(unittest.TestCase):
         transpose,
         atol,
         rtol,
+        use_fft_contraction=False,
         verbose=True,
     ):
 
@@ -282,6 +302,7 @@ class TestDiscreteContinuousConvolution(unittest.TestCase):
             bias=False,
             theta_cutoff=theta_cutoff,
             optimized_kernel=use_optimized_kernels,
+            use_fft_contraction=use_fft_contraction,
         ).to(self.device)
 
         filter_basis = conv.filter_basis

--- a/tests/test_fft_contraction.py
+++ b/tests/test_fft_contraction.py
@@ -1,0 +1,172 @@
+# coding=utf-8
+
+# SPDX-FileCopyrightText: Copyright (c) 2022 The torch-harmonics Authors. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import unittest
+from parameterized import parameterized
+
+import torch
+from torch_harmonics import DiscreteContinuousConvS2, DiscreteContinuousConvTransposeS2
+
+from testutils import disable_tf32, set_seed
+
+
+class TestFFTContraction(unittest.TestCase):
+    """Test FFT-based contraction against the loop-and-roll torch reference."""
+
+    @parameterized.expand(
+        [
+            # same resolution
+            [2, 4, 2, (16, 32), (16, 32), 3, "piecewise linear", "mean", "equiangular", "equiangular", 1e-5],
+            # downsampling
+            [2, 4, 2, (16, 32), (8, 16), 3, "piecewise linear", "mean", "equiangular", "equiangular", 1e-5],
+            [2, 4, 2, (24, 48), (12, 24), (3, 3), "piecewise linear", "mean", "equiangular", "equiangular", 1e-5],
+            # different basis types
+            [2, 4, 2, (24, 48), (12, 24), (2, 2), "morlet", "mean", "equiangular", "equiangular", 1e-5],
+            [2, 4, 2, (24, 48), (12, 24), 3, "zernike", "mean", "equiangular", "equiangular", 1e-5],
+            # different grids
+            [2, 4, 2, (16, 32), (8, 16), 5, "piecewise linear", "mean", "equiangular", "legendre-gauss", 1e-5],
+            [2, 4, 2, (16, 32), (8, 16), 5, "piecewise linear", "mean", "legendre-gauss", "equiangular", 1e-5],
+            # 3x stride
+            [2, 4, 2, (18, 36), (6, 12), 7, "piecewise linear", "mean", "equiangular", "equiangular", 1e-5],
+        ],
+        skip_on_empty=True,
+    )
+    def test_fft_forward_against_torch(
+        self, batch_size, in_channels, out_channels, in_shape, out_shape,
+        kernel_shape, basis_type, basis_norm_mode, grid_in, grid_out, atol,
+    ):
+        disable_tf32()
+        set_seed(42)
+
+        nlat_in = in_shape[0]
+        if isinstance(kernel_shape, int):
+            theta_cutoff = (kernel_shape + 1) * torch.pi / float(nlat_in - 1)
+        else:
+            theta_cutoff = (kernel_shape[0] + 1) * torch.pi / float(nlat_in - 1)
+
+        conv_ref = DiscreteContinuousConvS2(
+            in_channels, out_channels, in_shape, out_shape, kernel_shape,
+            basis_type=basis_type, basis_norm_mode=basis_norm_mode,
+            grid_in=grid_in, grid_out=grid_out, bias=False,
+            theta_cutoff=theta_cutoff, optimized_kernel=False, use_fft_contraction=False,
+        )
+        conv_fft = DiscreteContinuousConvS2(
+            in_channels, out_channels, in_shape, out_shape, kernel_shape,
+            basis_type=basis_type, basis_norm_mode=basis_norm_mode,
+            grid_in=grid_in, grid_out=grid_out, bias=False,
+            theta_cutoff=theta_cutoff, optimized_kernel=False, use_fft_contraction=True,
+        )
+        with torch.no_grad():
+            conv_fft.weight.copy_(conv_ref.weight)
+
+        x = torch.randn(batch_size, in_channels, *in_shape)
+        y_ref = conv_ref(x)
+        y_fft = conv_fft(x)
+
+        self.assertEqual(y_ref.shape, y_fft.shape)
+        self.assertTrue(
+            torch.allclose(y_ref, y_fft, atol=atol, rtol=1e-4),
+            f"Forward max diff: {(y_ref - y_fft).abs().max().item():.2e}",
+        )
+
+    @parameterized.expand(
+        [
+            # same resolution
+            [2, 4, 2, (16, 32), (16, 32), 3, "piecewise linear", "mean", "equiangular", "equiangular", 1e-5],
+            # upsampling
+            [2, 4, 2, (8, 16), (16, 32), 5, "piecewise linear", "mean", "equiangular", "equiangular", 1e-5],
+            [2, 4, 2, (12, 24), (24, 48), (3, 3), "piecewise linear", "mean", "equiangular", "equiangular", 1e-5],
+            # different basis types
+            [2, 4, 2, (12, 24), (24, 48), (2, 2), "morlet", "mean", "equiangular", "equiangular", 1e-5],
+            [2, 4, 2, (12, 24), (24, 48), 3, "zernike", "mean", "equiangular", "equiangular", 1e-5],
+            # different grids
+            [2, 4, 2, (8, 16), (16, 32), 5, "piecewise linear", "mean", "equiangular", "legendre-gauss", 1e-5],
+            [2, 4, 2, (8, 16), (16, 32), 5, "piecewise linear", "mean", "legendre-gauss", "equiangular", 1e-5],
+            # 3x stride
+            [2, 4, 2, (6, 12), (18, 36), 7, "piecewise linear", "mean", "equiangular", "equiangular", 1e-5],
+        ],
+        skip_on_empty=True,
+    )
+    def test_fft_transpose_against_torch(
+        self, batch_size, in_channels, out_channels, in_shape, out_shape,
+        kernel_shape, basis_type, basis_norm_mode, grid_in, grid_out, atol,
+    ):
+        disable_tf32()
+        set_seed(42)
+
+        nlat_in = in_shape[0]
+        if isinstance(kernel_shape, int):
+            theta_cutoff = (kernel_shape + 1) * torch.pi / float(nlat_in - 1)
+        else:
+            theta_cutoff = (kernel_shape[0] + 1) * torch.pi / float(nlat_in - 1)
+
+        tconv_ref = DiscreteContinuousConvTransposeS2(
+            in_channels, out_channels, in_shape, out_shape, kernel_shape,
+            basis_type=basis_type, basis_norm_mode=basis_norm_mode,
+            grid_in=grid_in, grid_out=grid_out, bias=False,
+            theta_cutoff=theta_cutoff, optimized_kernel=False, use_fft_contraction=False,
+        )
+        tconv_fft = DiscreteContinuousConvTransposeS2(
+            in_channels, out_channels, in_shape, out_shape, kernel_shape,
+            basis_type=basis_type, basis_norm_mode=basis_norm_mode,
+            grid_in=grid_in, grid_out=grid_out, bias=False,
+            theta_cutoff=theta_cutoff, optimized_kernel=False, use_fft_contraction=True,
+        )
+        with torch.no_grad():
+            tconv_fft.weight.copy_(tconv_ref.weight)
+
+        x = torch.randn(batch_size, in_channels, *in_shape)
+        y_ref = tconv_ref(x)
+        y_fft = tconv_fft(x)
+
+        self.assertEqual(y_ref.shape, y_fft.shape)
+        self.assertTrue(
+            torch.allclose(y_ref, y_fft, atol=atol, rtol=1e-4),
+            f"Transpose max diff: {(y_ref - y_fft).abs().max().item():.2e}",
+        )
+
+    def test_fft_forward_gradient(self):
+        """Test that gradients flow correctly through the FFT path."""
+        disable_tf32()
+        set_seed(42)
+
+        conv = DiscreteContinuousConvS2(
+            4, 2, (16, 32), (8, 16), 3, bias=False,
+            optimized_kernel=False, use_fft_contraction=True,
+        )
+
+        x = torch.randn(2, 4, 16, 32, requires_grad=True)
+        y = conv(x)
+        loss = y.sum()
+        loss.backward()
+
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(conv.weight.grad)
+        self.assertFalse(torch.all(x.grad == 0))
+        self.assertFalse(torch.all(conv.weight.grad == 0))
+
+    def test_fft_transpose_gradient(self):
+        """Test that gradients flow correctly through the FFT transpose path."""
+        disable_tf32()
+        set_seed(42)
+
+        tconv = DiscreteContinuousConvTransposeS2(
+            4, 2, (8, 16), (16, 32), 3, bias=False,
+            optimized_kernel=False, use_fft_contraction=True,
+        )
+
+        x = torch.randn(2, 4, 8, 16, requires_grad=True)
+        y = tconv(x)
+        loss = y.sum()
+        loss.backward()
+
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(tconv.weight.grad)
+        self.assertFalse(torch.all(x.grad == 0))
+        self.assertFalse(torch.all(tconv.weight.grad == 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fft_contraction.py
+++ b/tests/test_fft_contraction.py
@@ -66,10 +66,7 @@ class TestFFTContraction(unittest.TestCase):
         y_fft = conv_fft(x)
 
         self.assertEqual(y_ref.shape, y_fft.shape)
-        self.assertTrue(
-            torch.allclose(y_ref, y_fft, atol=atol, rtol=1e-4),
-            f"Forward max diff: {(y_ref - y_fft).abs().max().item():.2e}",
-        )
+        torch.testing.assert_close(y_ref, y_fft, atol=atol, rtol=1e-4)
 
     @parameterized.expand(
         [
@@ -122,10 +119,7 @@ class TestFFTContraction(unittest.TestCase):
         y_fft = tconv_fft(x)
 
         self.assertEqual(y_ref.shape, y_fft.shape)
-        self.assertTrue(
-            torch.allclose(y_ref, y_fft, atol=atol, rtol=1e-4),
-            f"Transpose max diff: {(y_ref - y_fft).abs().max().item():.2e}",
-        )
+        torch.testing.assert_close(y_ref, y_fft, atol=atol, rtol=1e-4)
 
     def test_fft_forward_gradient(self):
         """Test that gradients flow correctly through the FFT path."""

--- a/tests/test_fft_contraction.py
+++ b/tests/test_fft_contraction.py
@@ -9,7 +9,7 @@ from parameterized import parameterized
 import torch
 from torch_harmonics import DiscreteContinuousConvS2, DiscreteContinuousConvTransposeS2
 
-from testutils import disable_tf32, set_seed
+from testutils import compare_tensors, disable_tf32, set_seed
 
 
 class TestFFTContraction(unittest.TestCase):
@@ -66,7 +66,7 @@ class TestFFTContraction(unittest.TestCase):
         y_fft = conv_fft(x)
 
         self.assertEqual(y_ref.shape, y_fft.shape)
-        torch.testing.assert_close(y_ref, y_fft, atol=atol, rtol=1e-4)
+        self.assertTrue(compare_tensors("fft_forward", y_ref, y_fft, atol=atol, rtol=1e-4, verbose=True))
 
     @parameterized.expand(
         [
@@ -119,7 +119,7 @@ class TestFFTContraction(unittest.TestCase):
         y_fft = tconv_fft(x)
 
         self.assertEqual(y_ref.shape, y_fft.shape)
-        torch.testing.assert_close(y_ref, y_fft, atol=atol, rtol=1e-4)
+        self.assertTrue(compare_tensors("fft_transpose", y_ref, y_fft, atol=atol, rtol=1e-4, verbose=True))
 
     def test_fft_forward_gradient(self):
         """Test that gradients flow correctly through the FFT path."""

--- a/torch_harmonics/benchmark/__init__.py
+++ b/torch_harmonics/benchmark/__init__.py
@@ -13,3 +13,4 @@ from torch_harmonics.benchmark.timer import (
 
 # Import to trigger registration of built-in benchmarks.
 import torch_harmonics.benchmark.sht  # noqa: F401
+import torch_harmonics.benchmark.disco  # noqa: F401

--- a/torch_harmonics/benchmark/__init__.py
+++ b/torch_harmonics/benchmark/__init__.py
@@ -1,0 +1,15 @@
+from torch_harmonics.benchmark.benchmark import (
+    BenchmarkABC,
+    BenchmarkResult,
+    get_benchmarks,
+    register_benchmark,
+)
+from torch_harmonics.benchmark.timer import (
+    CUDATimer,
+    NullTimer,
+    Timer,
+    TimerResult,
+)
+
+# Import to trigger registration of built-in benchmarks.
+import torch_harmonics.benchmark.sht  # noqa: F401

--- a/torch_harmonics/benchmark/__init__.py
+++ b/torch_harmonics/benchmark/__init__.py
@@ -4,6 +4,11 @@ from torch_harmonics.benchmark.benchmark import (
     get_benchmarks,
     register_benchmark,
 )
+from torch_harmonics.benchmark.memory import (
+    MemoryBenchmark,
+    MemoryResult,
+    benchmark_memory,
+)
 from torch_harmonics.benchmark.timer import (
     CUDATimer,
     NullTimer,

--- a/torch_harmonics/benchmark/__main__.py
+++ b/torch_harmonics/benchmark/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+import torch_harmonics.benchmark  # noqa: F401 — triggers benchmark registration
+from torch_harmonics.benchmark.run import cli
+
+sys.exit(cli())

--- a/torch_harmonics/benchmark/benchmark.py
+++ b/torch_harmonics/benchmark/benchmark.py
@@ -1,0 +1,93 @@
+import abc
+import dataclasses
+from collections.abc import Callable
+from typing import Self
+
+import torch
+
+from torch_harmonics.benchmark.timer import (
+    CPUEventPair,
+    CUDATimer,
+    NullTimer,
+    Timer,
+    TimerResult,
+)
+
+TensorDict = dict[str, torch.Tensor]
+
+
+@dataclasses.dataclass
+class BenchmarkResult:
+    timer: TimerResult
+    cpu_time: float
+
+    def __repr__(self) -> str:
+        return f"BenchmarkResult(timer={self.timer}, cpu_time={self.cpu_time})"
+
+    def asdict(self) -> dict:
+        return dataclasses.asdict(self)
+
+    def get_logs(self, max_depth: int) -> dict[str, float]:
+        logs = {"cpu_time": self.cpu_time}
+        logs.update(self.timer.get_logs(max_depth=max_depth))
+        return logs
+
+
+class BenchmarkABC(abc.ABC):
+    @classmethod
+    @abc.abstractmethod
+    def new(cls: type[Self]) -> Self:
+        """
+        Initialize any state needed for the benchmark.
+        This will be called once before the benchmark is run.
+        """
+        pass
+
+    @classmethod
+    def run_benchmark(cls, iters=10, warmup=1) -> BenchmarkResult:
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA is not available, cannot run benchmark.")
+        null_timer = NullTimer()
+        benchmark = cls.new()
+        for _ in range(warmup):
+            benchmark.run_instance(null_timer)
+        timer = CUDATimer()
+        cpu_timer = CPUEventPair()
+        cpu_timer.record_start()
+        for _ in range(iters):
+            with timer:
+                benchmark.run_instance(timer)
+        torch.cuda.synchronize()
+        cpu_timer.record_end()
+        return BenchmarkResult(
+            timer=timer.result,
+            cpu_time=cpu_timer.elapsed_time_ms(),
+        )
+
+    @abc.abstractmethod
+    def run_instance(self: Self, timer: Timer) -> TensorDict:
+        """
+        Run the benchmark. This will be called multiple times,
+        and should return a TensorDict of results.
+
+        This must not mutate any state on self, since the same instance may be
+        used across multiple iterations.
+        """
+        pass
+
+
+_BENCHMARKS: dict[str, type[BenchmarkABC]] = {}
+
+
+def register_benchmark(name: str) -> Callable[[type[BenchmarkABC]], type[BenchmarkABC]]:
+    def _register(fn: type[BenchmarkABC]) -> type[BenchmarkABC]:
+        if name in _BENCHMARKS:
+            raise ValueError(f"Benchmark with name '{name}' is already registered.")
+        _BENCHMARKS[name] = fn
+        return fn
+
+    return _register
+
+
+def get_benchmarks() -> dict[str, type[BenchmarkABC]]:
+    return _BENCHMARKS.copy()

--- a/torch_harmonics/benchmark/benchmark.py
+++ b/torch_harmonics/benchmark/benchmark.py
@@ -5,6 +5,7 @@ from typing import Self
 
 import torch
 
+from torch_harmonics.benchmark.memory import MemoryResult, benchmark_memory
 from torch_harmonics.benchmark.timer import (
     CPUEventPair,
     CUDATimer,
@@ -20,15 +21,19 @@ TensorDict = dict[str, torch.Tensor]
 class BenchmarkResult:
     timer: TimerResult
     cpu_time: float
+    memory: MemoryResult | None = None
 
     def __repr__(self) -> str:
-        return f"BenchmarkResult(timer={self.timer}, cpu_time={self.cpu_time})"
+        return f"BenchmarkResult(timer={self.timer}, cpu_time={self.cpu_time}, memory={self.memory})"
 
     def asdict(self) -> dict:
         return dataclasses.asdict(self)
 
     def get_logs(self, max_depth: int) -> dict[str, float]:
         logs = {"cpu_time": self.cpu_time}
+        if self.memory is not None:
+            logs["max_alloc_mb"] = self.memory.max_alloc / (1024.0 * 1024.0)
+            logs["max_reserved_mb"] = self.memory.max_reserved / (1024.0 * 1024.0)
         logs.update(self.timer.get_logs(max_depth=max_depth))
         return logs
 
@@ -53,15 +58,17 @@ class BenchmarkABC(abc.ABC):
             benchmark.run_instance(null_timer)
         timer = CUDATimer()
         cpu_timer = CPUEventPair()
-        cpu_timer.record_start()
-        for _ in range(iters):
-            with timer:
-                benchmark.run_instance(timer)
-        torch.cuda.synchronize()
-        cpu_timer.record_end()
+        with benchmark_memory() as bm:
+            cpu_timer.record_start()
+            for _ in range(iters):
+                with timer:
+                    benchmark.run_instance(timer)
+            torch.cuda.synchronize()
+            cpu_timer.record_end()
         return BenchmarkResult(
             timer=timer.result,
             cpu_time=cpu_timer.elapsed_time_ms(),
+            memory=bm.result,
         )
 
     @abc.abstractmethod

--- a/torch_harmonics/benchmark/disco.py
+++ b/torch_harmonics/benchmark/disco.py
@@ -68,6 +68,17 @@ class DiscreteContinuousConvS2TorchBenchmark1Degree(DiscreteContinuousConvS2Benc
         )
 
 
+@register_benchmark("disco_conv_s2_cuda_1deg")
+class DiscreteContinuousConvS2CUDABenchmark1Degree(DiscreteContinuousConvS2Benchmark):
+
+    @classmethod
+    def new(cls) -> "DiscreteContinuousConvS2CUDABenchmark1Degree":
+        return cls.new_with_shape(
+            B=scale_batch_size(64), in_channels=4, out_channels=4, nlat=180, nlon=360,
+            optimized_kernel=True,
+        )
+
+
 @register_benchmark("disco_conv_s2_fft_1deg")
 class DiscreteContinuousConvS2FFTBenchmark1Degree(DiscreteContinuousConvS2Benchmark):
 

--- a/torch_harmonics/benchmark/disco.py
+++ b/torch_harmonics/benchmark/disco.py
@@ -10,7 +10,7 @@ from torch_harmonics.benchmark.benchmark import (
 )
 from torch_harmonics.benchmark.hardware import get_device, scale_batch_size
 from torch_harmonics.benchmark.timer import Timer
-from torch_harmonics.disco import DiscreteContinuousConvS2
+from torch_harmonics.disco import DiscreteContinuousConvS2, DiscreteContinuousConvTransposeS2
 
 
 class DiscreteContinuousConvS2Benchmark(BenchmarkABC):
@@ -121,4 +121,69 @@ class DiscreteContinuousConvS2CUDABenchmarkHalfTo1Degree(DiscreteContinuousConvS
             B=scale_batch_size(32), in_channels=4, out_channels=4,
             nlat=360, nlon=720, nlat_out=180, nlon_out=360,
             optimized_kernel=True,
+        )
+
+
+class DiscreteContinuousConvTransposeS2Benchmark(BenchmarkABC):
+
+    @final
+    def __init__(self, conv: DiscreteContinuousConvTransposeS2, x: torch.Tensor):
+        self.conv = conv
+        self.x = x
+
+    @classmethod
+    @abc.abstractmethod
+    def new(cls) -> "DiscreteContinuousConvTransposeS2Benchmark": ...
+
+    @classmethod
+    @final
+    def new_with_shape(
+        cls: type[Self],
+        B: int,
+        in_channels: int,
+        out_channels: int,
+        nlat: int,
+        nlon: int,
+        nlat_out: int,
+        nlon_out: int,
+        kernel_shape: int = 3,
+        optimized_kernel: bool = False,
+        use_fft_contraction: bool = False,
+    ) -> Self:
+        device = get_device()
+        theta_cutoff = (kernel_shape + 1) * torch.pi / float(nlat - 1)
+        conv = DiscreteContinuousConvTransposeS2(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            in_shape=(nlat, nlon),
+            out_shape=(nlat_out, nlon_out),
+            kernel_shape=kernel_shape,
+            theta_cutoff=theta_cutoff,
+            optimized_kernel=optimized_kernel,
+            use_fft_contraction=use_fft_contraction,
+        ).to(device)
+        x = torch.randn(B, in_channels, nlat, nlon, device=device, requires_grad=True)
+        return cls(conv=conv, x=x)
+
+    @final
+    def run_instance(self, timer: Timer) -> TensorDict:
+        with timer.child("forward"):
+            result = self.conv(self.x)
+        grad_output = torch.randn_like(result)
+        with timer.child("backward"):
+            result.backward(grad_output)
+        self.conv.zero_grad()
+        self.x.grad = None
+        return {"output": result.detach()}
+
+
+@register_benchmark("disco_tconv_s2_fft_1deg_to_halfdeg")
+class DiscreteContinuousConvTransposeS2FFTBenchmark1ToHalfDegree(DiscreteContinuousConvTransposeS2Benchmark):
+
+    @classmethod
+    def new(cls) -> "DiscreteContinuousConvTransposeS2FFTBenchmark1ToHalfDegree":
+        return cls.new_with_shape(
+            B=scale_batch_size(32), in_channels=4, out_channels=4,
+            nlat=180, nlon=360, nlat_out=360, nlon_out=720,
+            use_fft_contraction=True,
         )

--- a/torch_harmonics/benchmark/disco.py
+++ b/torch_harmonics/benchmark/disco.py
@@ -33,17 +33,21 @@ class DiscreteContinuousConvS2Benchmark(BenchmarkABC):
         out_channels: int,
         nlat: int,
         nlon: int,
+        nlat_out: int | None = None,
+        nlon_out: int | None = None,
         kernel_shape: int = 3,
         optimized_kernel: bool = False,
         use_fft_contraction: bool = False,
     ) -> Self:
         device = get_device()
+        nlat_out = nlat_out if nlat_out is not None else nlat
+        nlon_out = nlon_out if nlon_out is not None else nlon
         theta_cutoff = (kernel_shape + 1) * torch.pi / float(nlat - 1)
         conv = DiscreteContinuousConvS2(
             in_channels=in_channels,
             out_channels=out_channels,
             in_shape=(nlat, nlon),
-            out_shape=(nlat, nlon),
+            out_shape=(nlat_out, nlon_out),
             kernel_shape=kernel_shape,
             theta_cutoff=theta_cutoff,
             optimized_kernel=optimized_kernel,
@@ -93,4 +97,28 @@ class DiscreteContinuousConvS2FFTBenchmark1Degree(DiscreteContinuousConvS2Benchm
         return cls.new_with_shape(
             B=scale_batch_size(64), in_channels=4, out_channels=4, nlat=180, nlon=360,
             use_fft_contraction=True,
+        )
+
+
+@register_benchmark("disco_conv_s2_fft_halfdeg_to_1deg")
+class DiscreteContinuousConvS2FFTBenchmarkHalfTo1Degree(DiscreteContinuousConvS2Benchmark):
+
+    @classmethod
+    def new(cls) -> "DiscreteContinuousConvS2FFTBenchmarkHalfTo1Degree":
+        return cls.new_with_shape(
+            B=scale_batch_size(32), in_channels=4, out_channels=4,
+            nlat=360, nlon=720, nlat_out=180, nlon_out=360,
+            use_fft_contraction=True,
+        )
+
+
+@register_benchmark("disco_conv_s2_cuda_halfdeg_to_1deg")
+class DiscreteContinuousConvS2CUDABenchmarkHalfTo1Degree(DiscreteContinuousConvS2Benchmark):
+
+    @classmethod
+    def new(cls) -> "DiscreteContinuousConvS2CUDABenchmarkHalfTo1Degree":
+        return cls.new_with_shape(
+            B=scale_batch_size(32), in_channels=4, out_channels=4,
+            nlat=360, nlon=720, nlat_out=180, nlon_out=360,
+            optimized_kernel=True,
         )

--- a/torch_harmonics/benchmark/disco.py
+++ b/torch_harmonics/benchmark/disco.py
@@ -49,12 +49,18 @@ class DiscreteContinuousConvS2Benchmark(BenchmarkABC):
             optimized_kernel=optimized_kernel,
             use_fft_contraction=use_fft_contraction,
         ).to(device)
-        x = torch.randn(B, in_channels, nlat, nlon, device=device)
+        x = torch.randn(B, in_channels, nlat, nlon, device=device, requires_grad=True)
         return cls(conv=conv, x=x)
 
     @final
     def run_instance(self, timer: Timer) -> TensorDict:
-        result = self.conv(self.x)
+        with timer.child("forward"):
+            result = self.conv(self.x)
+        grad_output = torch.randn_like(result)
+        with timer.child("backward"):
+            result.backward(grad_output)
+        self.conv.zero_grad()
+        self.x.grad = None
         return {"output": result.detach()}
 
 

--- a/torch_harmonics/benchmark/disco.py
+++ b/torch_harmonics/benchmark/disco.py
@@ -1,0 +1,68 @@
+import abc
+from typing import Self, final
+
+import torch
+
+from torch_harmonics.benchmark.benchmark import (
+    BenchmarkABC,
+    TensorDict,
+    register_benchmark,
+)
+from torch_harmonics.benchmark.timer import Timer
+from torch_harmonics.disco import DiscreteContinuousConvS2
+
+
+def _get_device():
+    return torch.device("cuda", torch.cuda.current_device())
+
+
+class DiscreteContinuousConvS2Benchmark(BenchmarkABC):
+
+    @final
+    def __init__(self, conv: DiscreteContinuousConvS2, x: torch.Tensor):
+        self.conv = conv
+        self.x = x
+
+    @classmethod
+    @abc.abstractmethod
+    def new(cls) -> "DiscreteContinuousConvS2Benchmark": ...
+
+    @classmethod
+    @final
+    def new_with_shape(
+        cls: type[Self],
+        B: int,
+        in_channels: int,
+        out_channels: int,
+        nlat: int,
+        nlon: int,
+        kernel_shape: int = 3,
+    ) -> Self:
+        device = _get_device()
+        theta_cutoff = (kernel_shape + 1) * torch.pi / float(nlat - 1)
+        conv = DiscreteContinuousConvS2(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            in_shape=(nlat, nlon),
+            out_shape=(nlat, nlon),
+            kernel_shape=kernel_shape,
+            theta_cutoff=theta_cutoff,
+            optimized_kernel=False,
+        ).to(device)
+        x = torch.randn(B, in_channels, nlat, nlon, device=device)
+        return cls(conv=conv, x=x)
+
+    @final
+    def run_instance(self, timer: Timer) -> TensorDict:
+        result = self.conv(self.x)
+        return {"output": result.detach()}
+
+
+@register_benchmark("disco_conv_s2_torch_1deg")
+class DiscreteContinuousConvS2TorchBenchmark1Degree(DiscreteContinuousConvS2Benchmark):
+
+    @classmethod
+    def new(cls) -> "DiscreteContinuousConvS2TorchBenchmark1Degree":
+        return cls.new_with_shape(
+            B=4, in_channels=4, out_channels=4, nlat=180, nlon=360,
+        )

--- a/torch_harmonics/benchmark/disco.py
+++ b/torch_harmonics/benchmark/disco.py
@@ -34,6 +34,8 @@ class DiscreteContinuousConvS2Benchmark(BenchmarkABC):
         nlat: int,
         nlon: int,
         kernel_shape: int = 3,
+        optimized_kernel: bool = False,
+        use_fft_contraction: bool = False,
     ) -> Self:
         device = get_device()
         theta_cutoff = (kernel_shape + 1) * torch.pi / float(nlat - 1)
@@ -44,7 +46,8 @@ class DiscreteContinuousConvS2Benchmark(BenchmarkABC):
             out_shape=(nlat, nlon),
             kernel_shape=kernel_shape,
             theta_cutoff=theta_cutoff,
-            optimized_kernel=False,
+            optimized_kernel=optimized_kernel,
+            use_fft_contraction=use_fft_contraction,
         ).to(device)
         x = torch.randn(B, in_channels, nlat, nlon, device=device)
         return cls(conv=conv, x=x)
@@ -61,5 +64,16 @@ class DiscreteContinuousConvS2TorchBenchmark1Degree(DiscreteContinuousConvS2Benc
     @classmethod
     def new(cls) -> "DiscreteContinuousConvS2TorchBenchmark1Degree":
         return cls.new_with_shape(
-            B=scale_batch_size(4), in_channels=4, out_channels=4, nlat=180, nlon=360,
+            B=scale_batch_size(16), in_channels=4, out_channels=4, nlat=180, nlon=360,
+        )
+
+
+@register_benchmark("disco_conv_s2_fft_1deg")
+class DiscreteContinuousConvS2FFTBenchmark1Degree(DiscreteContinuousConvS2Benchmark):
+
+    @classmethod
+    def new(cls) -> "DiscreteContinuousConvS2FFTBenchmark1Degree":
+        return cls.new_with_shape(
+            B=scale_batch_size(64), in_channels=4, out_channels=4, nlat=180, nlon=360,
+            use_fft_contraction=True,
         )

--- a/torch_harmonics/benchmark/disco.py
+++ b/torch_harmonics/benchmark/disco.py
@@ -8,12 +8,9 @@ from torch_harmonics.benchmark.benchmark import (
     TensorDict,
     register_benchmark,
 )
+from torch_harmonics.benchmark.hardware import get_device, scale_batch_size
 from torch_harmonics.benchmark.timer import Timer
 from torch_harmonics.disco import DiscreteContinuousConvS2
-
-
-def _get_device():
-    return torch.device("cuda", torch.cuda.current_device())
 
 
 class DiscreteContinuousConvS2Benchmark(BenchmarkABC):
@@ -38,7 +35,7 @@ class DiscreteContinuousConvS2Benchmark(BenchmarkABC):
         nlon: int,
         kernel_shape: int = 3,
     ) -> Self:
-        device = _get_device()
+        device = get_device()
         theta_cutoff = (kernel_shape + 1) * torch.pi / float(nlat - 1)
         conv = DiscreteContinuousConvS2(
             in_channels=in_channels,
@@ -64,5 +61,5 @@ class DiscreteContinuousConvS2TorchBenchmark1Degree(DiscreteContinuousConvS2Benc
     @classmethod
     def new(cls) -> "DiscreteContinuousConvS2TorchBenchmark1Degree":
         return cls.new_with_shape(
-            B=4, in_channels=4, out_channels=4, nlat=180, nlon=360,
+            B=scale_batch_size(4), in_channels=4, out_channels=4, nlat=180, nlon=360,
         )

--- a/torch_harmonics/benchmark/hardware.py
+++ b/torch_harmonics/benchmark/hardware.py
@@ -1,0 +1,52 @@
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# Batch size scale factors relative to Tesla T4 (the default baseline).
+# To add a new GPU, add an entry mapping its device name (as returned by
+# torch.cuda.get_device_properties(...).name) to a float scale factor.
+# Values > 1.0 mean the GPU is faster than a T4 and can use larger batches;
+# values < 1.0 mean it is slower.
+_BATCH_SIZE_FACTORS: dict[str, float] = {
+    "Tesla T4": 1.0,
+}
+
+_DEFAULT_BATCH_SIZE_FACTOR = 1.0
+
+
+def get_device() -> torch.device:
+    return torch.device("cuda", torch.cuda.current_device())
+
+
+def get_batch_size_factor() -> float:
+    """Return a hardware-dependent scale factor for benchmark batch sizes.
+
+    Benchmarks define a base batch size tuned for a Tesla T4. This function
+    returns a multiplier so that benchmarks take a similar wall-clock time
+    on other hardware. If the batch size is too small, the GPU will not be fully
+    occupied, and the benchmarks cannot be used to tune performance.
+    
+    Unknown devices fall back to the T4 default (1.0).
+    """
+    if not torch.cuda.is_available():
+        return _DEFAULT_BATCH_SIZE_FACTOR
+    name = torch.cuda.get_device_properties(torch.cuda.current_device()).name
+    factor = _BATCH_SIZE_FACTORS.get(name)
+    if factor is None:
+        logger.warning(
+            f"Unknown GPU '{name}', using default batch size factor "
+            f"{_DEFAULT_BATCH_SIZE_FACTOR}. Add an entry to "
+            f"_BATCH_SIZE_FACTORS in hardware.py to tune for this device."
+        )
+        return _DEFAULT_BATCH_SIZE_FACTOR
+    return factor
+
+
+def scale_batch_size(base: int) -> int:
+    """Scale a base batch size (tuned for Tesla T4) by the hardware factor.
+
+    Always returns at least 1.
+    """
+    return max(1, round(base * get_batch_size_factor()))

--- a/torch_harmonics/benchmark/memory.py
+++ b/torch_harmonics/benchmark/memory.py
@@ -1,0 +1,65 @@
+import dataclasses
+from typing import Literal
+
+import torch
+
+_benchmark_memory_started = False
+
+
+@dataclasses.dataclass
+class MemoryResult:
+    max_alloc: int
+    max_reserved: int
+
+
+class MemoryBenchmark:
+    def __init__(self):
+        self._ended = False
+
+    def __enter__(self) -> "MemoryBenchmark":
+        global _benchmark_memory_started
+        if _benchmark_memory_started:
+            raise RuntimeError(
+                "benchmark_memory cannot be nested due to its use of globals"
+            )
+        try:
+            if self._ended:
+                raise RuntimeError(
+                    "MemoryBenchmark cannot be reused after it has ended."
+                )
+            _benchmark_memory_started = True
+            torch.cuda.synchronize()
+            torch.cuda.reset_peak_memory_stats()
+            self._max_alloc = 0
+            self._max_reserved = 0
+        except Exception as e:
+            _benchmark_memory_started = False
+            raise e
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> Literal[False]:
+        torch.cuda.synchronize()
+        global _benchmark_memory_started
+        _benchmark_memory_started = False
+        self._ended = True
+        self._max_alloc = torch.cuda.max_memory_allocated()
+        self._max_reserved = torch.cuda.max_memory_reserved()
+        return False
+
+    @property
+    def result(self) -> MemoryResult:
+        if _benchmark_memory_started:
+            raise RuntimeError(
+                "MemoryBenchmark is still running. "
+                "Please exit the context before getting results."
+            )
+        if not self._ended:
+            raise RuntimeError(
+                "MemoryBenchmark has not been run yet. "
+                "Please enter and exit the context before getting results."
+            )
+        return MemoryResult(max_alloc=self._max_alloc, max_reserved=self._max_reserved)
+
+
+def benchmark_memory() -> MemoryBenchmark:
+    return MemoryBenchmark()

--- a/torch_harmonics/benchmark/run.py
+++ b/torch_harmonics/benchmark/run.py
@@ -1,0 +1,128 @@
+import argparse
+import dataclasses
+import json
+import logging
+import pathlib
+import subprocess
+import sys
+
+import torch
+
+from torch_harmonics.benchmark.benchmark import get_benchmarks
+
+_GIT_COMMIT: str | None = None
+
+
+def get_git_commit() -> str:
+    global _GIT_COMMIT
+    if _GIT_COMMIT is None:
+        try:
+            commit = (
+                subprocess.check_output(
+                    ["git", "rev-parse", "--short", "HEAD"],
+                    stderr=subprocess.DEVNULL,
+                )
+                .decode()
+                .strip()
+            )
+            dirty = (
+                subprocess.check_output(
+                    ["git", "status", "--porcelain"],
+                    stderr=subprocess.DEVNULL,
+                )
+                .decode()
+                .strip()
+            )
+            if dirty:
+                commit = f"{commit}-dirty"
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            commit = "unknown"
+        _GIT_COMMIT = commit
+    return _GIT_COMMIT
+
+
+def get_device_name() -> str:
+    if torch.cuda.is_available():
+        return torch.cuda.get_device_properties(0).name
+    else:
+        return "CPU"
+
+
+def main(
+    benchmark_name: str | None,
+    iters: int,
+    output_dir: pathlib.Path,
+) -> int:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    device_name = get_device_name()
+    safe_device_name = device_name.replace(" ", "_").replace("/", "_").lower()
+
+    logging.info(f"Running benchmarks on device: {device_name}")
+    benchmarks = get_benchmarks()
+    if benchmark_name is not None:
+        if benchmark_name not in benchmarks:
+            logging.error(
+                f"Specified benchmark {benchmark_name} not found. "
+                f"Available benchmarks: {', '.join(benchmarks.keys())}"
+            )
+            return 1
+        benchmarks_to_run = {benchmark_name: benchmarks[benchmark_name]}
+    else:
+        benchmarks_to_run = benchmarks
+
+    def get_filename(name, extension) -> pathlib.Path:
+        safe_name = name.replace("/", "_").replace(".", "_").lower()
+        return (
+            output_dir
+            / f"{safe_name}_{safe_device_name}_{get_git_commit()}.{extension}"
+        )
+
+    for name, cls in benchmarks_to_run.items():
+        logging.info(f"Running benchmark: {name}")
+        result = cls.run_benchmark(iters=iters)
+        result_data = json.dumps(dataclasses.asdict(result), indent=2)
+        logging.info(f"Result: {result_data}")
+        json_path = get_filename(name, "json")
+        with open(json_path, "w") as f:
+            logging.info(f"Saving result json to {f.name}")
+            f.write(result_data)
+
+    return 0
+
+
+def cli() -> int:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
+    parser = argparse.ArgumentParser(description="Run registered benchmarks.")
+    parser.add_argument(
+        "--name",
+        type=str,
+        default=None,
+        help=(
+            "Name of the benchmark to run. If not provided, "
+            "all benchmarks will be run."
+        ),
+    )
+    parser.add_argument(
+        "--iters",
+        type=int,
+        default=10,
+        help="Number of iterations to run each benchmark for.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="benchmark_results",
+        help="Directory to save benchmark results in.",
+    )
+    args = parser.parse_args()
+    return main(
+        benchmark_name=args.name,
+        iters=args.iters,
+        output_dir=pathlib.Path(args.output_dir),
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(cli())

--- a/torch_harmonics/benchmark/sht.py
+++ b/torch_harmonics/benchmark/sht.py
@@ -8,12 +8,9 @@ from torch_harmonics.benchmark.benchmark import (
     TensorDict,
     register_benchmark,
 )
+from torch_harmonics.benchmark.hardware import get_device, scale_batch_size
 from torch_harmonics.benchmark.timer import Timer
 from torch_harmonics.sht import InverseRealSHT, RealSHT
-
-
-def _get_device():
-    return torch.device("cuda", torch.cuda.current_device())
 
 
 class RealSHTBenchmark(BenchmarkABC):
@@ -30,7 +27,7 @@ class RealSHTBenchmark(BenchmarkABC):
     @classmethod
     @final
     def new_with_shape(cls: type[Self], B: int, H: int, L: int) -> Self:
-        device = _get_device()
+        device = get_device()
         x = torch.randn(B, H, L, device=device)
         forward_sht = RealSHT(nlat=H, nlon=L).to(device)
         return cls(forward_sht=forward_sht, x=x)
@@ -46,7 +43,7 @@ class RealSHTBenchmark1Degree(RealSHTBenchmark):
 
     @classmethod
     def new(cls) -> "RealSHTBenchmark1Degree":
-        return cls.new_with_shape(B=4096, H=180, L=360)
+        return cls.new_with_shape(B=scale_batch_size(4096), H=180, L=360)
 
 
 class InverseRealSHTBenchmark(BenchmarkABC):
@@ -63,7 +60,7 @@ class InverseRealSHTBenchmark(BenchmarkABC):
     @classmethod
     @final
     def new_with_shape(cls: type[Self], B: int, H: int, L: int) -> Self:
-        device = _get_device()
+        device = get_device()
         x = torch.randn(B, H, L, device=device)
         forward_sht = RealSHT(nlat=H, nlon=L).to(device)
         x_hat = forward_sht(x)
@@ -80,4 +77,4 @@ class InverseRealSHTBenchmark1Degree(InverseRealSHTBenchmark):
 
     @classmethod
     def new(cls) -> "InverseRealSHTBenchmark1Degree":
-        return cls.new_with_shape(B=4096, H=180, L=360)
+        return cls.new_with_shape(B=scale_batch_size(4096), H=180, L=360)

--- a/torch_harmonics/benchmark/sht.py
+++ b/torch_harmonics/benchmark/sht.py
@@ -1,0 +1,83 @@
+import abc
+from typing import Self, final
+
+import torch
+
+from torch_harmonics.benchmark.benchmark import (
+    BenchmarkABC,
+    TensorDict,
+    register_benchmark,
+)
+from torch_harmonics.benchmark.timer import Timer
+from torch_harmonics.sht import InverseRealSHT, RealSHT
+
+
+def _get_device():
+    return torch.device("cuda", torch.cuda.current_device())
+
+
+class RealSHTBenchmark(BenchmarkABC):
+
+    @final
+    def __init__(self, forward_sht: RealSHT, x: torch.Tensor):
+        self.forward_sht = forward_sht
+        self.x = x
+
+    @classmethod
+    @abc.abstractmethod
+    def new(cls) -> "RealSHTBenchmark": ...
+
+    @classmethod
+    @final
+    def new_with_shape(cls: type[Self], B: int, H: int, L: int) -> Self:
+        device = _get_device()
+        x = torch.randn(B, H, L, device=device)
+        forward_sht = RealSHT(nlat=H, nlon=L).to(device)
+        return cls(forward_sht=forward_sht, x=x)
+
+    @final
+    def run_instance(self, timer: Timer) -> TensorDict:
+        result = self.forward_sht(self.x)
+        return {"output": result.detach()}
+
+
+@register_benchmark("real_sht_1deg")
+class RealSHTBenchmark1Degree(RealSHTBenchmark):
+
+    @classmethod
+    def new(cls) -> "RealSHTBenchmark1Degree":
+        return cls.new_with_shape(B=4096, H=180, L=360)
+
+
+class InverseRealSHTBenchmark(BenchmarkABC):
+
+    @final
+    def __init__(self, inverse_sht: InverseRealSHT, x_hat: torch.Tensor):
+        self.inverse_sht = inverse_sht
+        self.x_hat = x_hat
+
+    @classmethod
+    @abc.abstractmethod
+    def new(cls) -> "InverseRealSHTBenchmark": ...
+
+    @classmethod
+    @final
+    def new_with_shape(cls: type[Self], B: int, H: int, L: int) -> Self:
+        device = _get_device()
+        x = torch.randn(B, H, L, device=device)
+        forward_sht = RealSHT(nlat=H, nlon=L).to(device)
+        x_hat = forward_sht(x)
+        inverse_sht = InverseRealSHT(nlat=H, nlon=L).to(device)
+        return cls(inverse_sht=inverse_sht, x_hat=x_hat)
+
+    @final
+    def run_instance(self, timer: Timer) -> TensorDict:
+        result = self.inverse_sht(self.x_hat)
+        return {"output": result.detach()}
+
+@register_benchmark("inverse_real_sht_1deg")
+class InverseRealSHTBenchmark1Degree(InverseRealSHTBenchmark):
+
+    @classmethod
+    def new(cls) -> "InverseRealSHTBenchmark1Degree":
+        return cls.new_with_shape(B=4096, H=180, L=360)

--- a/torch_harmonics/benchmark/timer.py
+++ b/torch_harmonics/benchmark/timer.py
@@ -1,0 +1,203 @@
+import collections
+import dataclasses
+import time
+from typing import Literal, Protocol, Self
+
+import torch
+
+
+@dataclasses.dataclass
+class TimerResult:
+    count: int
+    avg_time: float
+    children: dict[str, "TimerResult"]
+
+    def get_logs(self, max_depth: int) -> dict[str, float]:
+        logs = {
+            "avg_time": self.avg_time,
+        }
+        if max_depth > 0:
+            for child_name, child in self.children.items():
+                for log_name, value in child.get_logs(max_depth=max_depth - 1).items():
+                    logs[f"{child_name}/{log_name}"] = value
+        return logs
+
+    def assert_close(self, other: "TimerResult", rtol=0.02, children_rtol=0.02) -> None:
+        if self.count != other.count:
+            raise AssertionError(f"count differ: {self.count} vs {other.count}")
+        if not torch.isclose(
+            torch.tensor(self.avg_time), torch.tensor(other.avg_time), rtol=rtol
+        ):
+            raise AssertionError(
+                f"avg_time differ: {self.avg_time} vs "
+                f"{other.avg_time} given rtol={rtol}"
+            )
+        if self.children.keys() != other.children.keys():
+            raise AssertionError(
+                f"children keys differ: {self.children.keys()} vs "
+                f"{other.children.keys()}"
+            )
+        for key in self.children.keys():
+            try:
+                self.children[key].assert_close(
+                    other.children[key], rtol=children_rtol, children_rtol=children_rtol
+                )
+            except AssertionError as e:
+                raise AssertionError(f"child '{key}' differ: {e}") from e
+
+
+class Timer(Protocol):
+    def child(self, name: str) -> Self: ...
+    def __enter__(self) -> Self: ...
+    def __exit__(self, exc_type, exc_val, exc_tb) -> Literal[False]: ...
+
+
+class NullTimer:
+    def child(self, name: str) -> "NullTimer":
+        return self
+
+    def __enter__(self) -> "NullTimer":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> Literal[False]:
+        return False
+
+
+_: Timer = NullTimer()
+del _
+
+
+class EventPair:
+    def __init__(self):
+        self.start = torch.cuda.Event(enable_timing=True)
+        self.end = torch.cuda.Event(enable_timing=True)
+        self._stream = None
+        self._start_recorded = False
+        self._end_recorded = False
+
+    def record_start(self):
+        if self._start_recorded:
+            raise RuntimeError(
+                "record_start has already been called on this EventPair."
+            )
+        self._stream = torch.cuda.current_stream()
+        self.start.record(self._stream)
+        self._start_recorded = True
+
+    def record_end(self):
+        if not self._start_recorded:
+            raise RuntimeError("record_start must be called before record_end")
+        if self._end_recorded:
+            raise RuntimeError("record_end has already been called on this EventPair.")
+        if self._stream is None:
+            raise RuntimeError("record_start must be called before record_end")
+        self.end.record(self._stream)
+        self._end_recorded = True
+
+    def elapsed_time_ms(self) -> float:
+        if not self._start_recorded or not self._end_recorded:
+            raise RuntimeError(
+                "Both record_start and record_end must be called "
+                "before elapsed_time_ms can be called."
+            )
+        return self.start.elapsed_time(self.end)
+
+
+class CPUEventPair:
+    def __init__(self):
+        self.start_time = None
+        self.end_time = None
+
+    def record_start(self):
+        if self.start_time is not None:
+            raise RuntimeError(
+                "record_start has already been called on this CPUEventPair."
+            )
+        self.start_time = time.time()
+
+    def record_end(self):
+        if self.start_time is None:
+            raise RuntimeError("record_start must be called before record_end")
+        if self.end_time is not None:
+            raise RuntimeError(
+                "record_end has already been called on this CPUEventPair."
+            )
+        self.end_time = time.time()
+
+    def elapsed_time_ms(self) -> float:
+        if self.start_time is None or self.end_time is None:
+            raise RuntimeError(
+                "Both record_start and record_end must be called "
+                "before elapsed_time_ms can be called."
+            )
+        return (self.end_time - self.start_time) * 1000
+
+
+class CUDATimer:
+    def __init__(self):
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA is not available, cannot use CUDATimer.")
+        self._children: collections.defaultdict[str, CUDATimer] = (
+            collections.defaultdict(CUDATimer)
+        )
+        self._event_pairs: list[EventPair] = []
+        self._entered = False
+        self._result: TimerResult | None = None
+
+    @classmethod
+    def new_if_available(cls) -> "CUDATimer | NullTimer":
+        if torch.cuda.is_available():
+            return cls()
+        else:
+            return NullTimer()
+
+    def __enter__(self):
+        if self._entered:
+            raise RuntimeError("CUDATimer is already entered.")
+        self._entered = True
+        self._event_pairs.append(EventPair())
+        self._event_pairs[-1].record_start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if not self._event_pairs:
+            raise RuntimeError("CUDATimer context was not properly entered.")
+        self._event_pairs[-1].record_end()
+        self._entered = False
+        return False
+
+    def child(self, name: str) -> "CUDATimer":
+        if not self._entered:
+            raise RuntimeError(
+                "CUDATimer child cannot be used before entering the timer."
+            )
+        return self._children[name]
+
+    @property
+    def _avg_time(self) -> float:
+        if len(self._event_pairs) == 0:
+            raise RuntimeError(
+                "CUDATimer report cannot be generated before entering the timer."
+            )
+        total_time = sum(
+            event_pair.elapsed_time_ms() for event_pair in self._event_pairs
+        )
+        return total_time / len(self._event_pairs)
+
+    def _child_reports(self) -> dict[str, TimerResult]:
+        return {name: child.result for name, child in self._children.items()}
+
+    @property
+    def result(self) -> TimerResult:
+        if self._result is None:
+            torch.cuda.synchronize()
+            self._result = TimerResult(
+                count=len(self._event_pairs),
+                avg_time=self._avg_time,
+                children=self._child_reports(),
+            )
+        return self._result
+
+
+__: type[Timer] = CUDATimer
+del __

--- a/torch_harmonics/disco/_disco_utils.py
+++ b/torch_harmonics/disco/_disco_utils.py
@@ -140,29 +140,67 @@ if optimized_kernels_is_available():
     torch.library.register_autograd(
         "disco_kernels::_disco_s2_transpose_contraction_optimized", _disco_s2_transpose_contraction_bwd_optimized, setup_context=_setup_context_conv_backward)
 
-# FFT-based contraction functions
-def _densify_psi(psi_sparse: torch.Tensor, nlat_in: int, nlon_in: int):
-    """Convert sparse psi (K, nlat_out, nlat_in * nlon_in) to dense (K, nlat_out, nlat_in, nlon_in)."""
-    K, nlat_out, _ = psi_sparse.shape
-    return psi_sparse.to_dense().reshape(K, nlat_out, nlat_in, nlon_in)
+# FFT-based contraction functions (banded representation)
+def _precompute_psi_banded(psi_sparse: torch.Tensor, nlat_in: int, nlon: int):
+    """Build a banded dense representation of psi directly from sparse COO data.
 
+    Instead of densifying the full (K, nlat_out, nlat_in, nlon) tensor, this
+    only stores the contiguous band of input latitudes that have nonzero entries
+    for each output latitude, reducing memory by ~nlat_in/band_width.
 
-def _precompute_psi_fft_conj(psi_sparse: torch.Tensor, nlat_in: int, nlon_in: int):
-    """Densify psi and return conjugate of its rfft along the longitude axis."""
-    psi_dense = _densify_psi(psi_sparse, nlat_in, nlon_in)
-    return rfft(psi_dense, dim=-1).conj()
-
-
-def _disco_s2_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Tensor, nlon_out: int):
+    Returns
+    -------
+    psi_banded_fft_conj : (K, nlat_out, max_bw, nfreq) complex tensor
+    gather_idx : (nlat_out, max_bw) long tensor of input latitude indices
     """
-    FFT-based DISCO S2 contraction. Replaces the loop-and-roll implementation
-    with FFT circular cross-correlation.
+    K, nlat_out, _ = psi_sparse.shape
+    psi = psi_sparse.coalesce()
+    indices = psi.indices()  # (3, nnz)
+    values = psi.values()    # (nnz,)
+
+    ker_idx = indices[0]
+    row_idx = indices[1]   # output lat
+    col_idx = indices[2]   # input_lat * nlon + lon
+    input_lat = col_idx // nlon
+    input_lon = col_idx % nlon
+
+    # Find min/max input lat per output lat (across all kernel indices)
+    lat_min = torch.full((nlat_out,), nlat_in, dtype=torch.long)
+    lat_max = torch.full((nlat_out,), 0, dtype=torch.long)
+    lat_min.scatter_reduce_(0, row_idx, input_lat, reduce="amin")
+    lat_max.scatter_reduce_(0, row_idx, input_lat, reduce="amax")
+
+    # Handle empty rows
+    empty = lat_min >= nlat_in
+    lat_min[empty] = 0
+    lat_max[empty] = 0
+
+    max_bw = (lat_max - lat_min + 1).max().item()
+
+    # Build banded tensor from sparse entries (no full densification)
+    psi_banded = torch.zeros(K, nlat_out, max_bw, nlon, dtype=values.dtype)
+    banded_lat = input_lat - lat_min[row_idx]
+    psi_banded[ker_idx, row_idx, banded_lat, input_lon] = values
+
+    # Precompute FFT and gather index (clamped to valid range for zero-padded bands)
+    psi_banded_fft_conj = rfft(psi_banded, dim=-1).conj()
+    gather_idx = lat_min.unsqueeze(1) + torch.arange(max_bw).unsqueeze(0)  # (nlat_out, max_bw)
+    gather_idx = gather_idx.clamp(max=nlat_in - 1)
+
+    return psi_banded_fft_conj, gather_idx
+
+
+def _disco_s2_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Tensor, gather_idx: torch.Tensor, nlon_out: int):
+    """
+    FFT-based DISCO S2 contraction using banded psi representation.
 
     Parameters
     ----------
     x : torch.Tensor of shape (B, C, nlat_in, nlon_in)
-    psi_fft_conj : torch.Tensor of shape (K, nlat_out, nlat_in, nlon_in//2+1)
-        Precomputed conjugate FFT of the dense psi kernel.
+    psi_fft_conj : torch.Tensor of shape (K, nlat_out, bw, nfreq)
+        Precomputed conjugate FFT of the banded psi kernel.
+    gather_idx : torch.Tensor of shape (nlat_out, bw)
+        Input latitude indices for each output latitude band.
     nlon_out : int
 
     Returns
@@ -170,18 +208,18 @@ def _disco_s2_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Tensor, nlon_
     torch.Tensor of shape (B, C, K, nlat_out, nlon_out)
     """
     batch_size, n_chans, nlat_in, nlon_in = x.shape
-    kernel_size, nlat_out, _, nfreq = psi_fft_conj.shape
+    kernel_size, nlat_out, bw, nfreq = psi_fft_conj.shape
     pscale = nlon_in // nlon_out
 
     # FFT of input along longitude
-    X_f = rfft(x.to(torch.float32), dim=-1)  # (B*C, nlat_in, nfreq)
+    X_f = rfft(x.to(torch.float32), dim=-1)  # (B, C, nlat_in, nfreq)
     X_f = X_f.reshape(batch_size * n_chans, nlat_in, nfreq)
 
-    # Cross-correlate: einsum over nlat_in and frequency, then irfft
-    # psi_fft_conj: (K, nlat_out, nlat_in, nfreq)
-    # X_f: (B*C, nlat_in, nfreq)
-    Y_f = torch.einsum("konf,bnf->bkof", psi_fft_conj.to(X_f.dtype), X_f)
-    # Y_f: (B*C, K, nlat_out, nfreq)
+    # Gather relevant input lats for each output lat
+    X_f_gathered = X_f[:, gather_idx, :]  # (B*C, nlat_out, bw, nfreq)
+
+    # Cross-correlate: einsum over band width and frequency, then irfft
+    Y_f = torch.einsum("kowf,bowf->bkof", psi_fft_conj.to(X_f.dtype), X_f_gathered)
 
     # Inverse FFT
     y = irfft(Y_f, n=nlon_in, dim=-1)  # (B*C, K, nlat_out, nlon_in)
@@ -193,16 +231,17 @@ def _disco_s2_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Tensor, nlon_
     return y.to(x.dtype)
 
 
-def _disco_s2_transpose_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Tensor, nlon_out: int):
+def _disco_s2_transpose_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Tensor, gather_idx: torch.Tensor, nlon_out: int):
     """
-    FFT-based DISCO S2 transpose contraction.
+    FFT-based DISCO S2 transpose contraction using banded psi representation.
 
     Parameters
     ----------
     x : torch.Tensor of shape (B, C, K, nlat_in, nlon_in)
-    psi_fft_conj : torch.Tensor of shape (K, nlat_out, nlat_in, nfreq)
-        Precomputed conjugate FFT of the semi-transposed dense psi kernel.
-        psi_st_dense has shape (K, nlat_out, nlat_in, nlon_out).
+    psi_fft_conj : torch.Tensor of shape (K, nlat_out, bw, nfreq)
+        Precomputed conjugate FFT of the banded semi-transposed psi kernel.
+    gather_idx : torch.Tensor of shape (nlat_out, bw)
+        Input latitude indices for each output latitude band.
     nlon_out : int
 
     Returns
@@ -210,9 +249,8 @@ def _disco_s2_transpose_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Ten
     torch.Tensor of shape (B, C, nlat_out, nlon_out)
     """
     batch_size, n_chans, kernel_size, nlat_in, nlon_in = x.shape
-    _, nlat_out, nlat_in_psi, nfreq = psi_fft_conj.shape
+    _, nlat_out, bw, nfreq = psi_fft_conj.shape
 
-    assert nlat_in_psi == nlat_in
     assert nlon_out >= nlon_in
     pscale = nlon_out // nlon_in
 
@@ -221,19 +259,17 @@ def _disco_s2_transpose_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Ten
     x_ext = torch.zeros(batch_size * n_chans, kernel_size, nlat_in, nlon_out, device=x.device, dtype=x.dtype)
     x_ext[..., ::pscale] = x
 
-    # The loop-based code does roll(-1) BEFORE bmm for each pout.
-    # This means pout=0 uses a shift of -1, pout=1 uses -2, etc.
-    # Apply this constant offset before FFT.
+    # Apply constant offset before FFT (matches loop-based roll(-1) convention)
     x_ext = torch.roll(x_ext, -1, dims=-1)
 
     # FFT of upsampled input along longitude
     X_f = rfft(x_ext.to(torch.float32), dim=-1)  # (B*C, K, nlat_in, nfreq)
 
-    # Cross-correlate and sum over K and nlat_in
-    # psi_fft_conj: (K, nlat_out, nlat_in, nfreq)
-    # X_f: (B*C, K, nlat_in, nfreq)
-    Y_f = torch.einsum("koif,bkif->bof", psi_fft_conj.to(X_f.dtype), X_f)
-    # Y_f: (B*C, nlat_out, nfreq)
+    # Loop over kernel index to avoid materializing a large 5D gathered tensor
+    Y_f = torch.zeros(batch_size * n_chans, nlat_out, nfreq, device=X_f.device, dtype=X_f.dtype)
+    for k in range(kernel_size):
+        X_f_k_gathered = X_f[:, k][:, gather_idx, :]  # (B*C, nlat_out, bw, nfreq)
+        Y_f += torch.einsum("owf,bowf->bof", psi_fft_conj[k].to(X_f.dtype), X_f_k_gathered)
 
     # Inverse FFT
     y = irfft(Y_f, n=nlon_out, dim=-1)  # (B*C, nlat_out, nlon_out)

--- a/torch_harmonics/disco/_disco_utils.py
+++ b/torch_harmonics/disco/_disco_utils.py
@@ -219,7 +219,7 @@ def _disco_s2_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Tensor, gathe
     X_f_gathered = X_f[:, gather_idx, :]  # (B*C, nlat_out, bw, nfreq)
 
     # Cross-correlate: einsum over band width and frequency, then irfft
-    Y_f = torch.einsum("kowf,bowf->bkof", psi_fft_conj.to(X_f.dtype), X_f_gathered)
+    Y_f = torch.einsum("kowf,bowf->bkof", psi_fft_conj, X_f_gathered)
 
     # Inverse FFT
     y = irfft(Y_f, n=nlon_in, dim=-1)  # (B*C, K, nlat_out, nlon_in)
@@ -259,11 +259,14 @@ def _disco_s2_transpose_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Ten
     x_ext = torch.zeros(batch_size * n_chans, kernel_size, nlat_in, nlon_out, device=x.device, dtype=x.dtype)
     x_ext[..., ::pscale] = x
 
-    # Apply constant offset before FFT (matches loop-based roll(-1) convention)
-    x_ext = torch.roll(x_ext, -1, dims=-1)
-
     # FFT of upsampled input along longitude
     X_f = rfft(x_ext.to(torch.float32), dim=-1)  # (B*C, K, nlat_in, nfreq)
+
+    # Apply roll(-1) as a phase shift in frequency domain: multiply by exp(+2*pi*i*k/N)
+    # This avoids a full tensor copy from torch.roll
+    freq = torch.arange(nfreq, device=X_f.device, dtype=torch.float32)
+    phase = torch.exp(2j * torch.pi * freq / nlon_out)
+    X_f = X_f * phase
 
     # Loop over kernel index to avoid materializing a large 5D gathered tensor
     Y_f = torch.zeros(batch_size * n_chans, nlat_out, nfreq, device=X_f.device, dtype=X_f.dtype)

--- a/torch_harmonics/disco/_disco_utils.py
+++ b/torch_harmonics/disco/_disco_utils.py
@@ -34,6 +34,7 @@ from typing import Optional
 import torch
 from disco_helpers import optimized_kernels_is_available
 from . import disco_kernels
+from torch_harmonics.fft import rfft, irfft
 
 # custom kernels
 if optimized_kernels_is_available():
@@ -149,7 +150,7 @@ def _densify_psi(psi_sparse: torch.Tensor, nlat_in: int, nlon_in: int):
 def _precompute_psi_fft_conj(psi_sparse: torch.Tensor, nlat_in: int, nlon_in: int):
     """Densify psi and return conjugate of its rfft along the longitude axis."""
     psi_dense = _densify_psi(psi_sparse, nlat_in, nlon_in)
-    return torch.fft.rfft(psi_dense, dim=-1).conj()
+    return rfft(psi_dense, dim=-1).conj()
 
 
 def _disco_s2_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Tensor, nlon_out: int):
@@ -173,7 +174,7 @@ def _disco_s2_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Tensor, nlon_
     pscale = nlon_in // nlon_out
 
     # FFT of input along longitude
-    X_f = torch.fft.rfft(x.to(torch.float32), dim=-1)  # (B*C, nlat_in, nfreq)
+    X_f = rfft(x.to(torch.float32), dim=-1)  # (B*C, nlat_in, nfreq)
     X_f = X_f.reshape(batch_size * n_chans, nlat_in, nfreq)
 
     # Cross-correlate: einsum over nlat_in and frequency, then irfft
@@ -183,7 +184,7 @@ def _disco_s2_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Tensor, nlon_
     # Y_f: (B*C, K, nlat_out, nfreq)
 
     # Inverse FFT
-    y = torch.fft.irfft(Y_f, n=nlon_in, dim=-1)  # (B*C, K, nlat_out, nlon_in)
+    y = irfft(Y_f, n=nlon_in, dim=-1)  # (B*C, K, nlat_out, nlon_in)
 
     # Subsample for stride
     y = y[..., ::pscale]  # (B*C, K, nlat_out, nlon_out)
@@ -226,7 +227,7 @@ def _disco_s2_transpose_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Ten
     x_ext = torch.roll(x_ext, -1, dims=-1)
 
     # FFT of upsampled input along longitude
-    X_f = torch.fft.rfft(x_ext.to(torch.float32), dim=-1)  # (B*C, K, nlat_in, nfreq)
+    X_f = rfft(x_ext.to(torch.float32), dim=-1)  # (B*C, K, nlat_in, nfreq)
 
     # Cross-correlate and sum over K and nlat_in
     # psi_fft_conj: (K, nlat_out, nlat_in, nfreq)
@@ -235,7 +236,7 @@ def _disco_s2_transpose_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Ten
     # Y_f: (B*C, nlat_out, nfreq)
 
     # Inverse FFT
-    y = torch.fft.irfft(Y_f, n=nlon_out, dim=-1)  # (B*C, nlat_out, nlon_out)
+    y = irfft(Y_f, n=nlon_out, dim=-1)  # (B*C, nlat_out, nlon_out)
 
     y = y.reshape(batch_size, n_chans, nlat_out, nlon_out).contiguous()
     return y.to(x.dtype)

--- a/torch_harmonics/disco/_disco_utils.py
+++ b/torch_harmonics/disco/_disco_utils.py
@@ -139,6 +139,108 @@ if optimized_kernels_is_available():
     torch.library.register_autograd(
         "disco_kernels::_disco_s2_transpose_contraction_optimized", _disco_s2_transpose_contraction_bwd_optimized, setup_context=_setup_context_conv_backward)
 
+# FFT-based contraction functions
+def _densify_psi(psi_sparse: torch.Tensor, nlat_in: int, nlon_in: int):
+    """Convert sparse psi (K, nlat_out, nlat_in * nlon_in) to dense (K, nlat_out, nlat_in, nlon_in)."""
+    K, nlat_out, _ = psi_sparse.shape
+    return psi_sparse.to_dense().reshape(K, nlat_out, nlat_in, nlon_in)
+
+
+def _precompute_psi_fft_conj(psi_sparse: torch.Tensor, nlat_in: int, nlon_in: int):
+    """Densify psi and return conjugate of its rfft along the longitude axis."""
+    psi_dense = _densify_psi(psi_sparse, nlat_in, nlon_in)
+    return torch.fft.rfft(psi_dense, dim=-1).conj()
+
+
+def _disco_s2_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Tensor, nlon_out: int):
+    """
+    FFT-based DISCO S2 contraction. Replaces the loop-and-roll implementation
+    with FFT circular cross-correlation.
+
+    Parameters
+    ----------
+    x : torch.Tensor of shape (B, C, nlat_in, nlon_in)
+    psi_fft_conj : torch.Tensor of shape (K, nlat_out, nlat_in, nlon_in//2+1)
+        Precomputed conjugate FFT of the dense psi kernel.
+    nlon_out : int
+
+    Returns
+    -------
+    torch.Tensor of shape (B, C, K, nlat_out, nlon_out)
+    """
+    batch_size, n_chans, nlat_in, nlon_in = x.shape
+    kernel_size, nlat_out, _, nfreq = psi_fft_conj.shape
+    pscale = nlon_in // nlon_out
+
+    # FFT of input along longitude
+    X_f = torch.fft.rfft(x.to(torch.float32), dim=-1)  # (B*C, nlat_in, nfreq)
+    X_f = X_f.reshape(batch_size * n_chans, nlat_in, nfreq)
+
+    # Cross-correlate: einsum over nlat_in and frequency, then irfft
+    # psi_fft_conj: (K, nlat_out, nlat_in, nfreq)
+    # X_f: (B*C, nlat_in, nfreq)
+    Y_f = torch.einsum("konf,bnf->bkof", psi_fft_conj.to(X_f.dtype), X_f)
+    # Y_f: (B*C, K, nlat_out, nfreq)
+
+    # Inverse FFT
+    y = torch.fft.irfft(Y_f, n=nlon_in, dim=-1)  # (B*C, K, nlat_out, nlon_in)
+
+    # Subsample for stride
+    y = y[..., ::pscale]  # (B*C, K, nlat_out, nlon_out)
+
+    y = y.reshape(batch_size, n_chans, kernel_size, nlat_out, nlon_out).contiguous()
+    return y.to(x.dtype)
+
+
+def _disco_s2_transpose_contraction_fft(x: torch.Tensor, psi_fft_conj: torch.Tensor, nlon_out: int):
+    """
+    FFT-based DISCO S2 transpose contraction.
+
+    Parameters
+    ----------
+    x : torch.Tensor of shape (B, C, K, nlat_in, nlon_in)
+    psi_fft_conj : torch.Tensor of shape (K, nlat_out, nlat_in, nfreq)
+        Precomputed conjugate FFT of the semi-transposed dense psi kernel.
+        psi_st_dense has shape (K, nlat_out, nlat_in, nlon_out).
+    nlon_out : int
+
+    Returns
+    -------
+    torch.Tensor of shape (B, C, nlat_out, nlon_out)
+    """
+    batch_size, n_chans, kernel_size, nlat_in, nlon_in = x.shape
+    _, nlat_out, nlat_in_psi, nfreq = psi_fft_conj.shape
+
+    assert nlat_in_psi == nlat_in
+    assert nlon_out >= nlon_in
+    pscale = nlon_out // nlon_in
+
+    # Upsample x by interleaving zeros along longitude
+    x = x.reshape(batch_size * n_chans, kernel_size, nlat_in, nlon_in)
+    x_ext = torch.zeros(batch_size * n_chans, kernel_size, nlat_in, nlon_out, device=x.device, dtype=x.dtype)
+    x_ext[..., ::pscale] = x
+
+    # The loop-based code does roll(-1) BEFORE bmm for each pout.
+    # This means pout=0 uses a shift of -1, pout=1 uses -2, etc.
+    # Apply this constant offset before FFT.
+    x_ext = torch.roll(x_ext, -1, dims=-1)
+
+    # FFT of upsampled input along longitude
+    X_f = torch.fft.rfft(x_ext.to(torch.float32), dim=-1)  # (B*C, K, nlat_in, nfreq)
+
+    # Cross-correlate and sum over K and nlat_in
+    # psi_fft_conj: (K, nlat_out, nlat_in, nfreq)
+    # X_f: (B*C, K, nlat_in, nfreq)
+    Y_f = torch.einsum("koif,bkif->bof", psi_fft_conj.to(X_f.dtype), X_f)
+    # Y_f: (B*C, nlat_out, nfreq)
+
+    # Inverse FFT
+    y = torch.fft.irfft(Y_f, n=nlon_out, dim=-1)  # (B*C, nlat_out, nlon_out)
+
+    y = y.reshape(batch_size, n_chans, nlat_out, nlon_out).contiguous()
+    return y.to(x.dtype)
+
+
 # torch kernel related functions
 def _get_psi(kernel_size: int, psi_idx: torch.Tensor, psi_vals: torch.Tensor, nlat_in: int, nlon_in: int, nlat_out: int, nlon_out: int, nlat_in_local: Optional[int] = None, nlat_out_local: Optional[int] = None, semi_transposed: Optional[bool] = False):
     """Creates a sparse tensor for spherical harmonic convolution operations."""

--- a/torch_harmonics/disco/convolution.py
+++ b/torch_harmonics/disco/convolution.py
@@ -40,6 +40,8 @@ import torch.nn as nn
 from torch_harmonics.cache import lru_cache
 from torch_harmonics.quadrature import precompute_latitudes, precompute_longitudes
 from ._disco_utils import _get_psi, _disco_s2_contraction_torch, _disco_s2_transpose_contraction_torch
+from ._disco_utils import _disco_s2_contraction_fft, _disco_s2_transpose_contraction_fft
+from ._disco_utils import _precompute_psi_fft_conj
 from ._disco_utils import _disco_s2_contraction_optimized, _disco_s2_transpose_contraction_optimized
 from torch_harmonics.filter_basis import FilterBasis, get_filter_basis
 from disco_helpers import optimized_kernels_is_available, preprocess_psi
@@ -350,11 +352,13 @@ class DiscreteContinuousConv(nn.Module, metaclass=abc.ABCMeta):
         groups: Optional[int] = 1,
         bias: Optional[bool] = True,
         optimized_kernel: Optional[bool] = True,
+        use_fft_contraction: Optional[bool] = False,
     ):
         super().__init__()
 
         self.kernel_shape = kernel_shape
-        self.optimized_kernel = optimized_kernel and optimized_kernels_is_available()
+        self.use_fft_contraction = use_fft_contraction
+        self.optimized_kernel = optimized_kernel and optimized_kernels_is_available() and not use_fft_contraction
 
         # get the filter basis functions
         self.filter_basis = get_filter_basis(kernel_shape=kernel_shape, basis_type=basis_type)
@@ -443,8 +447,9 @@ class DiscreteContinuousConvS2(DiscreteContinuousConv):
         bias: Optional[bool] = True,
         theta_cutoff: Optional[float] = None,
         optimized_kernel: Optional[bool] = True,
+        use_fft_contraction: Optional[bool] = False,
     ):
-        super().__init__(in_channels, out_channels, kernel_shape, basis_type, groups, bias, optimized_kernel)
+        super().__init__(in_channels, out_channels, kernel_shape, basis_type, groups, bias, optimized_kernel, use_fft_contraction)
 
         self.nlat_in, self.nlon_in = in_shape
         self.nlat_out, self.nlon_out = out_shape
@@ -490,8 +495,13 @@ class DiscreteContinuousConvS2(DiscreteContinuousConv):
         self.register_buffer("psi_col_idx", col_idx, persistent=False)
         self.register_buffer("psi_vals", vals, persistent=False)
 
-        # also store psi as COO matrix just in case for torch input
-        if not self.optimized_kernel:
+        if self.use_fft_contraction:
+            # precompute FFT of densified psi for FFT-based contraction
+            psi_sparse = _get_psi(self.kernel_size, self.psi_idx, self.psi_vals, self.nlat_in, self.nlon_in, self.nlat_out, self.nlon_out)
+            psi_fft_conj = _precompute_psi_fft_conj(psi_sparse, self.nlat_in, self.nlon_in)
+            self.register_buffer("psi_fft_conj", psi_fft_conj, persistent=False)
+        elif not self.optimized_kernel:
+            # also store psi as COO matrix just in case for torch input
             self.psi = _get_psi(self.kernel_size, self.psi_idx, self.psi_vals, self.nlat_in, self.nlon_in, self.nlat_out, self.nlon_out)
 
     def extra_repr(self):
@@ -503,7 +513,9 @@ class DiscreteContinuousConvS2(DiscreteContinuousConv):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
 
-        if self.optimized_kernel:
+        if self.use_fft_contraction:
+            x = _disco_s2_contraction_fft(x, self.psi_fft_conj.to(x.device), self.nlon_out)
+        elif self.optimized_kernel:
             x = _disco_s2_contraction_optimized(
                 x, self.psi_roff_idx, self.psi_ker_idx, self.psi_row_idx, self.psi_col_idx, self.psi_vals, self.kernel_size, self.nlat_out, self.nlon_out
             )
@@ -582,8 +594,9 @@ class DiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
         bias: Optional[bool] = True,
         theta_cutoff: Optional[float] = None,
         optimized_kernel: Optional[bool] = True,
+        use_fft_contraction: Optional[bool] = False,
     ):
-        super().__init__(in_channels, out_channels, kernel_shape, basis_type, groups, bias, optimized_kernel)
+        super().__init__(in_channels, out_channels, kernel_shape, basis_type, groups, bias, optimized_kernel, use_fft_contraction)
 
         self.nlat_in, self.nlon_in = in_shape
         self.nlat_out, self.nlon_out = out_shape
@@ -630,8 +643,17 @@ class DiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
         self.register_buffer("psi_col_idx", col_idx, persistent=False)
         self.register_buffer("psi_vals", vals, persistent=False)
 
-        # also store psi just in case
-        if not self.optimized_kernel:
+        if self.use_fft_contraction:
+            # precompute FFT of semi-transposed dense psi for FFT-based transpose contraction
+            psi_st = _get_psi(self.kernel_size, self.psi_idx, self.psi_vals, self.nlat_in, self.nlon_in, self.nlat_out, self.nlon_out, semi_transposed=True)
+            # psi_st: (K, nlat_out, nlat_in * nlon_out) -> dense (K, nlat_out, nlat_in, nlon_out)
+            from ._disco_utils import _densify_psi
+            psi_st_dense = _densify_psi(psi_st, self.nlat_in, self.nlon_out)
+            # Store conjugate FFT for cross-correlation
+            psi_st_fft_conj = torch.fft.rfft(psi_st_dense, dim=-1).conj()
+            self.register_buffer("psi_st_fft_conj", psi_st_fft_conj, persistent=False)
+        elif not self.optimized_kernel:
+            # also store psi just in case
             self.psi_st = _get_psi(self.kernel_size, self.psi_idx, self.psi_vals, self.nlat_in, self.nlon_in, self.nlat_out, self.nlon_out, semi_transposed=True)
 
     def extra_repr(self):
@@ -651,7 +673,9 @@ class DiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
         x = torch.einsum("bgcxy,gock->bgokxy", x, self.weight.reshape(self.groups, -1, self.weight.shape[1], self.weight.shape[2])).contiguous()
         x = x.reshape(B, -1, x.shape[-3], H, W)
 
-        if self.optimized_kernel:
+        if self.use_fft_contraction:
+            out = _disco_s2_transpose_contraction_fft(x, self.psi_st_fft_conj.to(x.device), self.nlon_out)
+        elif self.optimized_kernel:
             out = _disco_s2_transpose_contraction_optimized(
                 x, self.psi_roff_idx, self.psi_ker_idx, self.psi_row_idx, self.psi_col_idx, self.psi_vals, self.kernel_size, self.nlat_out, self.nlon_out
             )

--- a/torch_harmonics/disco/convolution.py
+++ b/torch_harmonics/disco/convolution.py
@@ -41,7 +41,7 @@ from torch_harmonics.cache import lru_cache
 from torch_harmonics.quadrature import precompute_latitudes, precompute_longitudes
 from ._disco_utils import _get_psi, _disco_s2_contraction_torch, _disco_s2_transpose_contraction_torch
 from ._disco_utils import _disco_s2_contraction_fft, _disco_s2_transpose_contraction_fft
-from ._disco_utils import _precompute_psi_fft_conj
+from ._disco_utils import _precompute_psi_banded
 from ._disco_utils import _disco_s2_contraction_optimized, _disco_s2_transpose_contraction_optimized
 from torch_harmonics.filter_basis import FilterBasis, get_filter_basis
 from disco_helpers import optimized_kernels_is_available, preprocess_psi
@@ -496,10 +496,11 @@ class DiscreteContinuousConvS2(DiscreteContinuousConv):
         self.register_buffer("psi_vals", vals, persistent=False)
 
         if self.use_fft_contraction:
-            # precompute FFT of densified psi for FFT-based contraction
+            # precompute banded FFT of psi for FFT-based contraction
             psi_sparse = _get_psi(self.kernel_size, self.psi_idx, self.psi_vals, self.nlat_in, self.nlon_in, self.nlat_out, self.nlon_out)
-            psi_fft_conj = _precompute_psi_fft_conj(psi_sparse, self.nlat_in, self.nlon_in)
+            psi_fft_conj, gather_idx = _precompute_psi_banded(psi_sparse, self.nlat_in, self.nlon_in)
             self.register_buffer("psi_fft_conj", psi_fft_conj, persistent=False)
+            self.register_buffer("psi_gather_idx", gather_idx, persistent=False)
         elif not self.optimized_kernel:
             # also store psi as COO matrix just in case for torch input
             self.psi = _get_psi(self.kernel_size, self.psi_idx, self.psi_vals, self.nlat_in, self.nlon_in, self.nlat_out, self.nlon_out)
@@ -514,7 +515,7 @@ class DiscreteContinuousConvS2(DiscreteContinuousConv):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
 
         if self.use_fft_contraction:
-            x = _disco_s2_contraction_fft(x, self.psi_fft_conj.to(x.device), self.nlon_out)
+            x = _disco_s2_contraction_fft(x, self.psi_fft_conj.to(x.device), self.psi_gather_idx.to(x.device), self.nlon_out)
         elif self.optimized_kernel:
             x = _disco_s2_contraction_optimized(
                 x, self.psi_roff_idx, self.psi_ker_idx, self.psi_row_idx, self.psi_col_idx, self.psi_vals, self.kernel_size, self.nlat_out, self.nlon_out
@@ -644,14 +645,11 @@ class DiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
         self.register_buffer("psi_vals", vals, persistent=False)
 
         if self.use_fft_contraction:
-            # precompute FFT of semi-transposed dense psi for FFT-based transpose contraction
+            # precompute banded FFT of semi-transposed psi for FFT-based transpose contraction
             psi_st = _get_psi(self.kernel_size, self.psi_idx, self.psi_vals, self.nlat_in, self.nlon_in, self.nlat_out, self.nlon_out, semi_transposed=True)
-            # psi_st: (K, nlat_out, nlat_in * nlon_out) -> dense (K, nlat_out, nlat_in, nlon_out)
-            from ._disco_utils import _densify_psi
-            psi_st_dense = _densify_psi(psi_st, self.nlat_in, self.nlon_out)
-            # Store conjugate FFT for cross-correlation
-            psi_st_fft_conj = torch.fft.rfft(psi_st_dense, dim=-1).conj()
+            psi_st_fft_conj, psi_st_gather_idx = _precompute_psi_banded(psi_st, self.nlat_in, self.nlon_out)
             self.register_buffer("psi_st_fft_conj", psi_st_fft_conj, persistent=False)
+            self.register_buffer("psi_st_gather_idx", psi_st_gather_idx, persistent=False)
         elif not self.optimized_kernel:
             # also store psi just in case
             self.psi_st = _get_psi(self.kernel_size, self.psi_idx, self.psi_vals, self.nlat_in, self.nlon_in, self.nlat_out, self.nlon_out, semi_transposed=True)
@@ -674,7 +672,7 @@ class DiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
         x = x.reshape(B, -1, x.shape[-3], H, W)
 
         if self.use_fft_contraction:
-            out = _disco_s2_transpose_contraction_fft(x, self.psi_st_fft_conj.to(x.device), self.nlon_out)
+            out = _disco_s2_transpose_contraction_fft(x, self.psi_st_fft_conj.to(x.device), self.psi_st_gather_idx.to(x.device), self.nlon_out)
         elif self.optimized_kernel:
             out = _disco_s2_transpose_contraction_optimized(
                 x, self.psi_roff_idx, self.psi_ker_idx, self.psi_row_idx, self.psi_col_idx, self.psi_vals, self.kernel_size, self.nlat_out, self.nlon_out

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -36,6 +36,8 @@ import torch
 
 from torch_harmonics.disco._disco_utils import _get_psi, _disco_s2_contraction_torch, _disco_s2_transpose_contraction_torch
 from torch_harmonics.disco._disco_utils import _disco_s2_contraction_optimized, _disco_s2_transpose_contraction_optimized
+from torch_harmonics.disco._disco_utils import _disco_s2_contraction_fft, _disco_s2_transpose_contraction_fft
+from torch_harmonics.disco._disco_utils import _precompute_psi_banded
 from disco_helpers import optimized_kernels_is_available, preprocess_psi
 from torch_harmonics.disco.convolution import (
     _precompute_convolution_tensor_s2,
@@ -138,6 +140,8 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
         Whether to use bias
     theta_cutoff: Optional[float]
         Theta cutoff for the filter basis
+    use_fft_contraction: Optional[bool]
+        Whether to use FFT-based contraction
 
     Returns
     -------
@@ -164,8 +168,9 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
         bias: Optional[bool] = True,
         theta_cutoff: Optional[float] = None,
         optimized_kernel: Optional[bool] = True,
+        use_fft_contraction: Optional[bool] = False,
     ):
-        super().__init__(in_channels, out_channels, kernel_shape, basis_type, groups, bias, optimized_kernel)
+        super().__init__(in_channels, out_channels, kernel_shape, basis_type, groups, bias, optimized_kernel, use_fft_contraction)
 
         self.nlat_in, self.nlon_in = in_shape
         self.nlat_out, self.nlon_out = out_shape
@@ -232,8 +237,13 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
         self.register_buffer("psi_col_idx", col_idx, persistent=False)
         self.register_buffer("psi_vals", vals, persistent=False)
 
-        # store psi jic:
-        if not self.optimized_kernel:
+        # store psi for the appropriate contraction mode
+        if self.use_fft_contraction:
+            psi_sparse = _get_psi(self.kernel_size, self.psi_idx, self.psi_vals, self.nlat_in, self.nlon_in, self.nlat_out, self.nlon_out, self.nlat_in_local, self.nlat_out_local)
+            psi_fft_conj, gather_idx = _precompute_psi_banded(psi_sparse, self.nlat_in_local, self.nlon_in)
+            self.register_buffer("psi_fft_conj", psi_fft_conj, persistent=False)
+            self.register_buffer("psi_gather_idx", gather_idx, persistent=False)
+        elif not self.optimized_kernel:
             self.psi = _get_psi(self.kernel_size, self.psi_idx, self.psi_vals, self.nlat_in, self.nlon_in, self.nlat_out, self.nlon_out, self.nlat_in_local, self.nlat_out_local)
 
     def extra_repr(self):
@@ -252,7 +262,9 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
         if self.comm_size_azimuth > 1:
             x = distributed_transpose_azimuth(x, (1, -1), self.lon_in_shapes)
 
-        if self.optimized_kernel:
+        if self.use_fft_contraction:
+            x = _disco_s2_contraction_fft(x, self.psi_fft_conj.to(x.device), self.psi_gather_idx.to(x.device), self.nlon_out)
+        elif self.optimized_kernel:
             x = _disco_s2_contraction_optimized(
                 x, self.psi_roff_idx, self.psi_ker_idx, self.psi_row_idx, self.psi_col_idx, self.psi_vals, self.kernel_size, self.nlat_out_local, self.nlon_out
             )
@@ -312,6 +324,8 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
         Whether to use bias
     theta_cutoff: Optional[float]
         Theta cutoff for the filter basis
+    use_fft_contraction: Optional[bool]
+        Whether to use FFT-based contraction
 
     Returns
     -------
@@ -340,8 +354,9 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
         bias: Optional[bool] = True,
         theta_cutoff: Optional[float] = None,
         optimized_kernel: Optional[bool] = True,
+        use_fft_contraction: Optional[bool] = False,
     ):
-        super().__init__(in_channels, out_channels, kernel_shape, basis_type, groups, bias, optimized_kernel)
+        super().__init__(in_channels, out_channels, kernel_shape, basis_type, groups, bias, optimized_kernel, use_fft_contraction)
 
         self.nlat_in, self.nlon_in = in_shape
         self.nlat_out, self.nlon_out = out_shape
@@ -411,8 +426,13 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
         self.register_buffer("psi_col_idx", col_idx, persistent=False)
         self.register_buffer("psi_vals", vals, persistent=False)
 
-        # store psi as COO
-        if not self.optimized_kernel:
+        # store psi for the appropriate contraction mode
+        if self.use_fft_contraction:
+            psi_st = _get_psi(self.kernel_size, self.psi_idx, self.psi_vals, self.nlat_in, self.nlon_in, self.nlat_out, self.nlon_out, self.nlat_in_local, self.nlat_out_local, semi_transposed=True)
+            psi_st_fft_conj, psi_st_gather_idx = _precompute_psi_banded(psi_st, self.nlat_in, self.nlon_out)
+            self.register_buffer("psi_st_fft_conj", psi_st_fft_conj, persistent=False)
+            self.register_buffer("psi_st_gather_idx", psi_st_gather_idx, persistent=False)
+        elif not self.optimized_kernel:
             self.psi_st = _get_psi(self.kernel_size, self.psi_idx, self.psi_vals, self.nlat_in, self.nlon_in, self.nlat_out, self.nlon_out, self.nlat_in_local, self.nlat_out_local, semi_transposed=True)
 
     def extra_repr(self):
@@ -441,7 +461,9 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
         x = gather_from_polar_region(x, -2, self.lat_in_shapes)
         x = copy_to_polar_region(x)
 
-        if self.optimized_kernel:
+        if self.use_fft_contraction:
+            out = _disco_s2_transpose_contraction_fft(x, self.psi_st_fft_conj.to(x.device), self.psi_st_gather_idx.to(x.device), self.nlon_out)
+        elif self.optimized_kernel:
             out = _disco_s2_transpose_contraction_optimized(
                 x, self.psi_roff_idx, self.psi_ker_idx, self.psi_row_idx, self.psi_col_idx, self.psi_vals, self.kernel_size, self.nlat_out_local, self.nlon_out
             )


### PR DESCRIPTION
## Summary
  - Replace the loop-and-roll longitude correlation in DISCO S2 convolutions with FFT-based circular cross-correlation, enabled via use_fft_contraction=True on DiscreteContinuousConvS2 and DiscreteContinuousConvTransposeS2
  - Add a benchmark framework (torch_harmonics.benchmark) with a registry pattern, CUDA event timing, hardware-dependent batch size scaling, and a CLI runner (python -m torch_harmonics.benchmark)
  - Register benchmarks for RealSHT, InverseRealSHT, and DISCO convolutions (both torch sparse and FFT paths)

## Benchmark results (Tesla T4)

```
  ┌─────────────────────────────────┬───────────────┐
  │            Benchmark            │ Avg time (ms) │
  ├─────────────────────────────────┼───────────────┤
  │ disco_conv_s2_torch_1deg (B=16) │ ~97           │
  ├─────────────────────────────────┼───────────────┤
  │ disco_conv_s2_cuda_1deg (B=64)  │ ~24           │
  ├─────────────────────────────────┼───────────────┤
  │ disco_conv_s2_fft_1deg (B=64)   │ ~29           │
  └─────────────────────────────────┴───────────────┘
```

These results correspond to a 13.4x speed-up of the per-sample time. At equal batch size (B=16), the FFT path is ~10x faster than the torch sparse path (lower because the T4 has lower utilization for the FFT path). With this optimization, the torch-only timings are in the ballpark of the optimized CUDA timings, at least for this T4 GPU at 1-degree resolution.

## Test plan

  - pytest tests/test_fft_contraction.py — verifies FFT and torch paths produce assert_close-compatible results for forward, transpose, and gradients across multiple grid/basis/stride configurations
  - python -m torch_harmonics.benchmark — runs all registered benchmarks and saves JSON results