### PR TITLE
Refactoring Custom Autograd

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,9 @@
 * Added Fourier-Bessel basis functions
 * New `modal` filter basis normalization mode subtracts the mean to reduce spectral leakage
 * New `geometric` mode uses the theoretical area measure of the spherical cap to normalize
+* Added optional QK normalization (`use_qknorm`) to `AttentionS2` and `NeighborhoodAttentionS2`
+* Refactored attention custom autograd to perform QKV projections outside the custom op, letting torch handle conv2d gradients natively
+* **Breaking**: default attention scale in `NeighborhoodAttentionS2` changed from `1/sqrt(k_channels)` to `1/sqrt(k_channels // num_heads)` to match standard MHA head-dim scaling; affects users relying on the default with `num_heads > 1`
 
 ### v0.9.0
 

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -35,6 +35,7 @@ import unittest
 from parameterized import parameterized, parameterized_class
 
 import torch
+import torch.nn.functional as F
 from torch.library import opcheck
 
 # from torch.autograd import gradcheck
@@ -72,23 +73,35 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
 
     @parameterized.expand(
         [
-            # Format: [batch_size, channels, channels_out, heads, in_shape, out_shape, grid_in, grid_out, atol, rtol]
-            [4, 4, 4, 1, (6, 12), (6, 12), "equiangular", "equiangular", 1e-5, 1e-3],
-            [4, 4, 4, 2, (6, 12), (6, 12), "equiangular", "equiangular", 1e-5, 1e-3],
-            [4, 4, 4, 4, (6, 12), (6, 12), "equiangular", "equiangular", 1e-5, 1e-3],
-            [4, 4, 8, 4, (6, 12), (6, 12), "equiangular", "equiangular", 1e-5, 1e-3],
-            [4, 8, 4, 4, (6, 12), (6, 12), "equiangular", "equiangular", 1e-5, 1e-3],
-            [4, 8, 4, 4, (12, 24), (6, 12), "equiangular", "equiangular", 1e-5, 1e-3],
-            [4, 8, 4, 4, (6, 12), (12, 24), "equiangular", "equiangular", 1e-5, 1e-3],
-            [4, 1, 1, 1, (2, 4), (2, 4), "equiangular", "equiangular", 1e-5, 1e-3],
-            [4, 1, 4, 1, (2, 4), (2, 4), "equiangular", "equiangular", 1e-5, 1e-3],
-            [4, 4, 4, 4, (6, 12), (6, 12), "legendre-gauss", "legendre-gauss", 1e-5, 1e-3],
-            [4, 4, 4, 1, (6, 12), (6, 12), "lobatto", "lobatto", 1e-5, 1e-3],
+            # Format: [batch_size, channels, channels_out, heads, in_shape, out_shape, grid_in, grid_out, use_qknorm, atol, rtol]
+            [4, 4, 4, 1, (6, 12), (6, 12), "equiangular", "equiangular", False, 1e-5, 1e-3],
+            [4, 4, 4, 2, (6, 12), (6, 12), "equiangular", "equiangular", False, 1e-5, 1e-3],
+            [4, 4, 4, 4, (6, 12), (6, 12), "equiangular", "equiangular", False, 1e-5, 1e-3],
+            [4, 4, 8, 4, (6, 12), (6, 12), "equiangular", "equiangular", False, 1e-5, 1e-3],
+            [4, 8, 4, 4, (6, 12), (6, 12), "equiangular", "equiangular", False, 1e-5, 1e-3],
+            [4, 8, 4, 4, (12, 24), (6, 12), "equiangular", "equiangular", False, 1e-5, 1e-3],
+            [4, 8, 4, 4, (6, 12), (12, 24), "equiangular", "equiangular", False, 1e-5, 1e-3],
+            [4, 1, 1, 1, (2, 4), (2, 4), "equiangular", "equiangular", False, 1e-5, 1e-3],
+            [4, 1, 4, 1, (2, 4), (2, 4), "equiangular", "equiangular", False, 1e-5, 1e-3],
+            [4, 4, 4, 4, (6, 12), (6, 12), "legendre-gauss", "legendre-gauss", False, 1e-5, 1e-3],
+            [4, 4, 4, 1, (6, 12), (6, 12), "lobatto", "lobatto", False, 1e-5, 1e-3],
+            # same cases with QK norm enabled
+            [4, 4, 4, 1, (6, 12), (6, 12), "equiangular", "equiangular", True, 1e-5, 1e-3],
+            [4, 4, 4, 2, (6, 12), (6, 12), "equiangular", "equiangular", True, 1e-5, 1e-3],
+            [4, 4, 4, 4, (6, 12), (6, 12), "equiangular", "equiangular", True, 1e-5, 1e-3],
+            [4, 4, 8, 4, (6, 12), (6, 12), "equiangular", "equiangular", True, 1e-5, 1e-3],
+            [4, 8, 4, 4, (6, 12), (6, 12), "equiangular", "equiangular", True, 1e-5, 1e-3],
+            [4, 8, 4, 4, (12, 24), (6, 12), "equiangular", "equiangular", True, 1e-5, 1e-3],
+            [4, 8, 4, 4, (6, 12), (12, 24), "equiangular", "equiangular", True, 1e-5, 1e-3],
+            [4, 1, 1, 1, (2, 4), (2, 4), "equiangular", "equiangular", True, 1e-5, 1e-3],
+            [4, 1, 4, 1, (2, 4), (2, 4), "equiangular", "equiangular", True, 1e-5, 1e-3],
+            [4, 4, 4, 4, (6, 12), (6, 12), "legendre-gauss", "legendre-gauss", True, 1e-5, 1e-3],
+            [4, 4, 4, 1, (6, 12), (6, 12), "lobatto", "lobatto", True, 1e-5, 1e-3],
         ],
         skip_on_empty=True,
     )
     @unittest.skipUnless(optimized_kernels_is_available(), "skipping test because optimized kernels are not available")
-    def test_custom_implementation(self, batch_size, channels, channels_out, heads, in_shape, out_shape, grid_in, grid_out, atol, rtol, verbose=False):
+    def test_custom_implementation(self, batch_size, channels, channels_out, heads, in_shape, out_shape, grid_in, grid_out, use_qknorm, atol, rtol, verbose=True):
         """Tests numerical equivalence between the custom (CUDA) implementation and the reference torch implementation"""
 
         if (self.device.type == "cuda") and (not cuda_kernels_is_available()):
@@ -109,10 +122,10 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
         inputs_opt = {k: v.detach().clone().to(self.device).requires_grad_() for k, v in inputs_ref.items()}
 
         # reference input and model
-        model_ref = NeighborhoodAttentionS2(in_channels=channels, out_channels=channels_out, num_heads=heads, in_shape=in_shape, out_shape=out_shape, grid_in=grid_in, grid_out=grid_out, bias=True, optimized_kernel=False).to(self.device)
+        model_ref = NeighborhoodAttentionS2(in_channels=channels, out_channels=channels_out, num_heads=heads, in_shape=in_shape, out_shape=out_shape, grid_in=grid_in, grid_out=grid_out, bias=True, use_qknorm=use_qknorm, optimized_kernel=False).to(self.device)
 
         # Device model and inputs
-        model_opt = NeighborhoodAttentionS2(in_channels=channels, out_channels=channels_out, num_heads=heads, in_shape=in_shape, out_shape=out_shape, grid_in=grid_in, grid_out=grid_out, bias=True, optimized_kernel=True).to(self.device)
+        model_opt = NeighborhoodAttentionS2(in_channels=channels, out_channels=channels_out, num_heads=heads, in_shape=in_shape, out_shape=out_shape, grid_in=grid_in, grid_out=grid_out, bias=True, use_qknorm=use_qknorm, optimized_kernel=True).to(self.device)
 
         # Synchronize parameters of model
         model_opt.load_state_dict(model_ref.state_dict())
@@ -312,10 +325,12 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
             "q": torch.randn(batch_size, channels, nlat_out, nlon_out, requires_grad=True, device=self.device, dtype=torch.float32),
         }
 
-        test_inputs = (inputs["k"], inputs["v"], inputs["q"], 
-                       att.k_weights, att.v_weights, att.q_weights, 
-                       att.k_bias, att.v_bias, att.q_bias, 
-                       att.quad_weights, att.psi_col_idx, att.psi_roff_idx, 
+        kw = F.conv2d(inputs["k"], att.k_weights, att.k_bias)
+        vw = F.conv2d(inputs["v"], att.v_weights, att.v_bias)
+        qw = F.conv2d(inputs["q"], att.q_weights, att.q_bias) * att.scale
+
+        test_inputs = (kw, vw, qw,
+                       att.quad_weights, att.psi_col_idx, att.psi_roff_idx,
                        att.psi_max_nnz, att.num_heads, nlon_in, nlat_out, nlon_out)
 
         opcheck(torch.ops.attention_kernels._neighborhood_s2_attention_optimized, test_inputs)
@@ -406,6 +421,40 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
             print(f"Backward execution time on device {self.device.type}: {duration:.2f} ms")
         threshold = _perf_test_thresholds[self.device.type]["bwd_ms"]
         self.assertTrue(duration <= threshold, msg=f"Backward execution time on device {self.device.type} is too high: {duration:.2f} ms > {threshold:.2f} ms")
+
+    def test_wrong_shape_assertions(self):
+        """Verify that forward raises ValueError on spatial-shape mismatches."""
+        B, C = 2, 16
+        in_shape  = (12, 24)
+        out_shape = (6,  12)
+        nlat_in, nlon_in   = in_shape
+        nlat_out, nlon_out = out_shape
+
+        model = NeighborhoodAttentionS2(
+            in_channels=C,
+            in_shape=in_shape,
+            out_shape=out_shape,
+            grid_in="equiangular",
+            grid_out="equiangular",
+            num_heads=1,
+            bias=False,
+        ).to(self.device)
+
+        q  = torch.randn(B, C, nlat_out, nlon_out, device=self.device)
+        kv = torch.randn(B, C, nlat_in,  nlon_in,  device=self.device)
+
+        # 1. Self-attention on an up/downsampling module: a single tensor cannot
+        #    simultaneously satisfy in_shape (for k/v) and out_shape (for q).
+        with self.assertRaises(ValueError):
+            model(q)  # key defaults to query, but key must have in_shape
+
+        # 2. q_shape == k_shape != v_shape: key carries out_shape instead of in_shape.
+        with self.assertRaises(ValueError):
+            model(q, q, kv)
+
+        # 3. q_shape == v_shape != k_shape: value carries out_shape instead of in_shape.
+        with self.assertRaises(ValueError):
+            model(q, kv, q)
 
 if __name__ == "__main__":
     unittest.main()

--- a/torch_harmonics/attention/_attention_utils.py
+++ b/torch_harmonics/attention/_attention_utils.py
@@ -39,8 +39,8 @@ from . import attention_kernels
 
 # HELPER ROUTINE FOR BACKWARD setup_context
 def _setup_context_attention_backward(ctx, inputs, output):
-    k, v, q, wk, wv, wq, bk, bv, bq, quad_weights, col_idx, row_off, max_psi_nnz, nh, nlon_in, nlat_out, nlon_out = inputs
-    ctx.save_for_backward(col_idx, row_off, quad_weights, k, v, q, wk, wv, wq, bk, bv, bq)
+    kw, vw, qw, quad_weights, col_idx, row_off, max_psi_nnz, nh, nlon_in, nlat_out, nlon_out = inputs
+    ctx.save_for_backward(col_idx, row_off, quad_weights, kw, vw, qw)
     ctx.nh = nh
     ctx.max_psi_nnz = max_psi_nnz
     ctx.nlon_in = nlon_in
@@ -69,15 +69,9 @@ if optimized_kernels_is_available():
 
     # forward
     @torch.library.custom_op("attention_kernels::_neighborhood_s2_attention_optimized", mutates_args=())
-    def _neighborhood_s2_attention_optimized(k: torch.Tensor, v: torch.Tensor, q: torch.Tensor,
-                                             wk: torch.Tensor, wv: torch.Tensor, wq: torch.Tensor,
-                                             bk: Union[torch.Tensor, None], bv: Union[torch.Tensor, None], bq: Union[torch.Tensor, None],
+    def _neighborhood_s2_attention_optimized(kw: torch.Tensor, vw: torch.Tensor, qw: torch.Tensor,
                                              quad_weights: torch.Tensor, col_idx: torch.Tensor, row_off: torch.Tensor,
                                              max_psi_nnz: int, nh: int, nlon_in: int, nlat_out: int, nlon_out: int) -> torch.Tensor:
-
-        kw = F.conv2d(k, weight=wk, bias=bk)
-        vw = F.conv2d(v, weight=wv, bias=bv)
-        qw = F.conv2d(q, weight=wq, bias=bq)
 
         # reshape, folding num heads into batch dim
         B, _, H, W = kw.shape
@@ -106,36 +100,19 @@ if optimized_kernels_is_available():
         return output
 
     @torch.library.register_fake("attention_kernels::_neighborhood_s2_attention_optimized")
-    def _(k: torch.Tensor, v: torch.Tensor, q: torch.Tensor,
-          wk: torch.Tensor, wv: torch.Tensor, wq: torch.Tensor,
-        bk: Union[torch.Tensor, None], bv: Union[torch.Tensor, None], bq: Union[torch.Tensor, None],
+    def _(kw: torch.Tensor, vw: torch.Tensor, qw: torch.Tensor,
         quad_weights: torch.Tensor, col_idx: torch.Tensor, row_off: torch.Tensor,
         max_psi_nnz: int, nh: int, nlon_in: int, nlat_out: int, nlon_out: int) -> torch.Tensor:
-        out_shape = (k.shape[0], wv.shape[0], nlat_out, nlon_out)
-        return torch.empty(out_shape, dtype=k.dtype, device=k.device)
+        out_shape = (kw.shape[0], vw.shape[1], nlat_out, nlon_out)
+        return torch.empty(out_shape, dtype=kw.dtype, device=kw.device)
 
 def _neighborhood_s2_attention_bwd_optimized(ctx, grad_output):
-    col_idx, row_off, quad_weights, k, v, q, wk, wv, wq, bk, bv, bq = ctx.saved_tensors
+    col_idx, row_off, quad_weights, kw, vw, qw = ctx.saved_tensors
     nh = ctx.nh
     max_psi_nnz = ctx.max_psi_nnz
     nlon_in = ctx.nlon_in
     nlat_out = ctx.nlat_out
     nlon_out = ctx.nlon_out
-
-    # check if we need the grads at all
-    k_needs_grad = ctx.needs_input_grad[0]
-    v_needs_grad = ctx.needs_input_grad[1]
-    q_needs_grad = ctx.needs_input_grad[2]
-    wk_needs_grad = ctx.needs_input_grad[3]
-    wv_needs_grad = ctx.needs_input_grad[4]
-    wq_needs_grad = ctx.needs_input_grad[5]
-    bk_needs_grad = ctx.needs_input_grad[6]
-    bv_needs_grad = ctx.needs_input_grad[7]
-    bq_needs_grad = ctx.needs_input_grad[8]
-
-    kw = F.conv2d(k, weight=wk, bias=bk)
-    vw = F.conv2d(v, weight=wv, bias=bv)
-    qw = F.conv2d(q, weight=wq, bias=bq)
 
     # reshape, folding num heads into batch dim
     B, _, H, W = kw.shape
@@ -162,64 +139,15 @@ def _neighborhood_s2_attention_bwd_optimized(ctx, grad_output):
                                                        col_idx, row_off,
                                                        nlon_in, nlat_out, nlon_out)
 
-    # weight grads
-    _, C, H, W = dkw.shape
-    dkw = dkw.reshape(B, -1, H, W)
-    dkw = dkw.to(dtype=kw_dtype)
-    if wk_needs_grad:
-        dwk = torch.einsum("bchw,bfhw->cf", dkw, k).reshape(*wk.shape).contiguous()
-    else:
-        dwk = None
+    # reshape back to original batch dim and convert back precision
+    _, _, Hk, Wk = dkw.shape
+    dkw = dkw.reshape(B, -1, Hk, Wk).to(dtype=kw_dtype)
+    _, _, Hv, Wv = dvw.shape
+    dvw = dvw.reshape(B, -1, Hv, Wv).to(dtype=vw_dtype)
+    _, _, Hq, Wq = dqw.shape
+    dqw = dqw.reshape(B, -1, Hq, Wq).to(dtype=qw_dtype)
 
-    _, C, H, W = dvw.shape
-    dvw = dvw.reshape(B, -1, H, W)
-    dvw = dvw.to(dtype=vw_dtype)
-    if wv_needs_grad:
-        dwv = torch.einsum("bchw,bfhw->cf", dvw, v).reshape(*wv.shape).contiguous()
-    else:
-        dwv = None
-
-    _, C, H, W = dqw.shape
-    dqw = dqw.reshape(B, -1, H, W)
-    dqw = dqw.to(dtype=qw_dtype)
-    if wq_needs_grad:
-        dwq = torch.einsum("bchw,bfhw->cf", dqw, q).reshape(*wq.shape).contiguous()
-    else:
-        dwq = None
-   
-    # input grads
-    if v_needs_grad:
-        dv = torch.nn.functional.conv2d(dvw, weight=wv.permute([1,0,2,3]), bias=None)
-    else:
-        dv = None
-
-    if k_needs_grad:
-        dk = torch.nn.functional.conv2d(dkw, weight=wk.permute([1,0,2,3]), bias=None)
-    else:
-        dk = None
-
-    if q_needs_grad:
-        dq = torch.nn.functional.conv2d(dqw, weight=wq.permute([1,0,2,3]), bias=None)
-    else:
-        dq = None
-
-    # bias grads:
-    if bv_needs_grad:
-        dbv = torch.sum(dvw, dim=(0,2,3))
-    else:
-        dbv = None
-
-    if bk_needs_grad:
-        dbk = torch.sum(dkw, dim=(0,2,3))
-    else:
-        dbk = None
-
-    if bq_needs_grad:
-        dbq = torch.sum(dqw, dim=(0,2,3))
-    else:
-        dbq = None
-
-    return dk, dv, dq, dwk, dwv, dwq, dbk, dbv, dbq, \
+    return dkw, dvw, dqw, \
             None, None, None, None, None, None, None, None
 
 # register backward
@@ -511,15 +439,9 @@ def _neighborhood_s2_attention_bwd_dq_torch(kx: torch.Tensor, vx: torch.Tensor, 
     return dqy
 
 @torch.library.custom_op("attention_kernels::_neighborhood_s2_attention_torch", mutates_args=())
-def _neighborhood_s2_attention_torch(k: torch.Tensor, v: torch.Tensor, q: torch.Tensor,
-                                     wk: torch.Tensor, wv: torch.Tensor, wq: torch.Tensor,
-                                     bk: Union[torch.Tensor, None], bv: Union[torch.Tensor, None], bq: Union[torch.Tensor, None],
+def _neighborhood_s2_attention_torch(kw: torch.Tensor, vw: torch.Tensor, qw: torch.Tensor,
                                      quad_weights: torch.Tensor, col_idx: torch.Tensor, row_off: torch.Tensor,
                                      max_psi_nnz: int, nh: int, nlon_in: int, nlat_out: int, nlon_out: int) -> torch.Tensor:
-    kw = F.conv2d(k, weight=wk, bias=bk)
-    vw = F.conv2d(v, weight=wv, bias=bv)
-    qw = F.conv2d(q, weight=wq, bias=bq)
-
     # reshape, folding num heads into batch dim
     B, _, H, W = kw.shape
     kw = kw.reshape(B*nh, -1, H, W)
@@ -536,41 +458,29 @@ def _neighborhood_s2_attention_torch(k: torch.Tensor, v: torch.Tensor, q: torch.
                                                   col_idx, row_off,
                                                   nlon_in, nlat_out, nlon_out)
 
-    _, C, H, W = output.shape
+    _, _, H, W = output.shape
     output = output.reshape(B, -1, H, W)
 
     return output
 
 @torch.library.register_fake("attention_kernels::_neighborhood_s2_attention_torch")
-def _(k: torch.Tensor, v: torch.Tensor, q: torch.Tensor,
-      wk: torch.Tensor, wv: torch.Tensor, wq: torch.Tensor,
-      bk: Union[torch.Tensor, None], bv: Union[torch.Tensor, None], bq: Union[torch.Tensor, None],
+def _(kw: torch.Tensor, vw: torch.Tensor, qw: torch.Tensor,
       quad_weights: torch.Tensor, col_idx: torch.Tensor, row_off: torch.Tensor,
       max_psi_nnz: int, nh: int, nlon_in: int, nlat_out: int, nlon_out: int) -> torch.Tensor:
-    out_shape = (k.shape[0], wv.shape[0], nlat_out, nlon_out)
-    return torch.empty(out_shape, dtype=k.dtype, device=k.device)
+    out_shape = (kw.shape[0], vw.shape[1], nlat_out, nlon_out)
+    return torch.empty(out_shape, dtype=kw.dtype, device=kw.device)
 
 def _neighborhood_s2_attention_bwd_torch(ctx, grad_output):
-    col_idx, row_off, quad_weights, k, v, q, wk, wv, wq, bk, bv, bq = ctx.saved_tensors
+    col_idx, row_off, quad_weights, kw, vw, qw = ctx.saved_tensors
     nh = ctx.nh
     nlon_in = ctx.nlon_in
     nlat_out = ctx.nlat_out
     nlon_out = ctx.nlon_out
 
     # check if we need the grads at all
-    k_needs_grad = ctx.needs_input_grad[0]
-    v_needs_grad = ctx.needs_input_grad[1]
-    q_needs_grad = ctx.needs_input_grad[2]
-    wk_needs_grad = ctx.needs_input_grad[3]
-    wv_needs_grad = ctx.needs_input_grad[4]
-    wq_needs_grad = ctx.needs_input_grad[5]
-    bk_needs_grad = ctx.needs_input_grad[6]
-    bv_needs_grad = ctx.needs_input_grad[7]
-    bq_needs_grad = ctx.needs_input_grad[8]
-
-    kw = F.conv2d(k, weight=wk, bias=bk)
-    vw = F.conv2d(v, weight=wv, bias=bv)
-    qw = F.conv2d(q, weight=wq, bias=bq)
+    kw_needs_grad = ctx.needs_input_grad[0]
+    vw_needs_grad = ctx.needs_input_grad[1]
+    qw_needs_grad = ctx.needs_input_grad[2]
 
     # reshape, folding num heads into batch dim
     B, _, H, W = kw.shape
@@ -582,85 +492,37 @@ def _neighborhood_s2_attention_bwd_torch(ctx, grad_output):
     B, _, H, W  = grad_output.shape
     grad_output = grad_output.reshape(B*nh, -1, H, W)
 
-    if v_needs_grad or wv_needs_grad or bv_needs_grad:
+    if vw_needs_grad:
         dvw = _neighborhood_s2_attention_bwd_dv_torch(kw, vw, qw, grad_output,
                                                       quad_weights,
                                                       col_idx, row_off,
                                                       nlon_in, nlat_out, nlon_out)
-        _, C, H, W = dvw.shape
+        _, _, H, W = dvw.shape
         dvw = dvw.reshape(B, -1, H, W)
     else:
         dvw = None
 
-    if k_needs_grad or wk_needs_grad or bk_needs_grad:
+    if kw_needs_grad:
         dkw = _neighborhood_s2_attention_bwd_dk_torch(kw, vw, qw, grad_output,
                                                       quad_weights,
                                                       col_idx, row_off,
                                                       nlon_in, nlat_out, nlon_out)
-        _, C, H, W = dkw.shape
+        _, _, H, W = dkw.shape
         dkw = dkw.reshape(B, -1, H, W)
     else:
         dkw = None
 
-    if q_needs_grad or wq_needs_grad or bq_needs_grad:
+    if qw_needs_grad:
         dqw = _neighborhood_s2_attention_bwd_dq_torch(kw, vw, qw, grad_output,
                                                       quad_weights,
                                                       col_idx, row_off,
                                                       nlon_in, nlat_out, nlon_out)
-        _, C, H, W = dqw.shape
+        _, _, H, W = dqw.shape
         dqw = dqw.reshape(B, -1, H, W)
     else:
         dqw = None
 
-    # input grads
-    if v_needs_grad:
-        dv = torch.nn.functional.conv2d(dvw, weight=wv.permute([1,0,2,3]), bias=None)
-    else:
-        dv = None
-
-    if k_needs_grad:
-        dk = torch.nn.functional.conv2d(dkw, weight=wk.permute([1,0,2,3]), bias=None)
-    else:
-        dk = None
-
-    if q_needs_grad:
-        dq = torch.nn.functional.conv2d(dqw, weight=wq.permute([1,0,2,3]), bias=None)
-    else:
-        dq = None
-
-    # weight grads
-    if wv_needs_grad:
-        dwv = torch.einsum("bchw,bfhw->cf", dvw, v).reshape(*wv.shape).contiguous()
-    else:
-        dwv = None
-
-    if wk_needs_grad:
-        dwk = torch.einsum("bchw,bfhw->cf", dkw, k).reshape(*wk.shape).contiguous()
-    else:
-        dwk = None
-
-    if wq_needs_grad:
-        dwq = torch.einsum("bchw,bfhw->cf", dqw, q).reshape(*wq.shape).contiguous()
-    else:
-        dwq = None
-
-    # bias grads:
-    if bv_needs_grad:
-        dbv = torch.sum(dvw, dim=(0,2,3))
-    else:
-        dbv = None
-
-    if bk_needs_grad:
-        dbk = torch.sum(dkw, dim=(0,2,3))
-    else:
-        dbk = None
-
-    if bq_needs_grad:
-        dbq = torch.sum(dqw, dim=(0,2,3))
-    else:
-        dbq = None
-
-    return dk, dv, dq, dwk, dwv, dwq, dbk, dbv, dbq, \
+    return dkw, dvw, dqw, \
             None, None, None, None, None, None, None, None
 
 # register backward

--- a/torch_harmonics/attention/_attention_utils.py
+++ b/torch_harmonics/attention/_attention_utils.py
@@ -33,7 +33,6 @@ import math
 from typing import Union, Tuple
 
 import torch
-import torch.nn.functional as F
 from attention_helpers import optimized_kernels_is_available
 from . import attention_kernels
 

--- a/torch_harmonics/attention/attention.py
+++ b/torch_harmonics/attention/attention.py
@@ -35,6 +35,7 @@ import math
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 from torch_harmonics.quadrature import precompute_latitudes
 from torch_harmonics.disco.convolution import _precompute_convolution_tensor_s2
@@ -85,6 +86,7 @@ class AttentionS2(nn.Module):
             grid_in: Optional[str] = "equiangular",
             grid_out: Optional[str] = "equiangular",
             scale: Optional[Union[torch.Tensor, float]] = None,
+            use_qknorm: Optional[bool] = False,
             bias: Optional[bool] = True,
             k_channels: Optional[int] = None,
             out_channels: Optional[int] = None,
@@ -114,18 +116,18 @@ class AttentionS2(nn.Module):
         log_quad_weights = torch.log(quad_weights).reshape(1,1,-1)
         self.register_buffer("log_quad_weights", log_quad_weights, persistent=False)
 
-        # learnable parameters
-        # TODO: double-check that this gives us the correct initialization magnitudes
-        # the standard MHA uses xavier uniform, NATTEN uses kaiming. Let's use that for now
+        # learnable parameters — Xavier uniform init matching PyTorch MHA convention:
+        # bound = sqrt(6 / (fan_in + fan_out)) for each projection
         if self.k_channels % self.num_heads != 0:
             raise ValueError(f"Please make sure that number of heads {self.num_heads} divides k_channels {self.k_channels} evenly.")
         if self.out_channels % self.num_heads != 0:
             raise ValueError(f"Please make sure that number of heads {self.num_heads} divides out_channels {self.out_channels} evenly.")
-        scale_qkv = math.sqrt(3.0 / self.in_channels)
-        self.q_weights = nn.Parameter(scale_qkv * (2 * torch.rand(self.k_channels, self.in_channels, 1, 1) - 1))
-        self.k_weights = nn.Parameter(scale_qkv * (2 * torch.rand(self.k_channels, self.in_channels, 1, 1) - 1))
-        self.v_weights = nn.Parameter(scale_qkv * (2 * torch.rand(self.out_channels, self.in_channels, 1, 1) - 1))
+        scale_qk   = math.sqrt(6.0 / (self.in_channels + self.k_channels))
+        scale_v    = math.sqrt(6.0 / (self.in_channels + self.out_channels))
         scale_proj = math.sqrt(3.0 / self.out_channels)
+        self.q_weights = nn.Parameter(scale_qk   * (2 * torch.rand(self.k_channels,   self.in_channels,  1, 1) - 1))
+        self.k_weights = nn.Parameter(scale_qk   * (2 * torch.rand(self.k_channels,   self.in_channels,  1, 1) - 1))
+        self.v_weights = nn.Parameter(scale_v    * (2 * torch.rand(self.out_channels,  self.in_channels,  1, 1) - 1))
         self.proj_weights = nn.Parameter(scale_proj * (2 * torch.rand(self.out_channels, self.out_channels, 1, 1) - 1))
 
         if bias:
@@ -138,6 +140,13 @@ class AttentionS2(nn.Module):
             self.k_bias = None
             self.v_bias = None
             self.proj_bias = None
+
+        if use_qknorm:
+            self.q_norm_weights = nn.Parameter(torch.zeros(self.k_channels // self.num_heads))
+            self.k_norm_weights = nn.Parameter(torch.zeros(self.k_channels // self.num_heads))
+        else:
+            self.q_norm_weights = None
+            self.k_norm_weights = None
 
 
     def extra_repr(self):
@@ -155,7 +164,7 @@ class AttentionS2(nn.Module):
         # change this later to allow arbitrary number of batch dims
         assert (query.dim() == key.dim()) and (key.dim() == value.dim()) and (value.dim() == 4)
 
-        # perform MLP
+        # perform QKV projections
         query = nn.functional.conv2d(query, self.q_weights, bias=self.q_bias)
         key = nn.functional.conv2d(key, self.k_weights, bias=self.k_bias)
         value = nn.functional.conv2d(value, self.v_weights, bias=self.v_bias)
@@ -176,8 +185,18 @@ class AttentionS2(nn.Module):
         B, _, C, H, W = value.shape
         value = value.permute(0,1,3,4,2).reshape(B, self.num_heads, H*W, C)
 
-        # multiply the query, key and value tensors
-        out = nn.functional.scaled_dot_product_attention(query, key, value, attn_mask=self.log_quad_weights, dropout_p=self.drop_rate, scale=self.scale)
+        if self.q_norm_weights is not None:
+            query = F.rms_norm(query, normalized_shape=self.q_norm_weights.shape, weight=1 + self.q_norm_weights)
+        if self.k_norm_weights is not None:
+            key = F.rms_norm(key, normalized_shape=self.k_norm_weights.shape, weight=1 + self.k_norm_weights)
+
+        # apply scale — if scale is a tensor (e.g. learnable), multiply into query
+        # directly since SDPA only accepts a float scale
+        if isinstance(self.scale, torch.Tensor):
+            query = query * self.scale
+            out = F.scaled_dot_product_attention(query, key, value, attn_mask=self.log_quad_weights, dropout_p=self.drop_rate, scale=1.0)
+        else:
+            out = F.scaled_dot_product_attention(query, key, value, attn_mask=self.log_quad_weights, dropout_p=self.drop_rate, scale=self.scale)
 
         # reshape
         B, _, _, C = out.shape
@@ -235,6 +254,7 @@ class NeighborhoodAttentionS2(nn.Module):
         grid_out: Optional[str] = "equiangular",
         num_heads: Optional[int] = 1,
         scale: Optional[Union[torch.Tensor, float]] = None,
+        use_qknorm: Optional[bool] = False,
         bias: Optional[bool] = True,
         theta_cutoff: Optional[float] = None,
         k_channels: Optional[int] = None,
@@ -295,24 +315,24 @@ class NeighborhoodAttentionS2(nn.Module):
         self.register_buffer("psi_col_idx", col_idx, persistent=False)
         self.register_buffer("psi_roff_idx", roff_idx, persistent=False)
 
-        # learnable parameters
-        # TODO: double-check that this gives us the correct initialization magnitudes
-        # the standard MHA uses xavier uniform, NATTEN uses kaiming. Let's use that for now
+        # learnable parameters — Xavier uniform init matching PyTorch MHA convention:
+        # bound = sqrt(6 / (fan_in + fan_out)) for each projection
         if self.k_channels % self.num_heads != 0:
             raise ValueError(f"Please make sure that number of heads {self.num_heads} divides k_channels {self.k_channels} evenly.")
         if self.out_channels % self.num_heads != 0:
             raise ValueError(f"Please make sure that number of heads {self.num_heads} divides out_channels {self.out_channels} evenly.")
-        scale_qkv = math.sqrt(3.0 / self.in_channels)
-        self.q_weights = nn.Parameter(scale_qkv * (2 * torch.rand(self.k_channels, self.in_channels, 1, 1) - 1))
-        self.k_weights = nn.Parameter(scale_qkv * (2 * torch.rand(self.k_channels, self.in_channels, 1, 1) - 1))
-        self.v_weights = nn.Parameter(scale_qkv * (2 * torch.rand(self.out_channels, self.in_channels, 1, 1) - 1))
+        scale_qk   = math.sqrt(6.0 / (self.in_channels + self.k_channels))
+        scale_v    = math.sqrt(6.0 / (self.in_channels + self.out_channels))
         scale_proj = math.sqrt(3.0 / self.out_channels)
+        self.q_weights = nn.Parameter(scale_qk   * (2 * torch.rand(self.k_channels,   self.in_channels,  1, 1) - 1))
+        self.k_weights = nn.Parameter(scale_qk   * (2 * torch.rand(self.k_channels,   self.in_channels,  1, 1) - 1))
+        self.v_weights = nn.Parameter(scale_v    * (2 * torch.rand(self.out_channels,  self.in_channels,  1, 1) - 1))
         self.proj_weights = nn.Parameter(scale_proj * (2 * torch.rand(self.out_channels, self.out_channels, 1, 1) - 1))
 
         if scale is not None:
             self.scale = scale
         else:
-            self.scale = 1 / math.sqrt(self.k_channels)
+            self.scale = 1 / math.sqrt(self.k_channels // self.num_heads)
 
         if bias:
             self.q_bias = nn.Parameter(torch.zeros(self.k_channels))
@@ -324,6 +344,13 @@ class NeighborhoodAttentionS2(nn.Module):
             self.k_bias = None
             self.v_bias = None
             self.proj_bias = None
+
+        if use_qknorm:
+            self.q_norm_weights = nn.Parameter(torch.zeros(self.k_channels // self.num_heads))
+            self.k_norm_weights = nn.Parameter(torch.zeros(self.k_channels // self.num_heads))
+        else:
+            self.q_norm_weights = None
+            self.k_norm_weights = None
 
         if self.optimized_kernel:
             self.attention_handle = _neighborhood_s2_attention_optimized
@@ -345,7 +372,32 @@ class NeighborhoodAttentionS2(nn.Module):
         # change this later to allow arbitrary number of batch dims
         assert (query.dim() == key.dim()) and (key.dim() == value.dim()) and (value.dim() == 4)
 
-        # do the scaling
+        if query.shape[-2] != self.nlat_out or query.shape[-1] != self.nlon_out:
+            raise ValueError(f"query spatial shape {(query.shape[-2], query.shape[-1])} does not match out_shape {(self.nlat_out, self.nlon_out)}")
+        if key.shape[-2] != self.nlat_in or key.shape[-1] != self.nlon_in:
+            raise ValueError(f"key spatial shape {(key.shape[-2], key.shape[-1])} does not match in_shape {(self.nlat_in, self.nlon_in)}")
+        if value.shape[-2] != self.nlat_in or value.shape[-1] != self.nlon_in:
+            raise ValueError(f"value spatial shape {(value.shape[-2], value.shape[-1])} does not match in_shape {(self.nlat_in, self.nlon_in)}")
+
+        # perform QKV projections
+        query = nn.functional.conv2d(query, self.q_weights, bias=self.q_bias)
+        key = nn.functional.conv2d(key, self.k_weights, bias=self.k_bias)
+        value = nn.functional.conv2d(value, self.v_weights, bias=self.v_bias)
+
+        # perform QK normalization (must come before scale)
+        if self.q_norm_weights is not None:
+            B, C, H, W = query.shape
+            query = query.reshape(B, self.num_heads, -1, H, W).permute(0,1,3,4,2)
+            query = F.rms_norm(query, normalized_shape=self.q_norm_weights.shape, weight=1 + self.q_norm_weights)
+            query = query.permute(0,1,4,2,3).reshape(B, C, H, W).contiguous()
+
+        if self.k_norm_weights is not None:
+            B, C, H, W = key.shape
+            key = key.reshape(B, self.num_heads, -1, H, W).permute(0,1,3,4,2)
+            key = F.rms_norm(key, normalized_shape=self.k_norm_weights.shape, weight=1 + self.k_norm_weights)
+            key = key.permute(0,1,4,2,3).reshape(B, C, H, W).contiguous()
+
+        # scale after normalization
         query_scaled = query * self.scale
 
         # TODO: insert dimension checks for input
@@ -353,12 +405,6 @@ class NeighborhoodAttentionS2(nn.Module):
             key,
             value,
             query_scaled,
-            self.k_weights,
-            self.v_weights,
-            self.q_weights,
-            self.k_bias,
-            self.v_bias,
-            self.q_bias,
             self.quad_weights,
             self.psi_col_idx,
             self.psi_roff_idx,


### PR DESCRIPTION
This MR moves the weight updates out of the backward pass for attention, because it can be solely handled by pytorch and is less error prone. It also greatly simplifies all kernels and they focus on the main custom part.

Also, we added qk-norm support to all attention layers which is important for stability in latent space rollouts.
