### PR TITLE
Fixing Downsampling in Attention

### DIFF
--- a/Dockerfile.examples
+++ b/Dockerfile.examples
@@ -58,4 +58,4 @@ COPY . /workspace/torch_harmonics
 ENV FORCE_CUDA_EXTENSION=1
 ENV TORCH_HARMONICS_ENABLE_OPENMP=1
 ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 9.0 10.0+PTX"
-RUN cd /workspace/torch_harmonics && pip install --no-build-isolation .
+RUN cd /workspace/torch_harmonics && pip install --no-deps --no-build-isolation .

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -102,7 +102,6 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
             [4, 4, 8, 4, (6, 12), (6, 12), "equiangular", "equiangular", True, 1e-5, 1e-3],
             [4, 8, 4, 4, (6, 12), (6, 12), "equiangular", "equiangular", True, 1e-5, 1e-3],
             [4, 8, 4, 4, (12, 24), (6, 12), "equiangular", "equiangular", True, 1e-5, 1e-3],
-            [4, 8, 4, 4, (6, 12), (12, 24), "equiangular", "equiangular", True, 1e-5, 1e-3],
             [4, 1, 1, 1, (2, 4), (2, 4), "equiangular", "equiangular", True, 1e-5, 1e-3],
             [4, 1, 4, 1, (2, 4), (2, 4), "equiangular", "equiangular", True, 1e-5, 1e-3],
             [4, 4, 4, 4, (6, 12), (6, 12), "legendre-gauss", "legendre-gauss", True, 1e-5, 1e-3],

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -79,12 +79,22 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
             [4, 4, 4, 4, (6, 12), (6, 12), "equiangular", "equiangular", False, 1e-5, 1e-3],
             [4, 4, 8, 4, (6, 12), (6, 12), "equiangular", "equiangular", False, 1e-5, 1e-3],
             [4, 8, 4, 4, (6, 12), (6, 12), "equiangular", "equiangular", False, 1e-5, 1e-3],
-            [4, 8, 4, 4, (12, 24), (6, 12), "equiangular", "equiangular", False, 1e-5, 1e-3],
-            [4, 8, 4, 4, (6, 12), (12, 24), "equiangular", "equiangular", False, 1e-5, 1e-3],
             [4, 1, 1, 1, (2, 4), (2, 4), "equiangular", "equiangular", False, 1e-5, 1e-3],
             [4, 1, 4, 1, (2, 4), (2, 4), "equiangular", "equiangular", False, 1e-5, 1e-3],
             [4, 4, 4, 4, (6, 12), (6, 12), "legendre-gauss", "legendre-gauss", False, 1e-5, 1e-3],
             [4, 4, 4, 1, (6, 12), (6, 12), "lobatto", "lobatto", False, 1e-5, 1e-3],
+            # downsampling: nlon_in must be an integer multiple of nlon_out (pscale = nlon_in / nlon_out)
+            [4, 8, 4, 4, (12, 24), (6, 12), "equiangular",    "equiangular",    False, 1e-5, 1e-3],  # lat 2x, lon 2x (pscale=2)
+            [4, 4, 4, 1, (6, 12),  (6, 6),  "equiangular",    "equiangular",    False, 1e-5, 1e-3],  # lon-only, pscale=2
+            [4, 4, 4, 1, (12, 24), (6, 8),  "equiangular",    "equiangular",    False, 1e-5, 1e-3],  # pscale=3
+            [4, 4, 4, 1, (12, 24), (3, 6),  "equiangular",    "equiangular",    False, 1e-5, 1e-3],  # pscale=4
+            [4, 4, 4, 1, (12, 12), (6, 12), "equiangular",    "equiangular",    False, 1e-5, 1e-3],  # lat-only, pscale=1
+            [4, 4, 4, 1, (12, 24), (6, 12), "legendre-gauss", "legendre-gauss", False, 1e-5, 1e-3],  # LG grid, pscale=2
+            # odd latitude sizes
+            [4, 4, 4, 1, (7, 12),  (5, 6),  "equiangular",    "equiangular",    False, 1e-5, 1e-3],  # odd-odd lat, pscale=2
+            [4, 4, 4, 1, (9, 12),  (5, 4),  "equiangular",    "equiangular",    False, 1e-5, 1e-3],  # odd-odd lat, pscale=3
+            [4, 4, 4, 1, (11, 24), (7, 12), "equiangular",    "equiangular",    False, 1e-5, 1e-3],  # odd-odd lat, pscale=2
+            [4, 4, 4, 1, (12, 24), (11, 24),"equiangular",    "equiangular",    False, 1e-5, 1e-3],  # odd nlat_out only, pscale=1  
             # same cases with QK norm enabled
             [4, 4, 4, 1, (6, 12), (6, 12), "equiangular", "equiangular", True, 1e-5, 1e-3],
             [4, 4, 4, 2, (6, 12), (6, 12), "equiangular", "equiangular", True, 1e-5, 1e-3],
@@ -97,6 +107,18 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
             [4, 1, 4, 1, (2, 4), (2, 4), "equiangular", "equiangular", True, 1e-5, 1e-3],
             [4, 4, 4, 4, (6, 12), (6, 12), "legendre-gauss", "legendre-gauss", True, 1e-5, 1e-3],
             [4, 4, 4, 1, (6, 12), (6, 12), "lobatto", "lobatto", True, 1e-5, 1e-3],
+            # downsampling: nlon_in must be an integer multiple of nlon_out (pscale = nlon_in / nlon_out)
+            [4, 8, 4, 4, (12, 24), (6, 12), "equiangular",    "equiangular",    True, 1e-5, 1e-3],  # lat 2x, lon 2x (pscale=2)
+            [4, 4, 4, 1, (6, 12),  (6, 6),  "equiangular",    "equiangular",    True, 1e-5, 1e-3],  # lon-only, pscale=2
+            [4, 4, 4, 1, (12, 24), (6, 8),  "equiangular",    "equiangular",    True, 1e-5, 1e-3],  # pscale=3
+            [4, 4, 4, 1, (12, 24), (3, 6),  "equiangular",    "equiangular",    True, 1e-5, 1e-3],  # pscale=4
+            [4, 4, 4, 1, (12, 12), (6, 12), "equiangular",    "equiangular",    True, 1e-5, 1e-3],  # lat-only, pscale=1
+            [4, 4, 4, 1, (12, 24), (6, 12), "legendre-gauss", "legendre-gauss", True, 1e-5, 1e-3],  # LG grid, pscale=2
+            # odd latitude sizes
+            [4, 4, 4, 1, (7, 12),  (5, 6),  "equiangular",    "equiangular",    True, 1e-5, 1e-3],  # odd-odd lat, pscale=2
+            [4, 4, 4, 1, (9, 12),  (5, 4),  "equiangular",    "equiangular",    True, 1e-5, 1e-3],  # odd-odd lat, pscale=3
+            [4, 4, 4, 1, (11, 24), (7, 12), "equiangular",    "equiangular",    True, 1e-5, 1e-3],  # odd-odd lat, pscale=2
+            [4, 4, 4, 1, (12, 24), (11, 24),"equiangular",    "equiangular",    True, 1e-5, 1e-3],  # odd nlat_out only, pscale=1    
         ],
         skip_on_empty=True,
     )
@@ -162,7 +184,17 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
     @parameterized.expand(
         [
             # Format: [batch_size, channels, heads, in_shape, out_shape, grid_in, grid_out, atol, rtol]
-            [2, 64, 1, (25, 48), (25, 48), "equiangular", "equiangular", 5e-2, 1e-4],
+            # same shape
+            [2, 64, 1, (25, 48), (25, 48),    "equiangular",    "equiangular",    5e-2, 1e-4],
+            # downsampling: nlon_in must be an integer multiple of nlon_out (pscale = nlon_in / nlon_out)
+            [2, 16, 1, (24, 48), (12, 24),    "equiangular",    "equiangular",    5e-2, 1e-4],  # lat 2x, lon 2x (pscale=2)
+            [2, 16, 1, (12, 24), (12, 12),    "equiangular",    "equiangular",    5e-2, 1e-4],  # lon-only, pscale=2
+            [2, 16, 1, (12, 24), (6, 8),      "equiangular",    "equiangular",    5e-2, 1e-4],  # pscale=3
+            [2, 16, 1, (24, 48), (6, 12),     "equiangular",    "equiangular",    5e-2, 1e-4],  # pscale=4
+            [2, 16, 1, (24, 48), (12, 24),    "legendre-gauss", "legendre-gauss", 5e-2, 1e-4],  # LG grid, pscale=2
+            # odd latitude sizes
+            [2, 16, 1, (11, 24), (7, 12),     "equiangular",    "equiangular",    5e-2, 1e-4],  # odd-odd lat, pscale=2
+            [2, 16, 1, (13, 24), (9, 8),      "equiangular",    "equiangular",    5e-2, 1e-4],  # odd-odd lat, pscale=3
         ],
         skip_on_empty=True,
     )
@@ -188,14 +220,16 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
         }
         inputs_device = {k: v.detach().clone().to(self.device).requires_grad_() for k, v in inputs_host.items()}
 
-        # reference input and model
+        # reference input and model (use default local theta_cutoff so the test is sensitive
+        # to the (wi + pscale*wo) % nlon_in shift; a global cutoff makes every input a neighbor
+        # of every output and collapses the shift to a permutation the result is invariant to)
         att_host = NeighborhoodAttentionS2(
-            in_channels=channels, num_heads=heads, in_shape=in_shape, out_shape=out_shape, grid_in=grid_in, grid_out=grid_out, bias=True, theta_cutoff=2 * torch.pi
+            in_channels=channels, num_heads=heads, in_shape=in_shape, out_shape=out_shape, grid_in=grid_in, grid_out=grid_out, bias=True
         )
 
         # Device model and inputs
         att_device = NeighborhoodAttentionS2(
-            in_channels=channels, num_heads=heads, in_shape=in_shape, out_shape=out_shape, grid_in=grid_in, grid_out=grid_out, bias=True, theta_cutoff=2 * torch.pi
+            in_channels=channels, num_heads=heads, in_shape=in_shape, out_shape=out_shape, grid_in=grid_in, grid_out=grid_out, bias=True
         ).to(self.device)
 
         # Synchronize parameters of model
@@ -239,7 +273,17 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
         skip_on_empty=True,
     )
     def test_neighborhood_global_equivalence(self, batch_size, channels, channels_out, heads, in_shape, out_shape, grid_in, grid_out, atol, rtol, verbose=False):
-        """Tests numerical equivalence between the global spherical attention module and the neighborhood spherical attention module with the neighborhood set ot the whole sphere"""
+        """Tests that NeighborhoodAttentionS2 reduces to the global AttentionS2 when its neighborhood covers the whole sphere.
+
+        Passing ``theta_cutoff = 2 * pi`` forces every input point into the support of every output point,
+        so the sparse psi mechanism in NeighborhoodAttentionS2 becomes mathematically identical to the dense
+        softmax(Q Kt) V computation in AttentionS2 (with the same quadrature weights applied).
+
+        Cases are restricted to ``in_shape == out_shape`` because the neighborhood kernel advances the input
+        column index by ``pscale * wo`` where ``pscale = nlon_in / nlon_out``; only when the two grids match
+        does that shift reproduce the translation-invariant behavior of the global attention. With
+        downsampling the shift maps multiple outputs to the same input column set, and the two modules are
+        not expected to agree numerically."""
 
         if (self.device.type == "cuda") and (not cuda_kernels_is_available()):
             raise unittest.SkipTest("skipping test because CUDA kernels are not available")

--- a/torch_harmonics/attention/_attention_utils.py
+++ b/torch_harmonics/attention/_attention_utils.py
@@ -162,13 +162,16 @@ def _neighborhood_s2_attention_fwd_torch(kx: torch.Tensor, vx: torch.Tensor, qy:
                                          quad_weights: torch.Tensor, col_idx: torch.Tensor, row_off: torch.Tensor,
                                          nlon_in: int, nlat_out: int, nlon_out: int) -> torch.Tensor:
 
+    # one output lon step corresponds to pscale input lon steps; require an integer ratio
+    assert nlon_in % nlon_out == 0, f"nlon_in ({nlon_in}) must be an integer multiple of nlon_out ({nlon_out})"
+    pscale = nlon_in // nlon_out
 
     # prepare result tensor
     out_shape = (qy.shape[0], vx.shape[1], nlat_out, nlon_out)
     y = torch.zeros(out_shape, dtype=qy.dtype, device=qy.device)
 
     for ho in range(nlat_out):
-        
+
 	    # get number of nonzeros
         zstart = row_off[ho]
         zend = row_off[ho+1]
@@ -185,7 +188,7 @@ def _neighborhood_s2_attention_fwd_torch(kx: torch.Tensor, vx: torch.Tensor, qy:
                 hi = nz_col_idx // nlon_in
                 # account for output shift and ensure positive index due to circular condition
                 wi = nz_col_idx % nlon_in
-                wip = (wi + wo) % nlon_in
+                wip = (wi + pscale * wo) % nlon_in
 
                 # compute correlation & softmax numerator
                 q_ho_wo = qy[:, :, ho, wo]
@@ -223,6 +226,9 @@ def _neighborhood_s2_attention_bwd_dv_torch(kx: torch.Tensor, vx: torch.Tensor, 
     # output
     # dvx: B, Cout, Hi, Wi
 
+    assert nlon_in % nlon_out == 0, f"nlon_in ({nlon_in}) must be an integer multiple of nlon_out ({nlon_out})"
+    pscale = nlon_in // nlon_out
+
     dvx = torch.zeros_like(vx)
     batch_size = dy.shape[0]
 
@@ -244,7 +250,7 @@ def _neighborhood_s2_attention_bwd_dv_torch(kx: torch.Tensor, vx: torch.Tensor, 
                 hi = nz_col_idx // nlon_in
                 # account for output shift and ensure positive index due to circular condition
                 wi = nz_col_idx % nlon_in
-                wip = (wi+wo) % nlon_in
+                wip = (wi + pscale * wo) % nlon_in
 
                 # compute correlation & softmax numerator
                 q_ho_wo = qy[:, :, ho, wo]
@@ -260,7 +266,7 @@ def _neighborhood_s2_attention_bwd_dv_torch(kx: torch.Tensor, vx: torch.Tensor, 
                 hi = nz_col_idx // nlon_in
                 # account for output shift and ensure positive index due to circular condition
                 wi = nz_col_idx % nlon_in
-                wip = (wi+wo) % nlon_in
+                wip = (wi + pscale * wo) % nlon_in
                 alpha_nz[:,idz-zstart] = torch.exp(qdotk_nz[:,idz-zstart] - qdotk_max) * quad_weights[hi]
                 alpha_sum[:] += alpha_nz[:,idz-zstart]
 
@@ -271,7 +277,7 @@ def _neighborhood_s2_attention_bwd_dv_torch(kx: torch.Tensor, vx: torch.Tensor, 
                 hi = nz_col_idx // nlon_in
                 # account for output shift and ensure positive index due to circular condition
                 wi = nz_col_idx % nlon_in
-                wip = (wi+wo) % nlon_in
+                wip = (wi + pscale * wo) % nlon_in
                 dvx[:,:,hi, wip] += (alpha_nz[:, None, idz-zstart] / alpha_sum[:, None]) * dy[:,:,ho,wo]
 
     return dvx
@@ -291,6 +297,9 @@ def _neighborhood_s2_attention_bwd_dk_torch(kx: torch.Tensor, vx: torch.Tensor, 
     # quad_weights: Hi
     # output
     # dkx: B, C, Hi, Wi
+
+    assert nlon_in % nlon_out == 0, f"nlon_in ({nlon_in}) must be an integer multiple of nlon_out ({nlon_out})"
+    pscale = nlon_in // nlon_out
 
     dkx = torch.zeros_like(kx)
     batch_size = dy.shape[0]
@@ -314,7 +323,7 @@ def _neighborhood_s2_attention_bwd_dk_torch(kx: torch.Tensor, vx: torch.Tensor, 
                 hj = nz_col_idx // nlon_in
                 # account for output shift and ensure positive index due to circular condition
                 wj = nz_col_idx % nlon_in
-                wjp = (wj+wo) % nlon_in
+                wjp = (wj + pscale * wo) % nlon_in
 
                 # compute correlation & softmax numerator
                 q_ho_wo = qy[:, :, ho, wo]
@@ -330,7 +339,7 @@ def _neighborhood_s2_attention_bwd_dk_torch(kx: torch.Tensor, vx: torch.Tensor, 
                 hj = nz_col_idx // nlon_in
                 # account for output shift and ensure positive index due to circular condition
                 wj = nz_col_idx % nlon_in
-                wjp = (wj+wo) % nlon_in
+                wjp = (wj + pscale * wo) % nlon_in
 
                 alpha[:, idz-zstart] = torch.exp(qdotk_nz[:,idz-zstart] - qdotk_max) * quad_weights[hj]
                 alpha_sum[:] += alpha[:, idz-zstart]
@@ -350,7 +359,7 @@ def _neighborhood_s2_attention_bwd_dk_torch(kx: torch.Tensor, vx: torch.Tensor, 
                 hi = nz_col_idx // nlon_in
                 # account for output shift and ensure positive index due to circular condition
                 wi = nz_col_idx % nlon_in
-                wip = (wi+wo) % nlon_in
+                wip = (wi + pscale * wo) % nlon_in
 
                 # compute correlation & softmax numerator
                 gdotv = torch.sum(dy[:,:,ho, wo] * vx[:,:,hi, wip], dim=1)
@@ -373,6 +382,9 @@ def _neighborhood_s2_attention_bwd_dq_torch(kx: torch.Tensor, vx: torch.Tensor, 
     # quad_weights: Hi
     # output
     # dq: B, C, Ho, Wo
+
+    assert nlon_in % nlon_out == 0, f"nlon_in ({nlon_in}) must be an integer multiple of nlon_out ({nlon_out})"
+    pscale = nlon_in // nlon_out
 
     batch_size = dy.shape[0]
     channels_in = kx.shape[1]
@@ -402,7 +414,7 @@ def _neighborhood_s2_attention_bwd_dq_torch(kx: torch.Tensor, vx: torch.Tensor, 
                 hi = nz_col_idx // nlon_in
                 # account for output shift and ensure positive index due to circular condition
                 wi = nz_col_idx % nlon_in
-                wip = (wi+wo) % nlon_in
+                wip = (wi + pscale * wo) % nlon_in
 
                 idz_i = idz-zstart
 
@@ -420,7 +432,7 @@ def _neighborhood_s2_attention_bwd_dq_torch(kx: torch.Tensor, vx: torch.Tensor, 
                 hi = nz_col_idx // nlon_in
                 # account for output shift and ensure positive index due to circular condition
                 wi = nz_col_idx % nlon_in
-                wip = (wi+wo) % nlon_in
+                wip = (wi + pscale * wo) % nlon_in
 
                 q_ho_wo = qy[:, :, ho, wo]
                 k_hi_wi = kx[:, :, hi, wip]

--- a/torch_harmonics/attention/attention.py
+++ b/torch_harmonics/attention/attention.py
@@ -97,6 +97,9 @@ class AttentionS2(nn.Module):
         self.nlat_in, self.nlon_in = in_shape
         self.nlat_out, self.nlon_out = out_shape
 
+        assert self.nlon_in % self.nlon_out == 0, \
+            f"nlon_in ({self.nlon_in}) must be an integer multiple of nlon_out ({self.nlon_out}) for the attention p-shift to be exact"
+
         self.in_channels = in_channels
         self.num_heads = num_heads
         self.k_channels = in_channels if k_channels is None else k_channels
@@ -265,6 +268,9 @@ class NeighborhoodAttentionS2(nn.Module):
 
         self.nlat_in, self.nlon_in = in_shape
         self.nlat_out, self.nlon_out = out_shape
+
+        assert self.nlon_in % self.nlon_out == 0, \
+            f"nlon_in ({self.nlon_in}) must be an integer multiple of nlon_out ({self.nlon_out}) for the attention p-shift to be exact"
 
         self.in_channels = in_channels
         self.num_heads = num_heads

--- a/torch_harmonics/attention/csrc/attention_cpu.h
+++ b/torch_harmonics/attention/csrc/attention_cpu.h
@@ -50,6 +50,9 @@ namespace attention_kernels {
         const int64_t nlon_in, const int64_t nlat_out, const int64_t nlon_out,
         const int64_t batch_size, const int64_t nchannels_in, const int64_t nchannels_out) {
 
+        // one output lon step corresponds to pscale input lon steps (requires nlon_in % nlon_out == 0)
+        const int64_t pscale = nlon_in / nlon_out;
+
         // some parameters
         const int64_t block_wo = CACHE_BLOCK_SIZE;
         const int64_t nblock_wo = static_cast<int64_t>((nlon_out + block_wo - 1) / block_wo);
@@ -90,7 +93,7 @@ namespace attention_kernels {
                                 
                             // loop over wo block
                             for (int64_t wo = wo_start; wo < wo_end; wo++) {
-                                int64_t wip = (wi + wo) % nlon_in;
+                                int64_t wip = (wi + pscale * wo) % nlon_in;
     
                                 float qdotk = 0.0;
                                 //#pragma omp simd reduction(+:qdotk)
@@ -138,6 +141,9 @@ namespace attention_kernels {
         const int64_t nlon_in, const int64_t nlat_out, const int64_t nlon_out,
         const int64_t batch_size, const int64_t nchannels_in, const int64_t nchannels_out) {
 
+        // one output lon step corresponds to pscale input lon steps (requires nlon_in % nlon_out == 0)
+        const int64_t pscale = nlon_in / nlon_out;
+
         // compute dqy and dkx
         #pragma omp parallel for collapse(2)
         for (int64_t b = 0; b < batch_size; b++) {
@@ -171,7 +177,7 @@ namespace attention_kernels {
                             int64_t hi = static_cast<int64_t>(nz_col_idx / nlon_in);
                             // account for output shift and ensure positive index due to circular condition
                             int64_t wi = nz_col_idx % nlon_in;
-                            int64_t wip = (wi+wo) % nlon_in;
+                            int64_t wip = (wi + pscale * wo) % nlon_in;
         
                             // compute correlation & softmax numerator
                             qdotk_nz[idz-zstart] = 0.0;
@@ -220,7 +226,7 @@ namespace attention_kernels {
                             int64_t hi = static_cast<int64_t>(nz_col_idx / nlon_in);
                             // account for output shift and ensure positive index due to circular condition
                             int64_t wi = nz_col_idx % nlon_in;
-                            int64_t wip = (wi+wo) % nlon_in;
+                            int64_t wip = (wi + pscale * wo) % nlon_in;
         
                             // dkx: alpha normalization
                             float alpha_norm = std::exp(qdotk_nz[idz-zstart] - qdotk_max) * quad_weights_arr[hi] / alpha_sum;
@@ -265,7 +271,7 @@ namespace attention_kernels {
                             int64_t hi = static_cast<int64_t>(nz_col_idx / nlon_in);
                             // account for output shift and ensure positive index due to circular condition
                             int64_t wi = nz_col_idx % nlon_in;
-                            int64_t wip = (wi+wo) % nlon_in;
+                            int64_t wip = (wi + pscale * wo) % nlon_in;
         
                             // compute correlation & softmax numerator
                             qdotk_nz[idz-zstart] = 0.0;
@@ -292,7 +298,7 @@ namespace attention_kernels {
                             int64_t hi = static_cast<int64_t>(nz_col_idx / nlon_in);
                             // account for output shift and ensure positive index due to circular condition
                             int64_t wi = nz_col_idx % nlon_in;
-                            int64_t wip = (wi+wo) % nlon_in;
+                            int64_t wip = (wi + pscale * wo) % nlon_in;
         
                             // recompute alpha
                             float alpha_norm = std::exp(qdotk_nz[idz-zstart] - qdotk_max) * quad_weights_arr[hi] / alpha_sum;

--- a/torch_harmonics/attention/csrc/attention_cpu_bwd.cpp
+++ b/torch_harmonics/attention/csrc/attention_cpu_bwd.cpp
@@ -58,6 +58,9 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> s2_attention_bwd_cpu(tor
     CHECK_CPU_INPUT_TENSOR(col_idx);
     CHECK_CPU_INPUT_TENSOR(row_off);
 
+    TORCH_CHECK(nlon_in % nlon_out == 0,
+                "nlon_in (", nlon_in, ") must be an integer multiple of nlon_out (", nlon_out, ")");
+
     // change to channels first:
     bool kx_is_channels_last = kx.strides()[1] == 1;
     bool vx_is_channels_last = vx.strides()[1] == 1;

--- a/torch_harmonics/attention/csrc/attention_cpu_fwd.cpp
+++ b/torch_harmonics/attention/csrc/attention_cpu_fwd.cpp
@@ -45,6 +45,9 @@ namespace attention_kernels {
         CHECK_CPU_INPUT_TENSOR(col_idx);
         CHECK_CPU_INPUT_TENSOR(row_off);
 
+        TORCH_CHECK(nlon_in % nlon_out == 0,
+                    "nlon_in (", nlon_in, ") must be an integer multiple of nlon_out (", nlon_out, ")");
+
         // change to channels first:
         bool kx_is_channels_last = kx.strides()[1] == 1;
         bool vx_is_channels_last = vx.strides()[1] == 1;

--- a/torch_harmonics/attention/csrc/attention_cuda_bwd.cu
+++ b/torch_harmonics/attention/csrc/attention_cuda_bwd.cu
@@ -105,6 +105,9 @@ void s2_attn_bwd_generic_vec_k(int nchans_in,  // no. of FLOATV_T elements along
     const int wo = wid - (h*nlon_out);
     const int ho = row_idx[h];
 
+    // one output lon step corresponds to pscale input lon steps (requires nlon_in % nlon_out == 0)
+    const int pscale = nlon_in / nlon_out;
+
     // offset input tensors
     kx += int64_t(batch)*nlat_in*nlon_in*nchans_in;
     qy += int64_t(batch)*nlat_out*nlon_out*nchans_in + int64_t(ho)*nlon_out*nchans_in + int64_t(wo)*nchans_in;
@@ -160,7 +163,8 @@ void s2_attn_bwd_generic_vec_k(int nchans_in,  // no. of FLOATV_T elements along
 
         const int hi = col / nlon_in;
         const int wi = col - (hi * nlon_in);
-        const int wip = (wi + wo) - ((wi + wo) / nlon_in) * nlon_in;
+        const int wi_wo = wi + pscale * wo;
+        const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
 
         const FLOATV_T *_kx = kx + int64_t(hi)*nlon_in*nchans_in  + int64_t(wip)*nchans_in;
         const FLOATV_T *_vx = vx + int64_t(hi)*nlon_in*nchans_out + int64_t(wip)*nchans_out;
@@ -216,7 +220,8 @@ void s2_attn_bwd_generic_vec_k(int nchans_in,  // no. of FLOATV_T elements along
         const int64_t col = col_idx[off];
         const int hi = col / nlon_in;
         const int wi = col - (hi * nlon_in);
-        const int wip = (wi + wo) - ((wi + wo) / nlon_in) * nlon_in;
+        const int wi_wo = wi + pscale * wo;
+        const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
 
         const FLOATV_T *_kx = kx + int64_t(hi)*nlon_in*nchans_in  + int64_t(wip)*nchans_in;
         const FLOATV_T *_vx = vx + int64_t(hi)*nlon_in*nchans_out + int64_t(wip)*nchans_out;
@@ -340,6 +345,9 @@ void s2_attn_bwd_special_vec_k(int nchan_in,  // no. of FLOATV_T elements along 
     const int wo = ctaid - (h*nlon_out);
     const int ho = row_idx[h];
 
+    // one output lon step corresponds to pscale input lon steps (requires nlon_in % nlon_out == 0)
+    const int pscale = nlon_in / nlon_out;
+
     // offset input tensors
     kx += int64_t(batch)*nlat_in*nlon_in*nchan_in + tidx;
     qy += int64_t(batch)*nlat_out*nlon_out*nchan_in + int64_t(ho)*nlon_out*nchan_in + int64_t(wo)*nchan_in + tidx;
@@ -414,15 +422,16 @@ void s2_attn_bwd_special_vec_k(int nchan_in,  // no. of FLOATV_T elements along 
 
     const int rlen = rend - rbeg;
 
-    // accumulate alpha_sum, integral, and shared stats, 
+    // accumulate alpha_sum, integral, and shared stats,
     // along with a progressively computed qdotk_max.
     for (int off = 0; off < rlen; off++) {
-        
+
         const int64_t col = col_idx[off];
 
         const int hi = col / nlon_in;
         const int wi = col - (hi * nlon_in);
-        const int wip = (wi + wo) - ((wi + wo) / nlon_in) * nlon_in;
+        const int wi_wo = wi + pscale * wo;
+        const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
 
         const FLOATV_T *_kx = kx + int64_t(hi)*nlon_in*nchan_in  + int64_t(wip)*nchan_in;
         const FLOATV_T *_vx = vx + int64_t(hi)*nlon_in*nchan_out + int64_t(wip)*nchan_out;
@@ -514,7 +523,8 @@ void s2_attn_bwd_special_vec_k(int nchan_in,  // no. of FLOATV_T elements along 
 
         const int hi = col / nlon_in;
         const int wi = col - (hi * nlon_in);
-        const int wip = (wi + wo) - ((wi + wo) / nlon_in) * nlon_in;
+        const int wi_wo = wi + pscale * wo;
+        const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
 
         const FLOATV_T *_kx = kx + int64_t(hi)*nlon_in*nchan_in  + int64_t(wip)*nchan_in;
         const FLOATV_T *_vx = vx + int64_t(hi)*nlon_in*nchan_out + int64_t(wip)*nchan_out;
@@ -858,10 +868,13 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> s2_attention_bwd_dkvq_cuda(at::Te
     CHECK_CUDA_TENSOR(quad_weights);
     CHECK_CUDA_TENSOR(psi_col_idx);
     CHECK_CUDA_TENSOR(psi_row_off);
-    
+
+    TORCH_CHECK(nlon_in % nlon_out == 0,
+                "nlon_in (", nlon_in, ") must be an integer multiple of nlon_out (", nlon_out, ")");
+
     //const size_t uo_num_channels = kx.size(1);
     size_t nchans_in  = qy.size(1); // or kx.size(1)
-    size_t nchans_out = vx.size(1); 
+    size_t nchans_out = vx.size(1);
 
     const int batch_size = kx.size(0);
 

--- a/torch_harmonics/attention/csrc/attention_cuda_fwd.cu
+++ b/torch_harmonics/attention/csrc/attention_cuda_fwd.cu
@@ -86,6 +86,9 @@ void s2_attn_fwd_generic_vec_k(int nchan_in,   // no. of FLOATV_T elements along
     const int wo = wid - (h*nlon_out);
     const int ho = row_idx[h];
 
+    // one output lon step corresponds to pscale input lon steps (requires nlon_in % nlon_out == 0)
+    const int pscale = nlon_in / nlon_out;
+
     for(int chan = tidx; chan < nchan_out; chan += WARP_SIZE) {
         shy[chan] = __vset<FLOATV_T>(0.f);
     }
@@ -112,7 +115,8 @@ void s2_attn_fwd_generic_vec_k(int nchan_in,   // no. of FLOATV_T elements along
 
         const int hi = col / nlon_in;
         const int wi = col - (hi*nlon_in);
-        const int wip = (wi+wo) - ((wi+wo) / nlon_in) * nlon_in;
+        const int wi_wo = wi + pscale*wo;
+        const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
 
         const FLOATV_T *_kx = kx + int64_t(hi)*nlon_in*nchan_in  + int64_t(wip)*nchan_in;
         const FLOATV_T *_vx = vx + int64_t(hi)*nlon_in*nchan_out + int64_t(wip)*nchan_out;
@@ -203,6 +207,9 @@ void s2_attn_fwd_special_vec_k(int nchan_in,  // no. of FLOATV_T elements along 
     const int wo = ctaid - (h*nlon_out);
     const int ho = row_idx[h];
 
+    // one output lon step corresponds to pscale input lon steps (requires nlon_in % nlon_out == 0)
+    const int pscale = nlon_in / nlon_out;
+
     kx += int64_t(batch)*nlat_in*nlon_in*nchan_in;
     qy += int64_t(batch)*nlat_out*nlon_out*nchan_in + int64_t(ho)*nlon_out*nchan_in + int64_t(wo)*nchan_in;
     if constexpr(CHIN_AS_OUT) {
@@ -248,7 +255,8 @@ void s2_attn_fwd_special_vec_k(int nchan_in,  // no. of FLOATV_T elements along 
 
         const int hi = col / nlon_in;
         const int wi = col - (hi*nlon_in);
-        const int wip = (wi+wo) - ((wi+wo) / nlon_in) * nlon_in;
+        const int wi_wo = wi + pscale*wo;
+        const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
 
         const FLOATV_T *_kx = kx + int64_t(hi)*nlon_in*nchan_in  + int64_t(wip)*nchan_in;
         const FLOATV_T *_vx = vx + int64_t(hi)*nlon_in*nchan_out + int64_t(wip)*nchan_out;
@@ -530,8 +538,11 @@ torch::Tensor s2_attention_fwd_cuda(at::Tensor kx,
     CHECK_CUDA_TENSOR(psi_col_idx);
     CHECK_CUDA_TENSOR(psi_row_off);
 
+    TORCH_CHECK(nlon_in % nlon_out == 0,
+                "nlon_in (", nlon_in, ") must be an integer multiple of nlon_out (", nlon_out, ")");
+
     size_t nchans_in  = qy.size(1); // or kx.size(1)
-    size_t nchans_out = vx.size(1); 
+    size_t nchans_out = vx.size(1);
 
     const int batch_size = kx.size(0);
 

--- a/torch_harmonics/disco/convolution.py
+++ b/torch_harmonics/disco/convolution.py
@@ -507,7 +507,8 @@ class DiscreteContinuousConvS2(DiscreteContinuousConv):
         self.nlat_out, self.nlon_out = out_shape
 
         # make sure the p-shift works by checking that longitudes are divisible
-        assert self.nlon_in % self.nlon_out == 0
+        assert self.nlon_in % self.nlon_out == 0, \
+            f"nlon_in ({self.nlon_in}) must be an integer multiple of nlon_out ({self.nlon_out}) for the DISCO p-shift to be exact"
 
         # heuristic to compute theta cutoff based on the bandlimit of the input field and overlaps of the basis functions
         if theta_cutoff is None:
@@ -646,7 +647,8 @@ class DiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
         self.nlat_out, self.nlon_out = out_shape
 
         # make sure the p-shift works by checking that longitudes are divisible
-        assert self.nlon_out % self.nlon_in == 0
+        assert self.nlon_out % self.nlon_in == 0, \
+            f"nlon_out ({self.nlon_out}) must be an integer multiple of nlon_in ({self.nlon_in}) for the DISCO transpose p-shift to be exact"
 
         # bandlimit
         if theta_cutoff is None:

--- a/torch_harmonics/disco/csrc/disco_cpu.cpp
+++ b/torch_harmonics/disco/csrc/disco_cpu.cpp
@@ -35,7 +35,7 @@ namespace disco_kernels {
     // cpu ops
     torch::Tensor disco_cpu_fwd(torch::Tensor inp, torch::Tensor roff_idx, torch::Tensor ker_idx, torch::Tensor row_idx,
         torch::Tensor col_idx, torch::Tensor vals, int64_t K, int64_t Ho, int64_t Wo) {
-        
+
         // sanity checks
         CHECK_CPU_INPUT_TENSOR(inp);
         CHECK_CPU_INPUT_TENSOR(roff_idx);
@@ -43,6 +43,10 @@ namespace disco_kernels {
         CHECK_CPU_INPUT_TENSOR(row_idx);
         CHECK_CPU_INPUT_TENSOR(col_idx);
         CHECK_CPU_INPUT_TENSOR(vals);
+
+        // the kernel uses pscale = Wi / Wo; require an integer ratio so the p-shift is exact
+        TORCH_CHECK(inp.size(3) % Wo == 0,
+                    "Wi (", inp.size(3), ") must be an integer multiple of Wo (", Wo, ")");
 
         // initialize output tensor
         auto out = torch::zeros({inp.size(0), inp.size(1), K, Ho, Wo}, inp.options());
@@ -65,7 +69,7 @@ namespace disco_kernels {
 
     torch::Tensor disco_cpu_bwd(torch::Tensor inp, torch::Tensor roff_idx, torch::Tensor ker_idx, torch::Tensor row_idx,
         torch::Tensor col_idx, torch::Tensor vals, int64_t K, int64_t Ho, int64_t Wo) {
-        
+
         // sanity checks
         CHECK_CPU_INPUT_TENSOR(inp);
         CHECK_CPU_INPUT_TENSOR(roff_idx);
@@ -73,6 +77,10 @@ namespace disco_kernels {
         CHECK_CPU_INPUT_TENSOR(row_idx);
         CHECK_CPU_INPUT_TENSOR(col_idx);
         CHECK_CPU_INPUT_TENSOR(vals);
+
+        // the kernel uses pscale = Wo / Wi; require an integer ratio so the p-shift is exact
+        TORCH_CHECK(Wo % inp.size(4) == 0,
+                    "Wo (", Wo, ") must be an integer multiple of Wi (", inp.size(4), ")");
 
         // initialize output tensor
         auto out = torch::zeros({inp.size(0), inp.size(1), Ho, Wo}, inp.options());

--- a/torch_harmonics/disco/csrc/disco_cuda_bwd.cu
+++ b/torch_harmonics/disco/csrc/disco_cuda_bwd.cu
@@ -221,6 +221,10 @@ static void launch_kernel(int BC, int Hi, int Wi, int K, int Ho, int Wo, int64_t
         int64_t Wi = inp.size(4);
         int64_t nrows = roff_idx.size(0) - 1;
 
+        // the kernel uses pscale = Wo / Wi; require an integer ratio so the p-shift is exact
+        TORCH_CHECK(Wo % Wi == 0,
+                    "Wo (", Wo, ") must be an integer multiple of Wi (", Wi, ")");
+
         // allocate output
         int64_t out_dims[] = {B, C, Ho, Wo};
         auto options = torch::TensorOptions().device(inp.device()).dtype(val.dtype());

--- a/torch_harmonics/disco/csrc/disco_cuda_fwd.cu
+++ b/torch_harmonics/disco/csrc/disco_cuda_fwd.cu
@@ -209,6 +209,10 @@ static void launch_kernel(int BC, int Hi, int Wi, int K, int Ho, int Wo, int64_t
         int64_t Wi = inp.size(3);
         int64_t nrows = roff_idx.size(0) - 1;
 
+        // the kernel uses pscale = Wi / Wo; require an integer ratio so the p-shift is exact
+        TORCH_CHECK(Wi % Wo == 0,
+                    "Wi (", Wi, ") must be an integer multiple of Wo (", Wo, ")");
+
         // allocate output
         int64_t out_dims[] = {B, C, K, Ho, Wo};
         auto options = torch::TensorOptions().device(inp.device()).dtype(inp.dtype());


### PR DESCRIPTION
This mode properly handles downsampling in the NeighborhoodAttentionS2 layer. It also adds better error capturing and reporting for disallowed nlon_in/nlon_out combinations. 