### PR TITLE
removing in-place modifications in inverse fft

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        python3 -m pytest --cov-report term --cov-report json --cov-config=.coveragerc --cov=torch_harmonics \
+        python3 -m pytest -ra --cov-report term --cov-report json --cov-config=.coveragerc --cov=torch_harmonics \
           --ignore-glob="**/test_distributed_*" ./tests/
 
     - name: Update coverage badge

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -1,0 +1,165 @@
+# coding=utf-8
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 The torch-harmonics Authors. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+import unittest
+from parameterized import parameterized, parameterized_class
+import torch
+
+from torch_harmonics.fft import rfft, irfft
+
+_devices = [(torch.device("cpu"),)]
+if torch.cuda.is_available():
+    _devices.append((torch.device("cuda"),))
+
+
+@parameterized_class(("device",), _devices)
+class TestFFTWrappers(unittest.TestCase):
+    """Tests for the rfft/irfft wrappers in torch_harmonics.fft."""
+
+    @parameterized.expand([
+        # batch, nlon, nmodes
+        [1, 64, None],
+        [4, 64, None],
+        [4, 64, 16],
+        [4, 64, 48],
+        [4, 128, 33],
+    ])
+    def test_rfft_irfft_roundtrip(self, batch, nlon, nmodes):
+        """irfft(rfft(x)) should recover the original signal."""
+        x = torch.randn(batch, nlon, device=self.device, dtype=torch.float64)
+        coeffs = rfft(x, nmodes=nmodes, dim=-1, norm="forward")
+        x_rec = irfft(coeffs, n=nlon, dim=-1, norm="forward")
+        self.assertTrue(
+            torch.allclose(x, x_rec, atol=1e-10),
+            f"Roundtrip failed: max error {(x - x_rec).abs().max().item():.2e}",
+        )
+
+    @parameterized.expand([
+        # batch, nlon, nmodes, nlon_out
+        [4, 64, 16, 64],
+        [4, 64, 16, 128],
+        [4, 128, 33, 128],
+        [4, 128, 33, 256],
+    ])
+    def test_rfft_irfft_bandlimited_roundtrip(self, batch, nlon, nmodes, nlon_out):
+        """A band-limited signal (only nmodes frequencies) must survive a
+        roundtrip through rfft(truncate to nmodes) -> irfft(upsample to nlon_out)
+        -> rfft(truncate to nmodes) with the same spectral coefficients."""
+        # build a band-limited signal: only the first nmodes frequencies are nonzero
+        coeffs = torch.randn(batch, nmodes, device=self.device, dtype=torch.complex128)
+        coeffs[:, 0] = coeffs[:, 0].real  # DC must be real
+        x = irfft(coeffs, n=nlon, dim=-1, norm="forward")
+
+        # roundtrip: forward FFT with truncation, then inverse to a (possibly different) grid
+        coeffs_rt = rfft(x, nmodes=nmodes, dim=-1, norm="forward")
+        x_rt = irfft(coeffs_rt, n=nlon_out, dim=-1, norm="forward")
+        coeffs_rt2 = rfft(x_rt, nmodes=nmodes, dim=-1, norm="forward")
+
+        self.assertTrue(
+            torch.allclose(coeffs_rt, coeffs_rt2, atol=1e-10),
+            f"Band-limited roundtrip failed: max error {(coeffs_rt - coeffs_rt2).abs().max().item():.2e}",
+        )
+
+    @parameterized.expand([
+        # batch, nlon, nmodes
+        [1, 64, None],
+        [4, 64, None],
+        [4, 64, 16],
+        [4, 128, 33],
+    ])
+    def test_rfft_backward(self, batch, nlon, nmodes):
+        """Backward through rfft must not error (covers stride-0 grad from sum)."""
+        x = torch.randn(batch, nlon, device=self.device, dtype=torch.float32, requires_grad=True)
+        coeffs = rfft(x, nmodes=nmodes, dim=-1, norm="forward")
+        loss = coeffs.abs().sum()
+        loss.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertFalse(torch.isnan(x.grad).any())
+
+    @parameterized.expand([
+        # batch, nmodes, nlon
+        [1, 33, 64],
+        [4, 33, 64],
+        [4, 17, 64],
+        [4, 65, 128],
+    ])
+    def test_irfft_backward(self, batch, nmodes, nlon):
+        """Backward through irfft must not error (covers stride-0 grad from sum)."""
+        x = torch.randn(batch, nmodes, device=self.device, dtype=torch.complex64, requires_grad=True)
+        out = irfft(x, n=nlon, dim=-1, norm="forward")
+        loss = out.sum()
+        loss.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertFalse(torch.isnan(x.grad).any())
+
+    @parameterized.expand([
+        # batch, nmodes, nlon
+        [4, 33, 64],
+        [4, 65, 128],
+    ])
+    def test_irfft_hermitian_symmetry(self, batch, nmodes, nlon):
+        """irfft must zero the imaginary part of DC and Nyquist bins,
+        so injecting imaginary noise at those bins should not change the output."""
+        x = torch.randn(batch, nmodes, device=self.device, dtype=torch.complex64)
+        out_clean = irfft(x, n=nlon, dim=-1, norm="forward")
+
+        # inject nonzero imaginary parts at DC and Nyquist
+        x_dirty = x.clone()
+        x_dirty[:, 0] = x_dirty[:, 0] + 1j
+        if nlon % 2 == 0 and nlon // 2 < nmodes:
+            x_dirty[:, nlon // 2] = x_dirty[:, nlon // 2] + 1j
+        out_dirty = irfft(x_dirty, n=nlon, dim=-1, norm="forward")
+
+        self.assertTrue(
+            torch.allclose(out_clean, out_dirty, atol=1e-6),
+            f"Hermitian fix failed: max diff {(out_clean - out_dirty).abs().max().item():.2e}",
+        )
+
+    @parameterized.expand([
+        # batch, nmodes, nlon
+        [4, 33, 64],
+        [4, 65, 128],
+    ])
+    def test_rfft_irfft_grad_chain(self, batch, nmodes, nlon):
+        """Gradient must flow through rfft -> linear op -> irfft without error."""
+        x = torch.randn(batch, nlon, device=self.device, dtype=torch.float32, requires_grad=True)
+        coeffs = rfft(x, nmodes=nmodes, dim=-1, norm="forward")
+        # simple linear op in spectral space
+        coeffs = coeffs * 0.5
+        out = irfft(coeffs, n=nlon, dim=-1, norm="forward")
+        loss = out.sum()
+        loss.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertFalse(torch.isnan(x.grad).any())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -45,12 +45,11 @@ class TestFFTWrappers(unittest.TestCase):
     """Tests for the rfft/irfft wrappers in torch_harmonics.fft."""
 
     @parameterized.expand([
-        # batch, nlon, nmodes
+        # batch, nlon, nmodes (nmodes >= nlon//2+1 or None to keep all modes)
         [1, 64, None],
         [4, 64, None],
-        [4, 64, 16],
         [4, 64, 48],
-        [4, 128, 33],
+        [4, 128, None],
     ])
     def test_rfft_irfft_roundtrip(self, batch, nlon, nmodes):
         """irfft(rfft(x)) should recover the original signal."""

--- a/tests/test_spectral_convolution.py
+++ b/tests/test_spectral_convolution.py
@@ -194,8 +194,6 @@ class TestSpectralConvS2(unittest.TestCase):
     )
     def test_dtype_preservation(self, nlat, nlon, in_channels, out_channels, dtype, verbose=False):
         """Output dtype must match input dtype after the internal float32 cast."""
-        if dtype == torch.float16 and self.device.type == "cpu":
-            self.skipTest("float16 arithmetic is not supported on CPU")
 
         # set seed
         set_seed(333)

--- a/tests/test_spectral_convolution.py
+++ b/tests/test_spectral_convolution.py
@@ -420,10 +420,9 @@ class TestSpectralConvS2(unittest.TestCase):
 
     @parameterized.expand(
         [
-            # disabling tests for now because MKL DNN has problems with those:
             # nlat, nlon, channels, num_groups
-            #[32, 64, 4, 1],
-            #[32, 64, 4, 2],
+            [32, 64, 4, 1],
+            [32, 64, 4, 2],
         ],
         skip_on_empty=True,
     )

--- a/torch_harmonics/fft.py
+++ b/torch_harmonics/fft.py
@@ -74,15 +74,19 @@ def irfft(x: torch.Tensor, n: Optional[int] = None, dim: int = -1, **kwargs) -> 
     if n is None:
         n = 2 * (x.size(dim) - 1)
 
-    # ensure that imaginary part of 0 and nyquist components are zero
-    # this is important because not all backend algorithms provided through the
-    # irfft interface ensure that
-    if x.requires_grad:
-        # this ensures that we create a contiguous new tensor we can overwrite:
-        x = x.clone()
-    x[..., 0].imag = 0.0
+    # Zero the imaginary part of the DC bin (and Nyquist bin if present) to
+    # enforce Hermitian symmetry. We do this functionally via torch.complex()
+    # rather than in-place assignment (x[..., k].imag = 0.0) because the
+    # in-place write on a strided complex view breaks autograd's backward pass
+    # on CPU+MKL (DftiCommitDescriptor rejects the resulting stride pattern).
+    imag_scale = torch.ones(x.size(dim), dtype=x.real.dtype, device=x.device)
+    imag_scale[0] = 0.0
     if (n % 2 == 0) and (n // 2 < x.size(dim)):
-        x[..., n // 2].imag = 0.0
+        imag_scale[n // 2] = 0.0
+    shape = [1] * x.ndim
+    shape[dim] = -1
+    imag_scale = imag_scale.reshape(*shape)
+    x = torch.complex(x.real, x.imag * imag_scale)
 
     x = fft.irfft(x, n=n, dim=dim, **kwargs)
 

--- a/torch_harmonics/fft.py
+++ b/torch_harmonics/fft.py
@@ -56,7 +56,7 @@ def rfft(x: torch.Tensor, nmodes: Optional[int] = None, dim: int = -1, **kwargs)
     if "n" in kwargs:
         raise ValueError("The 'n' argument is not allowed. Use 'nmodes' instead.")
 
-    x = fft.rfft(x, dim=dim, **kwargs)
+    x = fft.rfft(x.contiguous(), dim=dim, **kwargs)
 
     if nmodes is not None and nmodes > x.shape[dim]:
         x = _pad_dim_right(x, dim, nmodes, value=0.0)
@@ -88,6 +88,6 @@ def irfft(x: torch.Tensor, n: Optional[int] = None, dim: int = -1, **kwargs) -> 
     imag_scale = imag_scale.reshape(*shape)
     x = torch.complex(x.real, x.imag * imag_scale)
 
-    x = fft.irfft(x, n=n, dim=dim, **kwargs)
+    x = fft.irfft(x.contiguous(), n=n, dim=dim, **kwargs)
 
     return x

--- a/torch_harmonics/fft.py
+++ b/torch_harmonics/fft.py
@@ -35,6 +35,8 @@ import torch
 import torch.fft as fft
 import torch.nn as nn
 
+from torch_harmonics.utils import ensure_contiguous
+
 
 def _pad_dim_right(x: torch.Tensor, dim: int, target_size: int, value: float = 0.0) -> torch.Tensor:
     """Pad tensor along a single dimension to target_size (right-side only)."""
@@ -56,7 +58,7 @@ def rfft(x: torch.Tensor, nmodes: Optional[int] = None, dim: int = -1, **kwargs)
     if "n" in kwargs:
         raise ValueError("The 'n' argument is not allowed. Use 'nmodes' instead.")
 
-    x = fft.rfft(x.contiguous(), dim=dim, **kwargs)
+    x = fft.rfft(ensure_contiguous(x), dim=dim, **kwargs)
 
     if nmodes is not None and nmodes > x.shape[dim]:
         x = _pad_dim_right(x, dim, nmodes, value=0.0)
@@ -88,6 +90,6 @@ def irfft(x: torch.Tensor, n: Optional[int] = None, dim: int = -1, **kwargs) -> 
     imag_scale = imag_scale.reshape(*shape)
     x = torch.complex(x.real, x.imag * imag_scale)
 
-    x = fft.irfft(x.contiguous(), n=n, dim=dim, **kwargs)
+    x = fft.irfft(ensure_contiguous(x), n=n, dim=dim, **kwargs)
 
     return x

--- a/torch_harmonics/fft.py
+++ b/torch_harmonics/fft.py
@@ -58,7 +58,7 @@ def rfft(x: torch.Tensor, nmodes: Optional[int] = None, dim: int = -1, **kwargs)
     if "n" in kwargs:
         raise ValueError("The 'n' argument is not allowed. Use 'nmodes' instead.")
 
-    x = fft.rfft(ensure_contiguous(x), dim=dim, **kwargs)
+    x = ensure_contiguous(fft.rfft(x, dim=dim, **kwargs))
 
     if nmodes is not None and nmodes > x.shape[dim]:
         x = _pad_dim_right(x, dim, nmodes, value=0.0)
@@ -90,6 +90,6 @@ def irfft(x: torch.Tensor, n: Optional[int] = None, dim: int = -1, **kwargs) -> 
     imag_scale = imag_scale.reshape(*shape)
     x = torch.complex(x.real, x.imag * imag_scale)
 
-    x = fft.irfft(ensure_contiguous(x), n=n, dim=dim, **kwargs)
+    x = ensure_contiguous(fft.irfft(x, n=n, dim=dim, **kwargs))
 
     return x

--- a/torch_harmonics/utils.py
+++ b/torch_harmonics/utils.py
@@ -1,0 +1,49 @@
+# coding=utf-8
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 The torch-harmonics Authors. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+import torch
+
+
+class _EnsureContiguous(torch.autograd.Function):
+    """Ensures the tensor is contiguous in both the forward and backward pass."""
+
+    @staticmethod
+    def forward(ctx, x):
+        return x.contiguous()
+
+    @staticmethod
+    def backward(ctx, grad):
+        return grad.contiguous()
+
+
+def ensure_contiguous(x: torch.Tensor) -> torch.Tensor:
+    """Ensures the tensor is contiguous in both the forward and backward pass."""
+    return _EnsureContiguous.apply(x)

--- a/torch_harmonics/utils.py
+++ b/torch_harmonics/utils.py
@@ -36,8 +36,12 @@ class _EnsureContiguous(torch.autograd.Function):
     """Ensures the tensor is contiguous in both the forward and backward pass."""
 
     @staticmethod
-    def forward(ctx, x):
+    def forward(x):
         return x.contiguous()
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        pass
 
     @staticmethod
     def backward(ctx, grad):


### PR DESCRIPTION
This MR fixes an in-place modification issue which throws MKL-FFT off in the backward pass.