### PR TITLE
making docstring with escapes raw

### DIFF
--- a/torch_harmonics/filter_basis.py
+++ b/torch_harmonics/filter_basis.py
@@ -446,7 +446,7 @@ class ZernikeFilterBasis(FilterBasis):
 
 
 class FourierBesselFilterBasis(FilterBasis):
-    """
+    r"""
     Fourier-Bessel (Disk Harmonic) filter basis on the unit disk.
 
     Basis functions are the Dirichlet Laplacian eigenfunctions on the disk:


### PR DESCRIPTION
this MR should fix the torch-harmonics/torch_harmonics/filter_basis.py:449: SyntaxWarning: invalid escape sequence '\p' warning