### PR TITLE
adding row-split caching

### DIFF
--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -805,13 +805,37 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
         nnz_per_row = (att.psi_roff_idx[1:] - att.psi_roff_idx[:-1]).cpu()
         row_idx_kernel = torch.argsort(nnz_per_row, descending=True).to(torch.int32).to(self.device)
 
+        # Precomputed CSR row split, threaded into every ring-step op (constant for a
+        # fixed psi; see split_csr_rows_op / _row_split in distributed_attention.py).
+        n_long_rows, max_row_len, mid_row_len = torch.ops.attention_kernels.split_csr_rows(row_idx_kernel, att.psi_roff_idx, nlat_out)
+
         # ---- forward ring step ----
         # State buffers in channels-last layout, as expected by the CUDA kernels.
         y_acc = torch.zeros(Bnh, nlat_out, nlon_out, C_v, device=self.device, dtype=torch.float32)
         alpha_sum = torch.zeros(Bnh, nlat_out, nlon_out, device=self.device, dtype=torch.float32)
         qdotk_max = torch.full((Bnh, nlat_out, nlon_out), float("-inf"), device=self.device, dtype=torch.float32)
 
-        fwd_inputs = (kw, vw, qw, y_acc, alpha_sum, qdotk_max, att.quad_weights, att.psi_col_idx, att.psi_roff_idx, row_idx_kernel, nlon_in, pscale, 0, 0, nlat_out, nlon_out)
+        fwd_inputs = (
+            kw,
+            vw,
+            qw,
+            y_acc,
+            alpha_sum,
+            qdotk_max,
+            att.quad_weights,
+            att.psi_col_idx,
+            att.psi_roff_idx,
+            row_idx_kernel,
+            nlon_in,
+            pscale,
+            0,
+            0,
+            nlat_out,
+            nlon_out,
+            n_long_rows,
+            max_row_len,
+            mid_row_len,
+        )
 
         opcheck(torch.ops.attention_kernels.forward_ring_step, fwd_inputs)
 
@@ -844,6 +868,9 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
             0,
             nlat_out,
             nlon_out,
+            n_long_rows,
+            max_row_len,
+            mid_row_len,
         )
 
         opcheck(torch.ops.attention_kernels.backward_ring_step_pass1, bwd1_inputs)
@@ -879,6 +906,9 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
             0,
             nlat_out,
             nlon_out,
+            n_long_rows,
+            max_row_len,
+            mid_row_len,
         )
 
         opcheck(torch.ops.attention_kernels.backward_ring_step_pass2, bwd2_inputs)

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -1030,5 +1030,62 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
             model(q, kv, q)
 
 
+class TestSplitCsrRows(unittest.TestCase):
+    """The split_csr_rows op has two implementations: a CPU host scan (used by the
+    DistributedNeighborhoodAttentionS2 constructor, which runs on the still-on-CPU
+    psi buffers) and the original CUDA kernel. They must select identical long/short
+    row splits, otherwise the constructor (CPU) and any device-side call would size
+    the ring kernels differently."""
+
+    @staticmethod
+    def _build_csr(row_lengths):
+        """Build (row_idx int32 sorted by decreasing length, row_off int64 prefix sum)
+        from a 1D tensor of per-row nnz — mirrors how _build_local_psi constructs them."""
+        rl = torch.as_tensor(row_lengths, dtype=torch.int64)
+        n = rl.numel()
+        row_off = torch.zeros(n + 1, dtype=torch.int64)
+        torch.cumsum(rl, dim=0, out=row_off[1:])
+        row_idx = torch.argsort(rl, descending=True).to(torch.int32)
+        return row_idx, row_off
+
+    @parameterized.expand(
+        [
+            # name, per-row lengths
+            ["all_short_uniform", [16] * 32],
+            ["all_short_varied", [3, 7, 1, 12, 5, 9, 2, 8, 4, 11]],
+            ["all_equal", [512] * 20],
+            ["single_row", [777]],
+            # long rows present: lengths above the SPLIT_LONG_ROW_MIN_LEN (1024) floor
+            ["one_long_rest_short", [4096] + [16] * 31],
+            ["several_long_floor_1024", [2048, 1536, 1100, 1024, 64, 32, 16, 8]],
+            # threshold branch dominates the floor (0.1 * max_rlen > 1024)
+            ["thres_branch_above_floor", [40000, 39000, 12000, 5000, 100, 50, 10]],
+            # boundary: a row exactly at the floor
+            ["exactly_at_floor", [1024, 1024, 1023, 512, 1]],
+            ["descending_ramp", list(range(200, 0, -1))],
+        ],
+        skip_on_empty=True,
+    )
+    @unittest.skipUnless(optimized_kernels_is_available(), "skipping test because optimized kernels are not available")
+    def test_cpu_cuda_equivalence(self, name, row_lengths):
+        if not (torch.cuda.is_available() and cuda_kernels_is_available()):
+            raise unittest.SkipTest("split_csr_rows CPU/CUDA comparison requires CUDA kernels")
+
+        row_idx, row_off = self._build_csr(row_lengths)
+        nlat_out = row_idx.numel()
+
+        cpu_out = torch.ops.attention_kernels.split_csr_rows(row_idx, row_off, nlat_out)
+        cuda_out = torch.ops.attention_kernels.split_csr_rows(row_idx.cuda(), row_off.cuda(), nlat_out)
+
+        cpu_out = tuple(int(x) for x in cpu_out)
+        cuda_out = tuple(int(x) for x in cuda_out)
+
+        self.assertEqual(
+            cpu_out,
+            cuda_out,
+            msg=f"[{name}] CPU split {cpu_out} != CUDA split {cuda_out} " f"(n_long_rows, max_row_len, mid_row_len)",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torch_harmonics/attention/optimized/attention_interface.cpp
+++ b/torch_harmonics/attention/optimized/attention_interface.cpp
@@ -97,12 +97,13 @@ namespace attention_kernels
         // col_idx must have wi pre-shifted by pscale * lon_lo_out — see
         // _build_local_psi in distributed_attention.py.
         // split_csr_rows precomputes the long/short row split for a fixed psi
-        // (returns n_long_rows, max_row_len, mid_row_len). Called once at setup;
-        // the result is passed into the ring-step ops below as the trailing
-        // (n_long_rows, max_row_len, mid_row_len) ints, hoisting it out of the
-        // per-step hot path (where it otherwise cost a 24-byte D2H sync/step).
-        m.def("split_csr_rows(Tensor row_idx, Tensor row_off, int nlat_out) -> (int, int, int)",
-              {at::Tag::pt2_compliant_tag});
+        // (returns n_long_rows, max_row_len, mid_row_len). Called once from the
+        // module constructor; the result is passed into the ring-step ops below
+        // as the trailing (n_long_rows, max_row_len, mid_row_len) ints, hoisting
+        // it out of the per-step hot path (where it otherwise cost a 24-byte D2H
+        // sync/step). NOT pt2-compliant and intentionally has no fake/meta impl:
+        // it is a setup-time host-side scalar computation that is never traced.
+        m.def("split_csr_rows(Tensor row_idx, Tensor row_off, int nlat_out) -> (int, int, int)");
         m.def("forward_ring_step(Tensor kx, Tensor vx, Tensor qy, Tensor(a!) y_acc, Tensor(b!) alpha_sum_buf, "
               "Tensor(c!) qdotk_max_buf, Tensor quad_weights, Tensor col_idx, Tensor row_off, Tensor row_idx, int "
               "nlon_in, int pscale, int lon_lo_kx, int lat_halo_start, int nlat_out, int nlon_out, int n_long_rows, "

--- a/torch_harmonics/attention/optimized/attention_interface.cpp
+++ b/torch_harmonics/attention/optimized/attention_interface.cpp
@@ -96,9 +96,17 @@ namespace attention_kernels
         // LOCAL output width and would give the wrong ratio when az_size > 1).
         // col_idx must have wi pre-shifted by pscale * lon_lo_out — see
         // _build_local_psi in distributed_attention.py.
+        // split_csr_rows precomputes the long/short row split for a fixed psi
+        // (returns n_long_rows, max_row_len, mid_row_len). Called once at setup;
+        // the result is passed into the ring-step ops below as the trailing
+        // (n_long_rows, max_row_len, mid_row_len) ints, hoisting it out of the
+        // per-step hot path (where it otherwise cost a 24-byte D2H sync/step).
+        m.def("split_csr_rows(Tensor row_idx, Tensor row_off, int nlat_out) -> (int, int, int)",
+              {at::Tag::pt2_compliant_tag});
         m.def("forward_ring_step(Tensor kx, Tensor vx, Tensor qy, Tensor(a!) y_acc, Tensor(b!) alpha_sum_buf, "
               "Tensor(c!) qdotk_max_buf, Tensor quad_weights, Tensor col_idx, Tensor row_off, Tensor row_idx, int "
-              "nlon_in, int pscale, int lon_lo_kx, int lat_halo_start, int nlat_out, int nlon_out) -> ()",
+              "nlon_in, int pscale, int lon_lo_kx, int lat_halo_start, int nlat_out, int nlon_out, int n_long_rows, "
+              "int max_row_len, int mid_row_len) -> ()",
               {at::Tag::pt2_compliant_tag});
         // Backward is split into two passes: pass1 finalizes per-output softmax
         // statistics (alpha_sum, qdotk_max, integral, alpha_k, alpha_kvw), pass2
@@ -106,12 +114,13 @@ namespace attention_kernels
         m.def("backward_ring_step_pass1(Tensor kx, Tensor vx, Tensor qy, Tensor dy, Tensor(a!) alpha_sum_buf, "
               "Tensor(b!) qdotk_max_buf, Tensor(c!) integral_buf, Tensor(d!) alpha_k_buf, Tensor(e!) alpha_kvw_buf, "
               "Tensor quad_weights, Tensor col_idx, Tensor row_off, Tensor row_idx, int nlon_in, int pscale, int "
-              "lon_lo_kx, int lat_halo_start, int nlat_out, int nlon_out) -> ()",
+              "lon_lo_kx, int lat_halo_start, int nlat_out, int nlon_out, int n_long_rows, int max_row_len, int "
+              "mid_row_len) -> ()",
               {at::Tag::pt2_compliant_tag});
         m.def("backward_ring_step_pass2(Tensor kx, Tensor vx, Tensor qy, Tensor dy, Tensor alpha_sum_buf, Tensor "
               "qdotk_max_buf, Tensor integral_norm_buf, Tensor(a!) dkx, Tensor(b!) dvx, Tensor quad_weights, Tensor "
               "col_idx, Tensor row_off, Tensor row_idx, int nlon_in, int pscale, int lon_lo_kx, int lat_halo_start, "
-              "int nlat_out, int nlon_out) -> ()",
+              "int nlat_out, int nlon_out, int n_long_rows, int max_row_len, int mid_row_len) -> ()",
               {at::Tag::pt2_compliant_tag});
     }
 

--- a/torch_harmonics/attention/optimized/attention_optimized.py
+++ b/torch_harmonics/attention/optimized/attention_optimized.py
@@ -85,6 +85,9 @@ if optimized_kernels_is_available():
         lat_halo_start: int,
         nlat_out: int,
         nlon_out: int,
+        n_long_rows: int,
+        max_row_len: int,
+        mid_row_len: int,
     ) -> None:
         pass
 
@@ -109,6 +112,9 @@ if optimized_kernels_is_available():
         lat_halo_start: int,
         nlat_out: int,
         nlon_out: int,
+        n_long_rows: int,
+        max_row_len: int,
+        mid_row_len: int,
     ) -> None:
         pass
 
@@ -133,6 +139,9 @@ if optimized_kernels_is_available():
         lat_halo_start: int,
         nlat_out: int,
         nlon_out: int,
+        n_long_rows: int,
+        max_row_len: int,
+        mid_row_len: int,
     ) -> None:
         pass
 

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda.cuh
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda.cuh
@@ -57,20 +57,23 @@ namespace attention_kernels
                                          at::Tensor alpha_sum_buf, at::Tensor qdotk_max_buf, at::Tensor quad_weights,
                                          at::Tensor psi_col_idx, at::Tensor psi_row_off, at::Tensor psi_row_idx,
                                          int64_t nlon_in, int64_t pscale, int64_t lon_lo_kx, int64_t lat_halo_start,
-                                         int64_t nlat_out, int64_t nlon_out);
+                                         int64_t nlat_out, int64_t nlon_out, int64_t n_long_rows, int64_t max_row_len,
+                                         int64_t mid_row_len);
 
     void s2_attention_bwd_ring_step_pass1_cuda(at::Tensor kx, at::Tensor vx, at::Tensor qy, at::Tensor dy,
                                                at::Tensor alpha_sum_buf, at::Tensor qdotk_max_buf,
                                                at::Tensor integral_buf, at::Tensor alpha_k_buf, at::Tensor alpha_kvw_buf,
                                                at::Tensor quad_weights, at::Tensor psi_col_idx, at::Tensor psi_row_off,
                                                at::Tensor psi_row_idx, int64_t nlon_in, int64_t pscale, int64_t lon_lo_kx,
-                                               int64_t lat_halo_start, int64_t nlat_out, int64_t nlon_out);
+                                               int64_t lat_halo_start, int64_t nlat_out, int64_t nlon_out,
+                                               int64_t n_long_rows, int64_t max_row_len, int64_t mid_row_len);
 
     void s2_attention_bwd_ring_step_pass2_cuda(at::Tensor kx, at::Tensor vx, at::Tensor qy, at::Tensor dy,
                                                at::Tensor alpha_sum_buf, at::Tensor qdotk_max_buf,
                                                at::Tensor integral_norm_buf, at::Tensor dkx, at::Tensor dvx,
                                                at::Tensor quad_weights, at::Tensor psi_col_idx, at::Tensor psi_row_off,
                                                at::Tensor psi_row_idx, int64_t nlon_in, int64_t pscale, int64_t lon_lo_kx,
-                                               int64_t lat_halo_start, int64_t nlat_out, int64_t nlon_out);
+                                               int64_t lat_halo_start, int64_t nlat_out, int64_t nlon_out,
+                                               int64_t n_long_rows, int64_t max_row_len, int64_t mid_row_len);
 
 } // namespace attention_kernels

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_bwd_ring.cu
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_bwd_ring.cu
@@ -1022,19 +1022,16 @@ namespace attention_kernels
             // const int nchans_in  = params.nchan_in;
             const int nchans_out = params.nchan_out;
 
-            int64_t n_long_rows;
-            int64_t max_row_len;
-            int64_t mid_row_len;
-
-            // splits the rows in "long" and "short" rows; long rows have
-            // a length >= max(SPLIT_LONG_ROW_MIN_LEN(1024), len(row_0))
-            // (since the rows are sorted in decreasing order, row_0 is the
-            // longest row); short rows are the remaining rows.
-            // If there are long rows, they are processed with a separate
-            // kernels using multiple blocks per row, in order to mitigate
-            // the imbalance causing long temporal tails.
-            split_csr_rows(SPLIT_ROW_LENGTH_THRES, SPLIT_LONG_ROW_MIN_LEN, nlat_out, _row_idx, _row_off, &n_long_rows,
-                           &max_row_len, &mid_row_len);
+            // Row split precomputed once at setup and threaded in via params —
+            // see split_csr_rows / split_csr_rows_op. long rows have a length
+            // >= max(SPLIT_LONG_ROW_MIN_LEN(1024), len(row_0)) (rows are sorted
+            // in decreasing order, so row_0 is the longest); short rows are the
+            // remaining rows. If there are long rows, they are processed with a
+            // separate kernel using multiple blocks per row, to mitigate the
+            // imbalance causing long temporal tails.
+            const int64_t n_long_rows = params.n_long_rows;
+            const int64_t max_row_len = params.max_row_len;
+            const int64_t mid_row_len = params.mid_row_len;
 
             if (n_long_rows > 0) {
                 // processes the "long rows", from _row_idx[0] to _row_idx[n_long_rows-1]
@@ -1107,7 +1104,7 @@ namespace attention_kernels
         int64_t nlon_kx, int64_t lon_lo_kx, int64_t lat_halo_start, int64_t nlat_out, int64_t nlon_out, at::Tensor kxP,
         at::Tensor vxP, at::Tensor qyP, at::Tensor dyP, at::Tensor row_idx, at::Tensor row_off, at::Tensor col_idx,
         at::Tensor quad_weights, at::Tensor alpha_sum_buf, at::Tensor qdotk_max_buf, at::Tensor integral_buf,
-        at::Tensor alpha_k_buf, at::Tensor alpha_kvw_buf)
+        at::Tensor alpha_k_buf, at::Tensor alpha_kvw_buf, int64_t n_long_rows, int64_t max_row_len, int64_t mid_row_len)
     {
 
         auto stream = at::cuda::getCurrentCUDAStream().stream();
@@ -1146,6 +1143,9 @@ namespace attention_kernels
         params.lat_halo_start = lat_halo_start;
         params.nlat_out = nlat_out;
         params.nlon_out = nlon_out;
+        params.n_long_rows = n_long_rows;
+        params.max_row_len = max_row_len;
+        params.mid_row_len = mid_row_len;
 
         if (!is_aligned<sizeof(float4)>(_kxp) || !is_aligned<sizeof(float4)>(_vxp) || !is_aligned<sizeof(float4)>(_qyp)
             || !is_aligned<sizeof(float4)>(_dyp) || (nchans_in % VEC_SIZE) != 0 || (nchans_out % VEC_SIZE) != 0) {
@@ -1653,19 +1653,16 @@ namespace attention_kernels
             int nchans_in = params.nchan_in;
             int nchans_out = params.nchan_out;
 
-            int64_t n_long_rows;
-            int64_t max_row_len;
-            int64_t mid_row_len;
-
-            // splits the rows in "long" and "short" rows; long rows have
-            // a length >= max(SPLIT_LONG_ROW_MIN_LEN(1024), len(row_0))
-            // (since the rows are sorted in decreasing order, row_0 is the
-            // longest row); short rows are the remaining rows.
-            // If there are long rows, they are processed with a separate
-            // kernels using multiple blocks per row, in order to mitigate
-            // the imbalance causing long temporal tails.
-            split_csr_rows(SPLIT_ROW_LENGTH_THRES, SPLIT_LONG_ROW_MIN_LEN, nlat_out, _row_idx, _row_off, &n_long_rows,
-                           &max_row_len, &mid_row_len);
+            // Row split precomputed once at setup and threaded in via params —
+            // see split_csr_rows / split_csr_rows_op. long rows have a length
+            // >= max(SPLIT_LONG_ROW_MIN_LEN(1024), len(row_0)) (rows are sorted
+            // in decreasing order, so row_0 is the longest); short rows are the
+            // remaining rows. If there are long rows, they are processed with a
+            // separate kernel using multiple blocks per row, to mitigate the
+            // imbalance causing long temporal tails.
+            const int64_t n_long_rows = params.n_long_rows;
+            const int64_t max_row_len = params.max_row_len;
+            const int64_t mid_row_len = params.mid_row_len;
 
             int64_t n_reg_rows = nlat_out - n_long_rows;
 
@@ -1764,14 +1761,12 @@ namespace attention_kernels
 
     ///////////////// END PASS2 SECTION
 
-    static void s2_attn_bwd_ring_step_pass2_dispatch(int64_t batch_size, int64_t nchans_in, int64_t nchans_out,
-                                                     int64_t nlon_in, int64_t pscale, int64_t nlat_halo,
-                                                     int64_t nlon_kx, int64_t lon_lo_kx, int64_t lat_halo_start,
-                                                     int64_t nlat_out, int64_t nlon_out, at::Tensor kxP, at::Tensor vxP,
-                                                     at::Tensor qyP, at::Tensor dyP, at::Tensor row_idx,
-                                                     at::Tensor row_off, at::Tensor col_idx, at::Tensor quad_weights,
-                                                     at::Tensor alpha_sum_buf, at::Tensor qdotk_max_buf,
-                                                     at::Tensor integral_norm_buf, at::Tensor dkxP, at::Tensor dvxP)
+    static void s2_attn_bwd_ring_step_pass2_dispatch(
+        int64_t batch_size, int64_t nchans_in, int64_t nchans_out, int64_t nlon_in, int64_t pscale, int64_t nlat_halo,
+        int64_t nlon_kx, int64_t lon_lo_kx, int64_t lat_halo_start, int64_t nlat_out, int64_t nlon_out, at::Tensor kxP,
+        at::Tensor vxP, at::Tensor qyP, at::Tensor dyP, at::Tensor row_idx, at::Tensor row_off, at::Tensor col_idx,
+        at::Tensor quad_weights, at::Tensor alpha_sum_buf, at::Tensor qdotk_max_buf, at::Tensor integral_norm_buf,
+        at::Tensor dkxP, at::Tensor dvxP, int64_t n_long_rows, int64_t max_row_len, int64_t mid_row_len)
     {
 
         auto stream = at::cuda::getCurrentCUDAStream().stream();
@@ -1810,6 +1805,9 @@ namespace attention_kernels
         params.lat_halo_start = lat_halo_start;
         params.nlat_out = nlat_out;
         params.nlon_out = nlon_out;
+        params.n_long_rows = n_long_rows;
+        params.max_row_len = max_row_len;
+        params.mid_row_len = mid_row_len;
 
         if (!is_aligned<sizeof(float4)>(_kxp) || !is_aligned<sizeof(float4)>(_vxp) || !is_aligned<sizeof(float4)>(_qyp)
             || !is_aligned<sizeof(float4)>(_dyp) || (nchans_in % VEC_SIZE) != 0 || (nchans_out % VEC_SIZE) != 0) {
@@ -1910,7 +1908,8 @@ namespace attention_kernels
                                                at::Tensor integral_buf, at::Tensor alpha_k_buf, at::Tensor alpha_kvw_buf,
                                                at::Tensor quad_weights, at::Tensor psi_col_idx, at::Tensor psi_row_off,
                                                at::Tensor psi_row_idx, int64_t nlon_in, int64_t pscale, int64_t lon_lo_kx,
-                                               int64_t lat_halo_start, int64_t nlat_out, int64_t nlon_out)
+                                               int64_t lat_halo_start, int64_t nlat_out, int64_t nlon_out,
+                                               int64_t n_long_rows, int64_t max_row_len, int64_t mid_row_len)
     {
         CHECK_CUDA_INPUT_TENSOR(kx);
         CHECK_CUDA_INPUT_TENSOR(vx);
@@ -1942,10 +1941,10 @@ namespace attention_kernels
         if (qyP.strides()[1] != 1) { qyP = permute_4D_to0231(qyP); }
         if (dyP.strides()[1] != 1) { dyP = permute_4D_to0231(dyP); }
 
-        s2_attn_bwd_ring_step_pass1_dispatch(batch_size, nchans_in, nchans_out, nlon_in, pscale, nlat_halo, nlon_kx,
-                                             lon_lo_kx, lat_halo_start, nlat_out, nlon_out, kxP, vxP, qyP, dyP,
-                                             psi_row_idx, psi_row_off, psi_col_idx, quad_weights, alpha_sum_buf,
-                                             qdotk_max_buf, integral_buf, alpha_k_buf, alpha_kvw_buf);
+        s2_attn_bwd_ring_step_pass1_dispatch(
+            batch_size, nchans_in, nchans_out, nlon_in, pscale, nlat_halo, nlon_kx, lon_lo_kx, lat_halo_start, nlat_out,
+            nlon_out, kxP, vxP, qyP, dyP, psi_row_idx, psi_row_off, psi_col_idx, quad_weights, alpha_sum_buf,
+            qdotk_max_buf, integral_buf, alpha_k_buf, alpha_kvw_buf, n_long_rows, max_row_len, mid_row_len);
 
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
@@ -1955,7 +1954,8 @@ namespace attention_kernels
                                                at::Tensor integral_norm_buf, at::Tensor dkx, at::Tensor dvx,
                                                at::Tensor quad_weights, at::Tensor psi_col_idx, at::Tensor psi_row_off,
                                                at::Tensor psi_row_idx, int64_t nlon_in, int64_t pscale, int64_t lon_lo_kx,
-                                               int64_t lat_halo_start, int64_t nlat_out, int64_t nlon_out)
+                                               int64_t lat_halo_start, int64_t nlat_out, int64_t nlon_out,
+                                               int64_t n_long_rows, int64_t max_row_len, int64_t mid_row_len)
     {
         CHECK_CUDA_INPUT_TENSOR(kx);
         CHECK_CUDA_INPUT_TENSOR(vx);
@@ -1990,10 +1990,10 @@ namespace attention_kernels
     dump_csr_linear("csr_attn_distr", pscale, nlon_in, lon_lo_kx, nlon_kx, lat_halo_start, nlat_halo, nlat_out, psi_row_idx, psi_row_off, psi_col_idx);
 #endif
         // dkx/dvx are already in channels-last format (allocated that way in Python)
-        s2_attn_bwd_ring_step_pass2_dispatch(batch_size, nchans_in, nchans_out, nlon_in, pscale, nlat_halo, nlon_kx,
-                                             lon_lo_kx, lat_halo_start, nlat_out, nlon_out, kxP, vxP, qyP, dyP,
-                                             psi_row_idx, psi_row_off, psi_col_idx, quad_weights, alpha_sum_buf,
-                                             qdotk_max_buf, integral_norm_buf, dkx, dvx);
+        s2_attn_bwd_ring_step_pass2_dispatch(
+            batch_size, nchans_in, nchans_out, nlon_in, pscale, nlat_halo, nlon_kx, lon_lo_kx, lat_halo_start, nlat_out,
+            nlon_out, kxP, vxP, qyP, dyP, psi_row_idx, psi_row_off, psi_col_idx, quad_weights, alpha_sum_buf,
+            qdotk_max_buf, integral_norm_buf, dkx, dvx, n_long_rows, max_row_len, mid_row_len);
 
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_fwd_ring.cu
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_fwd_ring.cu
@@ -902,19 +902,17 @@ namespace attention_kernels
             const int nlon_out = params.nlon_out;
             const int nchans_in = params.nchan_in;
 
-            int64_t n_long_rows;
-            int64_t max_row_len;
-            int64_t mid_row_len;
-
-            // splits the rows in "long" and "short" rows; long rows have
-            // a length >= max(SPLIT_LONG_ROW_MIN_LEN(1024), len(row_0))
-            // (since the rows are sorted in decreasing order, row_0 is the
-            // longest row); short rows are the remaining rows.
-            // If there are long rows, they are processed with a separate
-            // kernels using multiple blocks per row, in order to mitigate
-            // the imbalance causing long temporal tails.
-            split_csr_rows(SPLIT_ROW_LENGTH_THRES, SPLIT_LONG_ROW_MIN_LEN, nlat_out, _row_idx, _row_off, &n_long_rows,
-                           &max_row_len, &mid_row_len);
+            // Row split (long vs short rows) precomputed once at setup and
+            // threaded in via params — see split_csr_rows / split_csr_rows_op.
+            // long rows have a length >= max(SPLIT_LONG_ROW_MIN_LEN(1024),
+            // len(row_0)) (rows are sorted in decreasing order, so row_0 is the
+            // longest); short rows are the remaining rows. If there are long
+            // rows, they are processed with a separate kernel using multiple
+            // blocks per row, to mitigate the imbalance causing long temporal
+            // tails.
+            const int64_t n_long_rows = params.n_long_rows;
+            const int64_t max_row_len = params.max_row_len;
+            const int64_t mid_row_len = params.mid_row_len;
 
             if (n_long_rows > 0) {
                 // processes the "long rows", from _row_idx[0] to _row_idx[n_long_rows-1]
@@ -980,7 +978,8 @@ namespace attention_kernels
                                                int64_t lat_halo_start, int64_t nlat_out, int64_t nlon_out,
                                                at::Tensor kxP, at::Tensor vxP, at::Tensor qyP, at::Tensor row_idx,
                                                at::Tensor row_off, at::Tensor col_idx, at::Tensor quad_weights,
-                                               at::Tensor y_acc, at::Tensor alpha_sum_buf, at::Tensor qdotk_max_buf)
+                                               at::Tensor y_acc, at::Tensor alpha_sum_buf, at::Tensor qdotk_max_buf,
+                                               int64_t n_long_rows, int64_t max_row_len, int64_t mid_row_len)
     {
 
         static_assert(0 == (MAX_LOCAL_ARR_LEN & (MAX_LOCAL_ARR_LEN - 1)));
@@ -1018,6 +1017,9 @@ namespace attention_kernels
         params.lat_halo_start = lat_halo_start;
         params.nlat_out = nlat_out;
         params.nlon_out = nlon_out;
+        params.n_long_rows = n_long_rows;
+        params.max_row_len = max_row_len;
+        params.mid_row_len = mid_row_len;
 
         if (!is_aligned<sizeof(float4)>(_kxp) || !is_aligned<sizeof(float4)>(_vxp) || !is_aligned<sizeof(float4)>(_qyp)
             || !is_aligned<sizeof(float4)>(_y_acc) || (nchans_in % VEC_SIZE) != 0 || (nchans_out % VEC_SIZE) != 0) {
@@ -1130,7 +1132,8 @@ namespace attention_kernels
                                          at::Tensor alpha_sum_buf, at::Tensor qdotk_max_buf, at::Tensor quad_weights,
                                          at::Tensor psi_col_idx, at::Tensor psi_row_off, at::Tensor psi_row_idx,
                                          int64_t nlon_in, int64_t pscale, int64_t lon_lo_kx, int64_t lat_halo_start,
-                                         int64_t nlat_out, int64_t nlon_out)
+                                         int64_t nlat_out, int64_t nlon_out, int64_t n_long_rows, int64_t max_row_len,
+                                         int64_t mid_row_len)
     {
         CHECK_CUDA_INPUT_TENSOR(kx);
         CHECK_CUDA_INPUT_TENSOR(vx);
@@ -1163,7 +1166,8 @@ namespace attention_kernels
 
         s2_attn_fwd_ring_step_dispatch(batch_size, nchans_in, nchans_out, nlon_in, pscale, nlat_halo, nlon_kx,
                                        lon_lo_kx, lat_halo_start, nlat_out, nlon_out, kxP, vxP, qyP, psi_row_idx,
-                                       psi_row_off, psi_col_idx, quad_weights, y_acc, alpha_sum_buf, qdotk_max_buf);
+                                       psi_row_off, psi_col_idx, quad_weights, y_acc, alpha_sum_buf, qdotk_max_buf,
+                                       n_long_rows, max_row_len, mid_row_len);
 
         C10_CUDA_KERNEL_LAUNCH_CHECK();
     }

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_utils.cu
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_utils.cu
@@ -250,6 +250,28 @@ namespace attention_kernels
 
         return;
     }
+
+    // One-time host-side wrapper, exposed as the "split_csr_rows" op. The split
+    // is a pure function of the psi sparsity geometry (row_idx/row_off/nlat_out),
+    // which is fixed after init, so callers invoke this once and thread the
+    // result into every ring step instead of recomputing it (and paying a
+    // 24-byte D2H sync) per step. row_idx is int32, row_off is int64, both CUDA.
+    std::tuple<int64_t, int64_t, int64_t> split_csr_rows_op(at::Tensor row_idx, at::Tensor row_off, int64_t nlat_out)
+    {
+        CHECK_CUDA_TENSOR(row_idx);
+        CHECK_CUDA_TENSOR(row_off);
+
+        int32_t *_row_idx = reinterpret_cast<int32_t *>(row_idx.data_ptr());
+        int64_t *_row_off = reinterpret_cast<int64_t *>(row_off.data_ptr());
+
+        int64_t n_long_rows = 0, max_row_len = 0, mid_row_len = 0;
+        split_csr_rows(SPLIT_ROW_LENGTH_THRES, SPLIT_LONG_ROW_MIN_LEN, nlat_out, _row_idx, _row_off, &n_long_rows,
+                       &max_row_len, &mid_row_len);
+
+        return std::make_tuple(n_long_rows, max_row_len, mid_row_len);
+    }
+
+    TORCH_LIBRARY_IMPL(attention_kernels, CUDA, m) { m.impl("split_csr_rows", &split_csr_rows_op); }
     // END - CSR row splitting kernels and functions
 
     // BEGIN - general host-side functions

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_utils.cu
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_utils.cu
@@ -251,26 +251,71 @@ namespace attention_kernels
         return;
     }
 
-    // One-time host-side wrapper, exposed as the "split_csr_rows" op. The split
-    // is a pure function of the psi sparsity geometry (row_idx/row_off/nlat_out),
-    // which is fixed after init, so callers invoke this once and thread the
-    // result into every ring step instead of recomputing it (and paying a
-    // 24-byte D2H sync) per step. row_idx is int32, row_off is int64, both CUDA.
+    // One-time wrapper, exposed as the "split_csr_rows" op. The split is a pure
+    // function of the psi sparsity geometry (row_idx/row_off/nlat_out), which is
+    // fixed after init, so callers invoke this once (from the module constructor)
+    // and thread the result into every ring step instead of recomputing it (and
+    // paying a 24-byte D2H sync) per step. row_idx is int32, row_off is int64.
+    //
+    // Registered for both CPU and CUDA: the constructor computes the split while
+    // the local psi buffers are still on the CPU (before .to(device)), so the CPU
+    // path is the one normally taken. The CUDA path keeps the op valid if it is
+    // ever called on device tensors. The CPU scan mirrors get_rlen_boundary_k
+    // exactly (same constants + same float truncation in the threshold) so both
+    // backends select identical long/short row splits.
     std::tuple<int64_t, int64_t, int64_t> split_csr_rows_op(at::Tensor row_idx, at::Tensor row_off, int64_t nlat_out)
     {
-        CHECK_CUDA_TENSOR(row_idx);
-        CHECK_CUDA_TENSOR(row_off);
+        if (nlat_out <= 0) { return std::make_tuple(int64_t(0), int64_t(0), int64_t(0)); }
 
-        int32_t *_row_idx = reinterpret_cast<int32_t *>(row_idx.data_ptr());
-        int64_t *_row_off = reinterpret_cast<int64_t *>(row_off.data_ptr());
+        if (row_idx.is_cuda()) {
+            CHECK_CUDA_TENSOR(row_idx);
+            CHECK_CUDA_TENSOR(row_off);
 
-        int64_t n_long_rows = 0, max_row_len = 0, mid_row_len = 0;
-        split_csr_rows(SPLIT_ROW_LENGTH_THRES, SPLIT_LONG_ROW_MIN_LEN, nlat_out, _row_idx, _row_off, &n_long_rows,
-                       &max_row_len, &mid_row_len);
+            int32_t *_row_idx = reinterpret_cast<int32_t *>(row_idx.data_ptr());
+            int64_t *_row_off = reinterpret_cast<int64_t *>(row_off.data_ptr());
+
+            int64_t n_long_rows = 0, max_row_len = 0, mid_row_len = 0;
+            split_csr_rows(SPLIT_ROW_LENGTH_THRES, SPLIT_LONG_ROW_MIN_LEN, nlat_out, _row_idx, _row_off, &n_long_rows,
+                           &max_row_len, &mid_row_len);
+
+            return std::make_tuple(n_long_rows, max_row_len, mid_row_len);
+        }
+
+        // CPU path: host-side scan. Rows are sorted by decreasing length, so the
+        // "long" rows form a prefix; count it and read the first short row length.
+        at::Tensor ri = row_idx.contiguous();
+        at::Tensor ro = row_off.contiguous();
+        const int32_t *idx = ri.data_ptr<int32_t>();
+        const int64_t *off = ro.data_ptr<int64_t>();
+
+        const int64_t max_rlen = off[idx[0] + 1] - off[idx[0]];
+        const int64_t thres_len = int64_t(float(max_rlen) * SPLIT_ROW_LENGTH_THRES);
+        const int64_t min_longr_len
+            = (int64_t(SPLIT_LONG_ROW_MIN_LEN) > thres_len) ? int64_t(SPLIT_LONG_ROW_MIN_LEN) : thres_len;
+
+        int64_t tot_long = 0;
+        for (int64_t i = 0; i < nlat_out; i++) {
+            const int32_t row = idx[i];
+            const int64_t rlen = off[row + 1] - off[row];
+            if (rlen >= min_longr_len) {
+                tot_long++;
+            } else {
+                break;
+            }
+        }
+
+        const int64_t n_long_rows = tot_long;
+        const int64_t max_row_len = tot_long ? max_rlen : 0;
+        int64_t mid_row_len = 0;
+        if (tot_long < nlat_out) {
+            const int32_t first_short_row = idx[tot_long];
+            mid_row_len = off[first_short_row + 1] - off[first_short_row];
+        }
 
         return std::make_tuple(n_long_rows, max_row_len, mid_row_len);
     }
 
+    TORCH_LIBRARY_IMPL(attention_kernels, CPU, m) { m.impl("split_csr_rows", &split_csr_rows_op); }
     TORCH_LIBRARY_IMPL(attention_kernels, CUDA, m) { m.impl("split_csr_rows", &split_csr_rows_op); }
     // END - CSR row splitting kernels and functions
 

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_utils.cuh
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_utils.cuh
@@ -90,9 +90,10 @@ namespace attention_kernels
     void split_csr_rows(float thres, int64_t split_len, int64_t nrows, int32_t *row_idx, int64_t *row_off,
                         int64_t *n_long_rows, int64_t *max_row_len0, int64_t *max_row_len1);
 
-    // One-time host-side wrapper around split_csr_rows, exposed as the
-    // "split_csr_rows" op so Python can precompute the row split once (the
-    // result is constant for a fixed psi) and pass it into the ring-step ops.
+    // One-time wrapper exposed as the "split_csr_rows" op so Python can
+    // precompute the row split once (constant for a fixed psi) and pass it into
+    // the ring-step ops. Handles CPU and CUDA row_idx/row_off; the module
+    // constructor calls it on the still-on-CPU local psi buffers.
     std::tuple<int64_t, int64_t, int64_t> split_csr_rows_op(at::Tensor row_idx, at::Tensor row_off, int64_t nlat_out);
 
     unsigned int next_pow2(unsigned int x);

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_utils.cuh
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_utils.cuh
@@ -57,6 +57,14 @@ namespace attention_kernels
         int lat_halo_start;
         int nlat_out;
         int nlon_out;
+        // Precomputed CSR row split (see split_csr_rows). These depend only on
+        // the psi sparsity geometry (row_idx/row_off/nlat_out), which is fixed
+        // after init, so they are computed once on the host side and threaded
+        // in via the ring-step dispatch instead of being recomputed every ring
+        // step (which previously incurred a per-step 24-byte D2H sync).
+        int64_t n_long_rows;
+        int64_t max_row_len;
+        int64_t mid_row_len;
     };
 
     // CSR rows sorting kernels and functions
@@ -81,6 +89,11 @@ namespace attention_kernels
 
     void split_csr_rows(float thres, int64_t split_len, int64_t nrows, int32_t *row_idx, int64_t *row_off,
                         int64_t *n_long_rows, int64_t *max_row_len0, int64_t *max_row_len1);
+
+    // One-time host-side wrapper around split_csr_rows, exposed as the
+    // "split_csr_rows" op so Python can precompute the row split once (the
+    // result is constant for a fixed psi) and pass it into the ring-step ops.
+    std::tuple<int64_t, int64_t, int64_t> split_csr_rows_op(at::Tensor row_idx, at::Tensor row_off, int64_t nlat_out);
 
     unsigned int next_pow2(unsigned int x);
 

--- a/torch_harmonics/distributed/distributed_attention.py
+++ b/torch_harmonics/distributed/distributed_attention.py
@@ -99,6 +99,9 @@ class _RingNeighborhoodAttentionFn(torch.autograd.Function):
         az_group,
         az_rank: int,
         az_size: int,
+        psi_n_long_rows: int,
+        psi_max_row_len: int,
+        psi_mid_row_len: int,
     ):
         B, _, _, _ = kw.shape
         _, C_v, _, _ = vw.shape
@@ -145,6 +148,9 @@ class _RingNeighborhoodAttentionFn(torch.autograd.Function):
                 lat_halo_start,
                 nlat_out_local,
                 nlon_out_local,
+                psi_n_long_rows,
+                psi_max_row_len,
+                psi_mid_row_len,
             )
 
             if step < az_size - 1:
@@ -185,6 +191,9 @@ class _RingNeighborhoodAttentionFn(torch.autograd.Function):
             az_group,
             az_rank,
             az_size,
+            psi_n_long_rows,
+            psi_max_row_len,
+            psi_mid_row_len,
         ) = inputs
         y_out, alpha_sum, qdotk_max = output
         # alpha_sum and qdotk_max are internal accumulators, not true outputs;
@@ -201,6 +210,9 @@ class _RingNeighborhoodAttentionFn(torch.autograd.Function):
         ctx.az_group = az_group
         ctx.az_rank = az_rank
         ctx.az_size = az_size
+        ctx.psi_n_long_rows = psi_n_long_rows
+        ctx.psi_max_row_len = psi_max_row_len
+        ctx.psi_mid_row_len = psi_mid_row_len
 
     @staticmethod
     @torch.amp.custom_bwd(device_type="cuda")
@@ -218,6 +230,9 @@ class _RingNeighborhoodAttentionFn(torch.autograd.Function):
         az_group = ctx.az_group
         az_rank = ctx.az_rank
         az_size = ctx.az_size
+        psi_n_long_rows = ctx.psi_n_long_rows
+        psi_max_row_len = ctx.psi_max_row_len
+        psi_mid_row_len = ctx.psi_mid_row_len
 
         # Autograd contract: skip per-branch work (kernel calls, allreduces) for any
         # of {kw, vw, qw} that doesn't need a gradient, and return None in those slots.
@@ -230,7 +245,7 @@ class _RingNeighborhoodAttentionFn(torch.autograd.Function):
         # Defensive: if somehow none of (kw, vw, qw) need grad (e.g., user wired
         # requires_grad onto one of the index buffers), there's nothing to compute.
         if not (kw_needs_grad or vw_needs_grad or qw_needs_grad):
-            return (None,) * 18
+            return (None,) * 21
 
         B, C_k, H_halo, _ = kw.shape
         _, C_v, _, _ = vw.shape
@@ -294,6 +309,9 @@ class _RingNeighborhoodAttentionFn(torch.autograd.Function):
                 lat_halo_start,
                 nlat_out_local,
                 nlon_out_local,
+                psi_n_long_rows,
+                psi_max_row_len,
+                psi_mid_row_len,
             )
 
             if step < az_size - 1:
@@ -367,6 +385,9 @@ class _RingNeighborhoodAttentionFn(torch.autograd.Function):
                     lat_halo_start,
                     nlat_out_local,
                     nlon_out_local,
+                    psi_n_long_rows,
+                    psi_max_row_len,
+                    psi_mid_row_len,
                 )
 
                 if kw_needs_grad:
@@ -412,8 +433,9 @@ class _RingNeighborhoodAttentionFn(torch.autograd.Function):
         # Return grads for (kw, vw, qw, psi_col, psi_roff, psi_row, quad_weights,
         #                   nlon_in, pscale, lon_chunk_starts, nlon_kx_list, lat_halo_start,
         #                   nlat_out_local, nlon_out_local, r_lat,
-        #                   az_group, az_rank, az_size)
-        return dkw, dvw, dqy, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
+        #                   az_group, az_rank, az_size,
+        #                   psi_n_long_rows, psi_max_row_len, psi_mid_row_len)
+        return (dkw, dvw, dqy, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None)
 
 
 # ---------------------------------------------------------------------------
@@ -522,6 +544,14 @@ class DistributedNeighborhoodAttentionS2(NeighborhoodAttentionS2):
         # local wo directly without knowing the global lon offset.
         self._build_local_psi()
 
+        # Cache for the precomputed CSR row split (n_long_rows, max_row_len,
+        # mid_row_len). It is a pure function of the local psi geometry, which
+        # is fixed after init, so it is computed once on first forward (when the
+        # psi buffers are guaranteed to be on the CUDA device) and reused — see
+        # _row_split(). This hoists split_csr_rows out of the per-ring-step hot
+        # path, where it otherwise cost a 24-byte D2H sync every step.
+        self._psi_row_split = None
+
         # ---- lat halo size ----
         # Compute r_lat from the global psi: maximum |hi_global - ho_global|
         # over all (ho, hi) pairs in the neighbourhood.
@@ -574,6 +604,21 @@ class DistributedNeighborhoodAttentionS2(NeighborhoodAttentionS2):
         self.register_buffer("psi_col_idx_local", col_idx_shifted, persistent=False)
         self.register_buffer("psi_roff_idx_local", roff_local, persistent=False)
         self.register_buffer("psi_row_idx_local", row_idx_local, persistent=False)
+
+    def _row_split(self):
+        """Precomputed (n_long_rows, max_row_len, mid_row_len) for the local psi.
+
+        Computed once and cached. The split depends only on the psi sparsity
+        geometry (psi_row_idx_local / psi_roff_idx_local / nlat_out_local),
+        which is fixed after init, so the result is identical on every ring step
+        and every iteration. Computing it here (lazily, on first forward) keeps
+        it off the per-step hot path; the underlying op does one kernel launch
+        and one 24-byte D2H, but only once per module lifetime.
+        """
+        if self._psi_row_split is None:
+            n_long_rows, max_row_len, mid_row_len = attention_kernels.split_csr_rows.default(self.psi_row_idx_local, self.psi_roff_idx_local, self.nlat_out_local)
+            self._psi_row_split = (int(n_long_rows), int(max_row_len), int(mid_row_len))
+        return self._psi_row_split
 
     def _compute_r_lat(self) -> int:
         """Max lat halo radius needed across all polar ranks.
@@ -688,6 +733,7 @@ class DistributedNeighborhoodAttentionS2(NeighborhoodAttentionS2):
         # projections under autocast already produce bf16, so this is usually
         # a no-op; covers the case where upstream is fp32-producing.
         key_halo, value_halo, query_proj = _cast_to_autocast_dtype(key_halo, value_halo, query_proj)
+        psi_n_long_rows, psi_max_row_len, psi_mid_row_len = self._row_split()
         out, _, _ = _RingNeighborhoodAttentionFn.apply(
             key_halo,
             value_halo,
@@ -707,6 +753,9 @@ class DistributedNeighborhoodAttentionS2(NeighborhoodAttentionS2):
             azimuth_group(),
             self.comm_rank_azimuth,
             self.comm_size_azimuth,
+            psi_n_long_rows,
+            psi_max_row_len,
+            psi_mid_row_len,
         )  # [Bnh, C_v, H_out_local, W_out_local]
 
         # unfold num_heads

--- a/torch_harmonics/distributed/distributed_attention.py
+++ b/torch_harmonics/distributed/distributed_attention.py
@@ -542,15 +542,7 @@ class DistributedNeighborhoodAttentionS2(NeighborhoodAttentionS2):
         # We filter to only the rows owned by this rank and shift the wi
         # component of col_idx by lon_lo_out so that the kernel can use
         # local wo directly without knowing the global lon offset.
-        self._build_local_psi()
-
-        # Cache for the precomputed CSR row split (n_long_rows, max_row_len,
-        # mid_row_len). It is a pure function of the local psi geometry, which
-        # is fixed after init, so it is computed once on first forward (when the
-        # psi buffers are guaranteed to be on the CUDA device) and reused — see
-        # _row_split(). This hoists split_csr_rows out of the per-ring-step hot
-        # path, where it otherwise cost a 24-byte D2H sync every step.
-        self._psi_row_split = None
+        self._build_local_psi()  # also precomputes self.psi_{n_long_rows,max_row_len,mid_row_len}
 
         # ---- lat halo size ----
         # Compute r_lat from the global psi: maximum |hi_global - ho_global|
@@ -605,20 +597,17 @@ class DistributedNeighborhoodAttentionS2(NeighborhoodAttentionS2):
         self.register_buffer("psi_roff_idx_local", roff_local, persistent=False)
         self.register_buffer("psi_row_idx_local", row_idx_local, persistent=False)
 
-    def _row_split(self):
-        """Precomputed (n_long_rows, max_row_len, mid_row_len) for the local psi.
-
-        Computed once and cached. The split depends only on the psi sparsity
-        geometry (psi_row_idx_local / psi_roff_idx_local / nlat_out_local),
-        which is fixed after init, so the result is identical on every ring step
-        and every iteration. Computing it here (lazily, on first forward) keeps
-        it off the per-step hot path; the underlying op does one kernel launch
-        and one 24-byte D2H, but only once per module lifetime.
-        """
-        if self._psi_row_split is None:
-            n_long_rows, max_row_len, mid_row_len = attention_kernels.split_csr_rows.default(self.psi_row_idx_local, self.psi_roff_idx_local, self.nlat_out_local)
-            self._psi_row_split = (int(n_long_rows), int(max_row_len), int(mid_row_len))
-        return self._psi_row_split
+        # Precompute the CSR long/short row split once, here in the constructor,
+        # on the still-on-CPU local psi buffers (split_csr_rows has a CPU path).
+        # The split depends only on the psi sparsity geometry, which is fixed
+        # after init, so it is identical on every ring step / iteration. Computing
+        # it once keeps it off the per-step hot path (it otherwise cost a 24-byte
+        # D2H sync per ring step) and off any compiled forward. Stored as plain
+        # Python ints and threaded into the ring-step ops.
+        n_long_rows, max_row_len, mid_row_len = attention_kernels.split_csr_rows.default(row_idx_local, roff_local, self.nlat_out_local)
+        self.psi_n_long_rows = int(n_long_rows)
+        self.psi_max_row_len = int(max_row_len)
+        self.psi_mid_row_len = int(mid_row_len)
 
     def _compute_r_lat(self) -> int:
         """Max lat halo radius needed across all polar ranks.
@@ -733,7 +722,6 @@ class DistributedNeighborhoodAttentionS2(NeighborhoodAttentionS2):
         # projections under autocast already produce bf16, so this is usually
         # a no-op; covers the case where upstream is fp32-producing.
         key_halo, value_halo, query_proj = _cast_to_autocast_dtype(key_halo, value_halo, query_proj)
-        psi_n_long_rows, psi_max_row_len, psi_mid_row_len = self._row_split()
         out, _, _ = _RingNeighborhoodAttentionFn.apply(
             key_halo,
             value_halo,
@@ -753,9 +741,9 @@ class DistributedNeighborhoodAttentionS2(NeighborhoodAttentionS2):
             azimuth_group(),
             self.comm_rank_azimuth,
             self.comm_size_azimuth,
-            psi_n_long_rows,
-            psi_max_row_len,
-            psi_mid_row_len,
+            self.psi_n_long_rows,
+            self.psi_max_row_len,
+            self.psi_mid_row_len,
         )  # [Bnh, C_v, H_out_local, W_out_local]
 
         # unfold num_heads


### PR DESCRIPTION
for performance reasons, the kernel re-computes the dense vs sparse splits with every pass. this is not necessary since this split is constant. This MR moves this into the constructor, improving kernel performance and removing some D2H syncs in the process.