### PR TITLE
Tkurth/assert fix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 * Distributed DISCO convolution now uses `reduce_scatter` instead of `all_reduce` + `scatter` for the polar reduction, cutting communicated data volume in half.
 * New ring communication variant for distributed DISCO convolution (`method="ring"`): nearest-neighbor rotation along the azimuth group replaces the bulk all-to-all transpose. The K-expanded intermediate never crosses any collective, making this path better suited for deep-channel / narrow-spatial layers. CUDA-only; set `fused=True` for maximum activation-memory savings (recomputes the ring forward in backward). Double-buffered P2P transfers available via `TORCH_HARMONICS_P2P_BUFFER=1`.
 * Improved performance for CPU based attention kernels.
+* Converted all Python assert statements to torch._check for better torch.compile friendliness. All asserts in cosntructors were converted into ValueErrors for streamlined and clear error handling. In C++ and CUDA compiled code, all dynamic asserts were changed to TORCH_CHECK calls.
 
 ### v0.9.1
 

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -899,7 +899,7 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
         self.assertTrue(duration <= threshold, msg=f"Backward execution time on device {self.device.type} is too high: {duration:.2f} ms > {threshold:.2f} ms")
 
     def test_wrong_shape_assertions(self):
-        """Verify that forward raises ValueError on spatial-shape mismatches."""
+        """Verify that forward raises RuntimeError on spatial-shape mismatches."""
         B, C = 2, 16
         in_shape = (12, 24)
         out_shape = (6, 12)
@@ -921,15 +921,15 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
 
         # 1. Self-attention on an up/downsampling module: a single tensor cannot
         #    simultaneously satisfy in_shape (for k/v) and out_shape (for q).
-        with self.assertRaises(ValueError):
+        with self.assertRaises(RuntimeError):
             model(q)  # key defaults to query, but key must have in_shape
 
         # 2. q_shape == k_shape != v_shape: key carries out_shape instead of in_shape.
-        with self.assertRaises(ValueError):
+        with self.assertRaises(RuntimeError):
             model(q, q, kv)
 
         # 3. q_shape == v_shape != k_shape: value carries out_shape instead of in_shape.
-        with self.assertRaises(ValueError):
+        with self.assertRaises(RuntimeError):
             model(q, kv, q)
 
 

--- a/tests/test_distributed_attention.py
+++ b/tests/test_distributed_attention.py
@@ -414,7 +414,7 @@ class TestDistributedNeighborhoodAttention(unittest.TestCase):
             )
 
     def test_wrong_shape_assertions(self):
-        """Verify that forward raises ValueError on spatial-shape mismatches."""
+        """Verify that forward raises RuntimeError on spatial-shape mismatches."""
         B, C = 2, 16
         in_shape = (64, 128)
         out_shape = (32, 64)
@@ -435,15 +435,15 @@ class TestDistributedNeighborhoodAttention(unittest.TestCase):
 
         # 1. Self-attention on an up/downsampling module: a single tensor cannot
         #    simultaneously satisfy in_shape (for k/v) and out_shape (for q).
-        with self.assertRaises(ValueError):
+        with self.assertRaises(RuntimeError):
             attn(q_local)  # key defaults to query, but key must have in_shape
 
         # 2. q_shape == k_shape != v_shape: key carries out_shape instead of in_shape.
-        with self.assertRaises(ValueError):
+        with self.assertRaises(RuntimeError):
             attn(q_local, q_local, k_local)
 
         # 3. q_shape == v_shape != k_shape: value carries out_shape instead of in_shape.
-        with self.assertRaises(ValueError):
+        with self.assertRaises(RuntimeError):
             attn(q_local, k_local, q_local)
 
 

--- a/tests/test_distributed_primitives.py
+++ b/tests/test_distributed_primitives.py
@@ -104,13 +104,13 @@ class TestComputeSplitShapes(unittest.TestCase):
         self.assertEqual(shapes, [1, 1, 1, 1])
 
     def test_fails_when_size_less_than_num_chunks(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(RuntimeError):
             compute_split_shapes(2, 5)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(RuntimeError):
             compute_split_shapes(1, 2)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(RuntimeError):
             compute_split_shapes(0, 1)
 
 

--- a/tests/test_random_fields.py
+++ b/tests/test_random_fields.py
@@ -116,8 +116,8 @@ class TestGaussianRandomFieldS2(unittest.TestCase):
         skip_on_empty=True,
     )
     def test_alpha_assertion(self, nlat, alpha, verbose=False):
-        """alpha <= 1 with sigma=None must raise AssertionError."""
-        with self.assertRaises(AssertionError):
+        """alpha <= 1 with sigma=None must raise ValueError."""
+        with self.assertRaises(ValueError):
             GaussianRandomFieldS2(nlat, alpha=alpha, sigma=None)
 
     @parameterized.expand(

--- a/torch_harmonics/attention/attention.py
+++ b/torch_harmonics/attention/attention.py
@@ -97,7 +97,8 @@ class AttentionS2(nn.Module):
         self.nlat_in, self.nlon_in = in_shape
         self.nlat_out, self.nlon_out = out_shape
 
-        assert self.nlon_in % self.nlon_out == 0, f"nlon_in ({self.nlon_in}) must be an integer multiple of nlon_out ({self.nlon_out}) for the attention p-shift to be exact"
+        if self.nlon_in % self.nlon_out != 0:
+            raise ValueError(f"nlon_in ({self.nlon_in}) must be an integer multiple of nlon_out ({self.nlon_out}) for the attention p-shift to be exact")
 
         self.in_channels = in_channels
         self.num_heads = num_heads
@@ -274,9 +275,8 @@ class NeighborhoodAttentionS2(nn.Module):
         # of nlon_in. Self-attention (nlon_in == nlon_out) satisfies both and falls
         # through the gather path with pscale == 1.
         self.upsample = (self.nlon_out % self.nlon_in == 0) and (self.nlon_in % self.nlon_out != 0)
-        assert (
-            self.nlon_in % self.nlon_out == 0
-        ) or self.upsample, f"either nlon_in ({self.nlon_in}) must be an integer multiple of nlon_out ({self.nlon_out}), or vice versa, for the attention p-shift to be exact"
+        if not (self.nlon_in % self.nlon_out == 0 or self.upsample):
+            raise ValueError(f"either nlon_in ({self.nlon_in}) must be an integer multiple of nlon_out ({self.nlon_out}), or vice versa, for the attention p-shift to be exact")
 
         self.in_channels = in_channels
         self.num_heads = num_heads

--- a/torch_harmonics/attention/attention.py
+++ b/torch_harmonics/attention/attention.py
@@ -163,7 +163,9 @@ class AttentionS2(nn.Module):
             value = query
 
         # change this later to allow arbitrary number of batch dims
-        assert (query.dim() == key.dim()) and (key.dim() == value.dim()) and (value.dim() == 4)
+        torch._check(query.dim() == 4, lambda: f"Expected 4-dimensional query tensor, got {query.dim()} dimensions")
+        torch._check(key.dim() == 4, lambda: f"Expected 4-dimensional key tensor, got {key.dim()} dimensions")
+        torch._check(value.dim() == 4, lambda: f"Expected 4-dimensional value tensor, got {value.dim()} dimensions")
 
         # perform QKV projections
         query = nn.functional.conv2d(query, self.q_weights, bias=self.q_bias)
@@ -399,14 +401,15 @@ class NeighborhoodAttentionS2(nn.Module):
             value = query
 
         # change this later to allow arbitrary number of batch dims
-        assert (query.dim() == key.dim()) and (key.dim() == value.dim()) and (value.dim() == 4)
-
-        if query.shape[-2] != self.nlat_out or query.shape[-1] != self.nlon_out:
-            raise ValueError(f"query spatial shape {(query.shape[-2], query.shape[-1])} does not match out_shape {(self.nlat_out, self.nlon_out)}")
-        if key.shape[-2] != self.nlat_in or key.shape[-1] != self.nlon_in:
-            raise ValueError(f"key spatial shape {(key.shape[-2], key.shape[-1])} does not match in_shape {(self.nlat_in, self.nlon_in)}")
-        if value.shape[-2] != self.nlat_in or value.shape[-1] != self.nlon_in:
-            raise ValueError(f"value spatial shape {(value.shape[-2], value.shape[-1])} does not match in_shape {(self.nlat_in, self.nlon_in)}")
+        torch._check(query.dim() == 4, lambda: f"Expected 4-dimensional query tensor, got {query.dim()} dimensions")
+        torch._check(key.dim() == 4, lambda: f"Expected 4-dimensional key tensor, got {key.dim()} dimensions")
+        torch._check(value.dim() == 4, lambda: f"Expected 4-dimensional value tensor, got {value.dim()} dimensions")
+        torch._check(query.shape[-2] == self.nlat_out, lambda: f"Expected query latitudes shape[-2]=={self.nlat_out}, got {query.shape[-2]}")
+        torch._check(query.shape[-1] == self.nlon_out, lambda: f"Expected query longitudes shape[-1]=={self.nlon_out}, got {query.shape[-1]}")
+        torch._check(key.shape[-2] == self.nlat_in, lambda: f"Expected key latitudes shape[-2]=={self.nlat_in}, got {key.shape[-2]}")
+        torch._check(key.shape[-1] == self.nlon_in, lambda: f"Expected key longitudes shape[-1]=={self.nlon_in}, got {key.shape[-1]}")
+        torch._check(value.shape[-2] == self.nlat_in, lambda: f"Expected value latitudes shape[-2]=={self.nlat_in}, got {value.shape[-2]}")
+        torch._check(value.shape[-1] == self.nlon_in, lambda: f"Expected value longitudes shape[-1]=={self.nlon_in}, got {value.shape[-1]}")
 
         # perform QKV projections
         query = nn.functional.conv2d(query, self.q_weights, bias=self.q_bias)

--- a/torch_harmonics/attention/kernels_torch/attention_torch.py
+++ b/torch_harmonics/attention/kernels_torch/attention_torch.py
@@ -76,7 +76,7 @@ def _neighborhood_s2_attention_fwd_torch(
 ) -> torch.Tensor:
 
     # one output lon step corresponds to pscale input lon steps; require an integer ratio
-    assert nlon_in % nlon_out == 0, f"nlon_in ({nlon_in}) must be an integer multiple of nlon_out ({nlon_out})"
+    torch._check(nlon_in % nlon_out == 0, lambda: f"nlon_in ({nlon_in}) must be an integer multiple of nlon_out ({nlon_out})")
     pscale = nlon_in // nlon_out
 
     # prepare result tensor
@@ -149,7 +149,7 @@ def _neighborhood_s2_attention_bwd_dv_torch(
     # output
     # dvx: B, Cout, Hi, Wi
 
-    assert nlon_in % nlon_out == 0, f"nlon_in ({nlon_in}) must be an integer multiple of nlon_out ({nlon_out})"
+    torch._check(nlon_in % nlon_out == 0, lambda: f"nlon_in ({nlon_in}) must be an integer multiple of nlon_out ({nlon_out})")
     pscale = nlon_in // nlon_out
 
     dvx = torch.zeros_like(vx)
@@ -230,7 +230,7 @@ def _neighborhood_s2_attention_bwd_dk_torch(
     # output
     # dkx: B, C, Hi, Wi
 
-    assert nlon_in % nlon_out == 0, f"nlon_in ({nlon_in}) must be an integer multiple of nlon_out ({nlon_out})"
+    torch._check(nlon_in % nlon_out == 0, lambda: f"nlon_in ({nlon_in}) must be an integer multiple of nlon_out ({nlon_out})")
     pscale = nlon_in // nlon_out
 
     dkx = torch.zeros_like(kx)
@@ -325,7 +325,7 @@ def _neighborhood_s2_attention_bwd_dq_torch(
     # output
     # dq: B, C, Ho, Wo
 
-    assert nlon_in % nlon_out == 0, f"nlon_in ({nlon_in}) must be an integer multiple of nlon_out ({nlon_out})"
+    torch._check(nlon_in % nlon_out == 0, lambda: f"nlon_in ({nlon_in}) must be an integer multiple of nlon_out ({nlon_out})")
     pscale = nlon_in // nlon_out
 
     batch_size = dy.shape[0]
@@ -557,7 +557,7 @@ def _neighborhood_s2_attention_upsample_fwd_torch(
     col_idx/row_off: psi built with swapped shapes; rows=nlat_in, cols=(ho*nlon_out + wo)
     """
 
-    assert nlon_out % nlon_in == 0, f"nlon_out ({nlon_out}) must be an integer multiple of nlon_in ({nlon_in})"
+    torch._check(nlon_out % nlon_in == 0, lambda: f"nlon_out ({nlon_out}) must be an integer multiple of nlon_in ({nlon_in})")
     pscale_out = nlon_out // nlon_in
 
     B = qy.shape[0]
@@ -623,7 +623,7 @@ def _neighborhood_s2_attention_upsample_bwd_dv_torch(
     where alpha_norm = alpha[ho,wop,hi,wi] / alpha_sum[ho,wop].
     """
 
-    assert nlon_out % nlon_in == 0
+    torch._check(nlon_out % nlon_in == 0, lambda: f"nlon_out ({nlon_out}) must be an integer multiple of nlon_in ({nlon_in})")
     pscale_out = nlon_out // nlon_in
 
     B = qy.shape[0]
@@ -692,7 +692,7 @@ def _neighborhood_s2_attention_upsample_bwd_dk_torch(
     where integral[ho, wop] = sum_j alpha_norm_j * (dy . v_j).
     """
 
-    assert nlon_out % nlon_in == 0
+    torch._check(nlon_out % nlon_in == 0, lambda: f"nlon_out ({nlon_out}) must be an integer multiple of nlon_in ({nlon_in})")
     pscale_out = nlon_out // nlon_in
 
     B = qy.shape[0]
@@ -768,7 +768,7 @@ def _neighborhood_s2_attention_upsample_bwd_dq_torch(
     We accumulate them per output cell by scattering from all (hi, wi) inputs.
     """
 
-    assert nlon_out % nlon_in == 0
+    torch._check(nlon_out % nlon_in == 0, lambda: f"nlon_out ({nlon_out}) must be an integer multiple of nlon_in ({nlon_in})")
     pscale_out = nlon_out // nlon_in
 
     B = qy.shape[0]

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_utils.cuh
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_utils.cuh
@@ -236,8 +236,10 @@ namespace attention_kernels
         grid.y = DIV_UP(src.size(3), block.x);
         grid.z = src.size(2) * src.size(0);
 
-        assert(grid.y < 65536);
-        assert(grid.z < 65536);
+        TORCH_CHECK(grid.y < 65536, "permute_to0231: grid.y (", grid.y,
+                    ") exceeds CUDA gridDim.y limit of 65535; input nlon dimension is too large");
+        TORCH_CHECK(grid.z < 65536, "permute_to0231: grid.z (", grid.z,
+                    ") exceeds CUDA gridDim.z limit of 65535; batch * nlat is too large");
 
         // get stream
         auto stream = at::cuda::getCurrentCUDAStream().stream();
@@ -316,8 +318,10 @@ namespace attention_kernels
         grid.y = DIV_UP(src.size(3), block.x);
         grid.z = src.size(1) * src.size(0);
 
-        assert(grid.y < 65536);
-        assert(grid.z < 65536);
+        TORCH_CHECK(grid.y < 65536, "permute_to0312: grid.y (", grid.y,
+                    ") exceeds CUDA gridDim.y limit of 65535; input nlon dimension is too large");
+        TORCH_CHECK(grid.z < 65536, "permute_to0312: grid.z (", grid.z,
+                    ") exceeds CUDA gridDim.z limit of 65535; batch * nchn is too large");
 
         // get stream
         auto stream = at::cuda::getCurrentCUDAStream().stream();

--- a/torch_harmonics/disco/convolution.py
+++ b/torch_harmonics/disco/convolution.py
@@ -273,8 +273,10 @@ def _precompute_convolution_tensor_s2(
 
     """
 
-    assert len(in_shape) == 2
-    assert len(out_shape) == 2
+    if len(in_shape) != 2:
+        raise ValueError(f"in_shape must be a 2-tuple (nlat, nlon), got length {len(in_shape)}")
+    if len(out_shape) != 2:
+        raise ValueError(f"out_shape must be a 2-tuple (nlat, nlon), got length {len(out_shape)}")
 
     kernel_size = filter_basis.kernel_size
 
@@ -513,7 +515,8 @@ class DiscreteContinuousConvS2(DiscreteContinuousConv):
         self.nlat_out, self.nlon_out = out_shape
 
         # make sure the p-shift works by checking that longitudes are divisible
-        assert self.nlon_in % self.nlon_out == 0, f"nlon_in ({self.nlon_in}) must be an integer multiple of nlon_out ({self.nlon_out}) for the DISCO p-shift to be exact"
+        if self.nlon_in % self.nlon_out != 0:
+            raise ValueError(f"nlon_in ({self.nlon_in}) must be an integer multiple of nlon_out ({self.nlon_out}) for the DISCO p-shift to be exact")
 
         # heuristic to compute theta cutoff based on the bandlimit of the input field and overlaps of the basis functions
         if theta_cutoff is None:
@@ -670,7 +673,8 @@ class DiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
         self.nlat_out, self.nlon_out = out_shape
 
         # make sure the p-shift works by checking that longitudes are divisible
-        assert self.nlon_out % self.nlon_in == 0, f"nlon_out ({self.nlon_out}) must be an integer multiple of nlon_in ({self.nlon_in}) for the DISCO transpose p-shift to be exact"
+        if self.nlon_out % self.nlon_in != 0:
+            raise ValueError(f"nlon_out ({self.nlon_out}) must be an integer multiple of nlon_in ({self.nlon_in}) for the DISCO transpose p-shift to be exact")
 
         # bandlimit
         if theta_cutoff is None:

--- a/torch_harmonics/disco/kernels_torch/disco_torch.py
+++ b/torch_harmonics/disco/kernels_torch/disco_torch.py
@@ -53,16 +53,16 @@ def _disco_s2_contraction_torch(x: torch.Tensor, psi: torch.Tensor, nlon_out: in
     on GPU, make sure to use the custom kernel written in CUDA.
     """
 
-    assert len(psi.shape) == 3
-    assert len(x.shape) == 4
+    torch._check(psi.dim() == 3, lambda: f"Expected 3-dimensional psi tensor, got {psi.dim()} dimensions")
+    torch._check(x.dim() == 4, lambda: f"Expected 4-dimensional input tensor, got {x.dim()} dimensions")
     psi = psi.to(x.device)
 
     batch_size, n_chans, nlat_in, nlon_in = x.shape
     kernel_size, nlat_out, _ = psi.shape
 
-    assert psi.shape[-1] == nlat_in * nlon_in
-    assert nlon_in % nlon_out == 0
-    assert nlon_in >= nlat_out
+    torch._check(psi.shape[-1] == nlat_in * nlon_in, lambda: f"Expected psi.shape[-1]=={nlat_in * nlon_in}, got {psi.shape[-1]}")
+    torch._check(nlon_in % nlon_out == 0, lambda: f"nlon_in ({nlon_in}) must be an integer multiple of nlon_out ({nlon_out})")
+    torch._check(nlon_in >= nlat_out, lambda: f"Expected nlon_in ({nlon_in}) >= nlat_out ({nlat_out})")
     pscale = nlon_in // nlon_out
 
     # add a dummy dimension for nkernel and move the batch and channel dims to the end
@@ -92,15 +92,15 @@ def _disco_s2_contraction_torch(x: torch.Tensor, psi: torch.Tensor, nlon_out: in
 
 # transpose convolution
 def _disco_s2_transpose_contraction_torch(x: torch.Tensor, psi: torch.Tensor, nlon_out: int):
-    assert len(psi.shape) == 3
-    assert len(x.shape) == 5
+    torch._check(psi.dim() == 3, lambda: f"Expected 3-dimensional psi tensor, got {psi.dim()} dimensions")
+    torch._check(x.dim() == 5, lambda: f"Expected 5-dimensional input tensor, got {x.dim()} dimensions")
     psi = psi.to(x.device)
 
     batch_size, n_chans, kernel_size, nlat_in, nlon_in = x.shape
     kernel_size, nlat_out, n_out = psi.shape
 
-    assert n_out % nlon_out == 0
-    assert nlon_out >= nlon_in
+    torch._check(n_out % nlon_out == 0, lambda: f"Expected n_out ({n_out}) to be an integer multiple of nlon_out ({nlon_out})")
+    torch._check(nlon_out >= nlon_in, lambda: f"Expected nlon_out ({nlon_out}) >= nlon_in ({nlon_in})")
     pscale = nlon_out // nlon_in
 
     # interleave zeros along the longitude dimension to allow for fractional offsets to be considered

--- a/torch_harmonics/distributed/distributed_attention.py
+++ b/torch_harmonics/distributed/distributed_attention.py
@@ -621,14 +621,15 @@ class DistributedNeighborhoodAttentionS2(NeighborhoodAttentionS2):
         if value is None:
             value = query
 
-        assert query.dim() == 4
-
-        if query.shape[-2] != self.nlat_out_local or query.shape[-1] != self.nlon_out_local:
-            raise ValueError(f"query spatial shape {(query.shape[-2], query.shape[-1])} does not match local out_shape {(self.nlat_out_local, self.nlon_out_local)}")
-        if key.shape[-2] != self.nlat_in_local or key.shape[-1] != self.nlon_in_local:
-            raise ValueError(f"key spatial shape {(key.shape[-2], key.shape[-1])} does not match local in_shape {(self.nlat_in_local, self.nlon_in_local)}")
-        if value.shape[-2] != self.nlat_in_local or value.shape[-1] != self.nlon_in_local:
-            raise ValueError(f"value spatial shape {(value.shape[-2], value.shape[-1])} does not match local in_shape {(self.nlat_in_local, self.nlon_in_local)}")
+        torch._check(query.dim() == 4, lambda: f"Expected 4-dimensional query tensor, got {query.dim()} dimensions")
+        torch._check(key.dim() == 4, lambda: f"Expected 4-dimensional key tensor, got {key.dim()} dimensions")
+        torch._check(value.dim() == 4, lambda: f"Expected 4-dimensional value tensor, got {value.dim()} dimensions")
+        torch._check(query.shape[-2] == self.nlat_out_local, lambda: f"Expected query latitudes shape[-2]=={self.nlat_out_local}, got {query.shape[-2]}")
+        torch._check(query.shape[-1] == self.nlon_out_local, lambda: f"Expected query longitudes shape[-1]=={self.nlon_out_local}, got {query.shape[-1]}")
+        torch._check(key.shape[-2] == self.nlat_in_local, lambda: f"Expected key latitudes shape[-2]=={self.nlat_in_local}, got {key.shape[-2]}")
+        torch._check(key.shape[-1] == self.nlon_in_local, lambda: f"Expected key longitudes shape[-1]=={self.nlon_in_local}, got {key.shape[-1]}")
+        torch._check(value.shape[-2] == self.nlat_in_local, lambda: f"Expected value latitudes shape[-2]=={self.nlat_in_local}, got {value.shape[-2]}")
+        torch._check(value.shape[-1] == self.nlon_in_local, lambda: f"Expected value longitudes shape[-1]=={self.nlon_in_local}, got {value.shape[-1]}")
 
         # ---- 1. project to k/v/q ----
         key_proj = nn.functional.conv2d(key, self.k_weights, bias=self.k_bias)

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -220,13 +220,13 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
         # at construction rather than first forward.
         if self.method == "ring":
             if not torch.cuda.is_available():
-                raise ValueError(
+                raise NotImplementedError(
                     "DistributedDiscreteContinuousConvS2(method='ring') is CUDA-only: "
                     "the ring loop relies on dist.batch_isend_irecv (NCCL) and the "
                     "per-step kernels are CUDA ops. Use method='a2a' for CPU/gloo backends."
                 )
             if not optimized_kernels_is_available():
-                raise ValueError(
+                raise NotImplementedError(
                     "DistributedDiscreteContinuousConvS2(method='ring') requires the "
                     "optimized ring-step CUDA kernels "
                     "(_disco_s2_contraction_ring_step_optimized and its transpose "
@@ -234,7 +234,7 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
                     "optimized DISCO library or use method='a2a'."
                 )
             if not optimized_kernel:
-                raise ValueError("DistributedDiscreteContinuousConvS2(method='ring') requires optimized_kernel=True (the ring step is CUDA-only).")
+                raise NotImplementedError("DistributedDiscreteContinuousConvS2(method='ring') requires optimized_kernel=True (the ring step is CUDA-only).")
 
         self.nlat_in, self.nlon_in = in_shape
         self.nlat_out, self.nlon_out = out_shape

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -219,19 +219,22 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
         # Assert their availability up front so misconfigured builds fail
         # at construction rather than first forward.
         if self.method == "ring":
-            assert torch.cuda.is_available(), (
-                "DistributedDiscreteContinuousConvS2(method='ring') is CUDA-only: "
-                "the ring loop relies on dist.batch_isend_irecv (NCCL) and the "
-                "per-step kernels are CUDA ops. Use method='a2a' for CPU/gloo backends."
-            )
-            assert optimized_kernels_is_available(), (
-                "DistributedDiscreteContinuousConvS2(method='ring') requires the "
-                "optimized ring-step CUDA kernels "
-                "(_disco_s2_contraction_ring_step_optimized and its transpose "
-                "variant), but they are not present in this build. Rebuild the "
-                "optimized DISCO library or use method='a2a'."
-            )
-            assert optimized_kernel, "DistributedDiscreteContinuousConvS2(method='ring') requires " "optimized_kernel=True (the ring step is CUDA-only)."
+            if not torch.cuda.is_available():
+                raise ValueError(
+                    "DistributedDiscreteContinuousConvS2(method='ring') is CUDA-only: "
+                    "the ring loop relies on dist.batch_isend_irecv (NCCL) and the "
+                    "per-step kernels are CUDA ops. Use method='a2a' for CPU/gloo backends."
+                )
+            if not optimized_kernels_is_available():
+                raise ValueError(
+                    "DistributedDiscreteContinuousConvS2(method='ring') requires the "
+                    "optimized ring-step CUDA kernels "
+                    "(_disco_s2_contraction_ring_step_optimized and its transpose "
+                    "variant), but they are not present in this build. Rebuild the "
+                    "optimized DISCO library or use method='a2a'."
+                )
+            if not optimized_kernel:
+                raise ValueError("DistributedDiscreteContinuousConvS2(method='ring') requires optimized_kernel=True (the ring step is CUDA-only).")
 
         self.nlat_in, self.nlon_in = in_shape
         self.nlat_out, self.nlon_out = out_shape

--- a/torch_harmonics/distributed/distributed_sht.py
+++ b/torch_harmonics/distributed/distributed_sht.py
@@ -133,11 +133,9 @@ class DistributedRealSHT(nn.Module):
 
     def forward(self, x: torch.Tensor):
 
-        if x.dim() < 3:
-            raise ValueError(f"Expected tensor with at least 3 dimensions but got {x.dim()} instead")
-
-        assert x.shape[-2] == self.nlat_local
-        assert x.shape[-1] == self.nlon_local
+        torch._check(x.dim() >= 3, lambda: f"Expected tensor with at least 3 dimensions but got {x.dim()} instead")
+        torch._check(x.shape[-2] == self.nlat_local, lambda: f"Expected latitudes shape[-2]=={self.nlat_local}, got {x.shape[-2]}")
+        torch._check(x.shape[-1] == self.nlon_local, lambda: f"Expected longitudes shape[-1]=={self.nlon_local}, got {x.shape[-1]}")
 
         # we need to ensure that we can split the channels evenly
         num_chans = x.shape[-3]
@@ -266,11 +264,9 @@ class DistributedInverseRealSHT(nn.Module):
 
     def forward(self, x: torch.Tensor):
 
-        if x.dim() < 3:
-            raise ValueError(f"Expected tensor with at least 3 dimensions but got {x.dim()} instead")
-
-        assert x.shape[-2] == self.lmax_local
-        assert x.shape[-1] == self.mmax_local
+        torch._check(x.dim() >= 3, lambda: f"Expected tensor with at least 3 dimensions but got {x.dim()} instead")
+        torch._check(x.shape[-2] == self.lmax_local, lambda: f"Expected spherical harmonic degrees (lmax) shape[-2]=={self.lmax_local}, got {x.shape[-2]}")
+        torch._check(x.shape[-1] == self.mmax_local, lambda: f"Expected spherical harmonic orders (mmax) shape[-1]=={self.mmax_local}, got {x.shape[-1]}")
 
         # we need to ensure that we can split the channels evenly
         num_chans = x.shape[-3]
@@ -407,12 +403,10 @@ class DistributedRealVectorSHT(nn.Module):
 
     def forward(self, x: torch.Tensor):
 
-        if x.dim() < 4:
-            raise ValueError(f"Expected tensor with at least 4 dimensions but got {x.dim()} instead")
-
-        assert x.shape[-3] == 2
-        assert x.shape[-2] == self.nlat_local
-        assert x.shape[-1] == self.nlon_local
+        torch._check(x.dim() >= 4, lambda: f"Expected tensor with at least 4 dimensions but got {x.dim()} instead")
+        torch._check(x.shape[-3] == 2, lambda: f"Expected vector field shape[-3]==2, got {x.shape[-3]}")
+        torch._check(x.shape[-2] == self.nlat_local, lambda: f"Expected latitudes shape[-2]=={self.nlat_local}, got {x.shape[-2]}")
+        torch._check(x.shape[-1] == self.nlon_local, lambda: f"Expected longitudes shape[-1]=={self.nlon_local}, got {x.shape[-1]}")
 
         # we need to ensure that we can split the channels evenly
         num_chans = x.shape[-4]
@@ -547,12 +541,10 @@ class DistributedInverseRealVectorSHT(nn.Module):
 
     def forward(self, x: torch.Tensor):
 
-        if x.dim() < 4:
-            raise ValueError(f"Expected tensor with at least 4 dimensions but got {x.dim()} instead")
-
-        assert x.shape[-3] == 2
-        assert x.shape[-2] == self.lmax_local
-        assert x.shape[-1] == self.mmax_local
+        torch._check(x.dim() >= 4, lambda: f"Expected tensor with at least 4 dimensions but got {x.dim()} instead")
+        torch._check(x.shape[-3] == 2, lambda: f"Expected vector field shape[-3]==2, got {x.shape[-3]}")
+        torch._check(x.shape[-2] == self.lmax_local, lambda: f"Expected spherical harmonic degrees (lmax) shape[-2]=={self.lmax_local}, got {x.shape[-2]}")
+        torch._check(x.shape[-1] == self.mmax_local, lambda: f"Expected spherical harmonic orders (mmax) shape[-1]=={self.mmax_local}, got {x.shape[-1]}")
 
         # store num channels
         num_chans = x.shape[-4]

--- a/torch_harmonics/distributed/distributed_spectral_convolution.py
+++ b/torch_harmonics/distributed/distributed_spectral_convolution.py
@@ -103,8 +103,10 @@ class DistributedSpectralConvS2(nn.Module):
     ):
         super().__init__()
 
-        assert in_channels % num_groups == 0
-        assert out_channels % num_groups == 0
+        if in_channels % num_groups != 0:
+            raise ValueError(f"in_channels ({in_channels}) must be divisible by num_groups ({num_groups})")
+        if out_channels % num_groups != 0:
+            raise ValueError(f"out_channels ({out_channels}) must be divisible by num_groups ({num_groups})")
 
         # copy inputs
         self.in_channels = in_channels

--- a/torch_harmonics/distributed/primitives.py
+++ b/torch_harmonics/distributed/primitives.py
@@ -58,7 +58,7 @@ def _check_shapes(msg, shapes_gather, shapes_expected):
 def compute_split_shapes(size: int, num_chunks: int) -> List[int]:
     """Compute the split shapes for a given size and number of chunks."""
 
-    assert size >= num_chunks, f"Cannot split {size} elements into {num_chunks} chunks; " f"every chunk must be non-empty."
+    torch._check(size >= num_chunks, lambda: f"Cannot split {size} elements into {num_chunks} chunks; every chunk must be non-empty.")
 
     base, remainder = divmod(size, num_chunks)
     return [base + 1] * remainder + [base] * (num_chunks - remainder)
@@ -67,11 +67,10 @@ def compute_split_shapes(size: int, num_chunks: int) -> List[int]:
 def split_tensor_along_dim(tensor, dim, num_chunks):
     """Split a tensor along a given dimension into a given number of chunks."""
 
-    assert dim < tensor.dim(), f"Error, tensor dimension is {tensor.dim()} which cannot be split along {dim}"
-    assert (
-        tensor.shape[dim] >= num_chunks
-    ), f"Error, cannot split dim {dim} of size {tensor.shape[dim]} into \
-                                              {num_chunks} chunks. Empty slices are currently not supported."
+    torch._check(dim < tensor.dim(), lambda: f"Error, tensor dimension is {tensor.dim()} which cannot be split along {dim}")
+    torch._check(
+        tensor.shape[dim] >= num_chunks, lambda: f"Error, cannot split dim {dim} of size {tensor.shape[dim]} into {num_chunks} chunks. Empty slices are currently not supported."
+    )
 
     # get split
     sections = compute_split_shapes(tensor.shape[dim], num_chunks)

--- a/torch_harmonics/examples/models/_layers.py
+++ b/torch_harmonics/examples/models/_layers.py
@@ -195,7 +195,8 @@ class PatchEmbed(nn.Module):
 
         # gather input
         B, C, H, W = x.shape
-        assert H == self.img_size[0] and W == self.img_size[1], f"Input image size ({H}*{W}) doesn't match model ({self.img_size[0]}*{self.img_size[1]})."
+        torch._check(H == self.img_size[0], lambda: f"Input image height ({H}) doesn't match model ({self.img_size[0]}).")
+        torch._check(W == self.img_size[1], lambda: f"Input image width ({W}) doesn't match model ({self.img_size[1]}).")
         # new: B, C, H*W
         x = self.proj(x).flatten(2)
         return x
@@ -413,9 +414,6 @@ class SpectralConvS2(nn.Module):
 
         # remember factorization details
         self.operator_type = operator_type
-
-        assert self.inverse_transform.lmax == self.modes_lat
-        assert self.inverse_transform.mmax == self.modes_lon
 
         weight_shape = [out_channels, in_channels]
 

--- a/torch_harmonics/examples/models/lsno.py
+++ b/torch_harmonics/examples/models/lsno.py
@@ -302,7 +302,8 @@ class SphericalNeuralOperatorBlock(nn.Module):
             self.inner_skip = nn.Conv2d(input_dim, output_dim, 1, 1)
             nn.init.normal_(self.inner_skip.weight, std=math.sqrt(gain_factor / input_dim))
         elif inner_skip == "identity":
-            assert input_dim == output_dim
+            if input_dim != output_dim:
+                raise ValueError(f"inner_skip='identity' requires input_dim == output_dim, got input_dim={input_dim}, output_dim={output_dim}")
             self.inner_skip = nn.Identity()
         elif inner_skip == "none":
             pass
@@ -342,7 +343,8 @@ class SphericalNeuralOperatorBlock(nn.Module):
             self.outer_skip = nn.Conv2d(input_dim, input_dim, 1, 1)
             torch.nn.init.normal_(self.outer_skip.weight, std=math.sqrt(gain_factor / input_dim))
         elif outer_skip == "identity":
-            assert input_dim == output_dim
+            if input_dim != output_dim:
+                raise ValueError(f"outer_skip='identity' requires input_dim == output_dim, got input_dim={input_dim}, output_dim={output_dim}")
             self.outer_skip = nn.Identity()
         elif outer_skip == "none":
             pass

--- a/torch_harmonics/examples/models/s2segformer.py
+++ b/torch_harmonics/examples/models/s2segformer.py
@@ -410,7 +410,8 @@ class TransformerBlock(nn.Module):
         if isinstance(drop_path_rates, float):
             drop_path_rates = [x.item() for x in torch.linspace(0, drop_path_rates, nrep)]
 
-        assert len(drop_path_rates) == nrep
+        if len(drop_path_rates) != nrep:
+            raise ValueError(f"drop_path_rates must have length {nrep}, got {len(drop_path_rates)}")
 
         self.fwd = [
             OverlapPatchMerging(
@@ -677,8 +678,10 @@ class SphericalSegformer(nn.Module):
         self.depths = depths
         self.kernel_shape = kernel_shape
 
-        assert len(self.heads) == self.num_blocks
-        assert len(self.depths) == self.num_blocks
+        if len(self.heads) != self.num_blocks:
+            raise ValueError(f"heads must have length num_blocks={self.num_blocks}, got {len(self.heads)}")
+        if len(self.depths) != self.num_blocks:
+            raise ValueError(f"depths must have length num_blocks={self.num_blocks}, got {len(self.depths)}")
 
         # activation function
         if activation_function == "relu":

--- a/torch_harmonics/examples/models/s2unet.py
+++ b/torch_harmonics/examples/models/s2unet.py
@@ -488,7 +488,8 @@ class SphericalUNet(nn.Module):
         self.depths = depths
         self.kernel_shape = kernel_shape
 
-        assert len(self.depths) == self.num_blocks
+        if len(self.depths) != self.num_blocks:
+            raise ValueError(f"depths must have length num_blocks={self.num_blocks}, got {len(self.depths)}")
 
         # activation function
         if activation_function == "relu":

--- a/torch_harmonics/examples/models/sfno.py
+++ b/torch_harmonics/examples/models/sfno.py
@@ -108,7 +108,8 @@ class SphericalFourierNeuralOperatorBlock(nn.Module):
             self.inner_skip = nn.Conv2d(input_dim, output_dim, 1, 1)
             nn.init.normal_(self.inner_skip.weight, std=math.sqrt(gain_factor / input_dim))
         elif inner_skip == "identity":
-            assert input_dim == output_dim
+            if input_dim != output_dim:
+                raise ValueError(f"inner_skip='identity' requires input_dim == output_dim, got input_dim={input_dim}, output_dim={output_dim}")
             self.inner_skip = nn.Identity()
         elif inner_skip == "none":
             pass
@@ -142,7 +143,8 @@ class SphericalFourierNeuralOperatorBlock(nn.Module):
             self.outer_skip = nn.Conv2d(input_dim, input_dim, 1, 1)
             torch.nn.init.normal_(self.outer_skip.weight, std=math.sqrt(gain_factor / input_dim))
         elif outer_skip == "identity":
-            assert input_dim == output_dim
+            if input_dim != output_dim:
+                raise ValueError(f"outer_skip='identity' requires input_dim == output_dim, got input_dim={input_dim}, output_dim={output_dim}")
             self.outer_skip = nn.Identity()
         elif outer_skip == "none":
             pass

--- a/torch_harmonics/quadrature.py
+++ b/torch_harmonics/quadrature.py
@@ -261,7 +261,8 @@ def clenshaw_curtiss_weights(n: int, a: Optional[float] = -1.0, b: Optional[floa
     [1] Joerg Waldvogel, Fast Construction of the Fejer and Clenshaw-Curtis Quadrature Rules; BIT Numerical Mathematics, Vol. 43, No. 1, pp. 001–018.
     """
 
-    assert n > 1
+    if n <= 1:
+        raise ValueError(f"n must be greater than 1, got {n}")
 
     tcc = torch.cos(torch.linspace(math.pi, 0, n, dtype=torch.float64, requires_grad=False))
 

--- a/torch_harmonics/random_fields.py
+++ b/torch_harmonics/random_fields.py
@@ -64,7 +64,8 @@ class GaussianRandomFieldS2(torch.nn.Module):
 
         # Default value of sigma if None is given.
         if sigma is None:
-            assert alpha > 1.0, f"Alpha must be greater than one, got {alpha}."
+            if alpha <= 1.0:
+                raise ValueError(f"Alpha must be greater than one, got {alpha}.")
             sigma = tau ** (0.5 * (2 * alpha - 2.0))
 
         # Inverse SHT

--- a/torch_harmonics/sht.py
+++ b/torch_harmonics/sht.py
@@ -112,11 +112,9 @@ class RealSHT(nn.Module):
 
     def forward(self, x: torch.Tensor):
 
-        if x.dim() < 2:
-            raise ValueError(f"Expected tensor with at least 2 dimensions but got {x.dim()} instead")
-
-        assert x.shape[-2] == self.nlat
-        assert x.shape[-1] == self.nlon
+        torch._check(x.dim() >= 2, lambda: f"Expected tensor with at least 2 dimensions but got {x.dim()} instead")
+        torch._check(x.shape[-2] == self.nlat, lambda: f"Expected latitudes shape[-2]=={self.nlat}, got {x.shape[-2]}")
+        torch._check(x.shape[-1] == self.nlon, lambda: f"Expected longitudes shape[-1]=={self.nlon}, got {x.shape[-1]}")
 
         # apply real fft in the longitudinal direction
         x = 2.0 * torch.pi * rfft(x, nmodes=self.mmax, dim=-1, norm="forward")
@@ -210,11 +208,9 @@ class InverseRealSHT(nn.Module):
 
     def forward(self, x: torch.Tensor):
 
-        if len(x.shape) < 2:
-            raise ValueError(f"Expected tensor with at least 2 dimensions but got {len(x.shape)} instead")
-
-        assert x.shape[-2] == self.lmax
-        assert x.shape[-1] == self.mmax
+        torch._check(x.dim() >= 2, lambda: f"Expected tensor with at least 2 dimensions but got {x.dim()} instead")
+        torch._check(x.shape[-2] == self.lmax, lambda: f"Expected spherical harmonic degrees (lmax) shape[-2]=={self.lmax}, got {x.shape[-2]}")
+        torch._check(x.shape[-1] == self.mmax, lambda: f"Expected spherical harmonic orders (mmax) shape[-1]=={self.mmax}, got {x.shape[-1]}")
 
         # transpose to put the contraction dim (lmax) on the fast axis
         x = x.transpose(-1, -2)
@@ -313,12 +309,10 @@ class RealVectorSHT(nn.Module):
 
     def forward(self, x: torch.Tensor):
 
-        if x.dim() < 3:
-            raise ValueError(f"Expected tensor with at least 3 dimensions but got {x.dim()} instead")
-
-        assert x.shape[-3] == 2
-        assert x.shape[-2] == self.nlat
-        assert x.shape[-1] == self.nlon
+        torch._check(x.dim() >= 3, lambda: f"Expected tensor with at least 3 dimensions but got {x.dim()} instead")
+        torch._check(x.shape[-3] == 2, lambda: f"Expected vector field shape[-3]==2, got {x.shape[-3]}")
+        torch._check(x.shape[-2] == self.nlat, lambda: f"Expected latitudes shape[-2]=={self.nlat}, got {x.shape[-2]}")
+        torch._check(x.shape[-1] == self.nlon, lambda: f"Expected longitudes shape[-1]=={self.nlon}, got {x.shape[-1]}")
 
         # apply real fft in the longitudinal direction
         x = 2.0 * torch.pi * rfft(x, nmodes=self.mmax, dim=-1, norm="forward")
@@ -414,12 +408,10 @@ class InverseRealVectorSHT(nn.Module):
 
     def forward(self, x: torch.Tensor):
 
-        if x.dim() < 3:
-            raise ValueError(f"Expected tensor with at least 3 dimensions but got {x.dim()} instead")
-
-        assert x.shape[-3] == 2
-        assert x.shape[-2] == self.lmax
-        assert x.shape[-1] == self.mmax
+        torch._check(x.dim() >= 3, lambda: f"Expected tensor with at least 3 dimensions but got {x.dim()} instead")
+        torch._check(x.shape[-3] == 2, lambda: f"Expected vector field shape[-3]==2, got {x.shape[-3]}")
+        torch._check(x.shape[-2] == self.lmax, lambda: f"Expected spherical harmonic degrees (lmax) shape[-2]=={self.lmax}, got {x.shape[-2]}")
+        torch._check(x.shape[-1] == self.mmax, lambda: f"Expected spherical harmonic orders (mmax) shape[-1]=={self.mmax}, got {x.shape[-1]}")
 
         # transpose to put the contraction dim (lmax) on the fast axis
         x = x.transpose(-1, -2)

--- a/torch_harmonics/spectral_convolution.py
+++ b/torch_harmonics/spectral_convolution.py
@@ -98,8 +98,10 @@ class SpectralConvS2(nn.Module):
     ):
         super().__init__()
 
-        assert in_channels % num_groups == 0
-        assert out_channels % num_groups == 0
+        if in_channels % num_groups != 0:
+            raise ValueError(f"in_channels ({in_channels}) must be divisible by num_groups ({num_groups})")
+        if out_channels % num_groups != 0:
+            raise ValueError(f"out_channels ({out_channels}) must be divisible by num_groups ({num_groups})")
 
         # copy inputs
         self.in_channels = in_channels


### PR DESCRIPTION
This MR replaces all asserts in the forward pass with torch._check and all asserts in non critical paths with raise ValueError for consistent error reporting. In compiled code, all remaining (dynamic) asserts were converted into TORCH_CHECK macros.

Adresses concerns in https://github.com/NVIDIA/torch-harmonics/issues/209