### PR TITLE
Preserve GaussianRandomFieldS2 sample dimensions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 * Improved performance of distributed attention kernels achieved by splitting the kernel into two different ones for dense and less dense rows. This happens behind the scenes and the distributed attention API is unchanged.
 * Improved distributed tests: tests now only print on rank 0 and test states are broadcast to all ranks before being triggered, to ensure clean failure on all ranks in case of failing tests.
 * Splitting logic in distributed SHT improved. Now the SHT splits all leading dims up to the spatial dims when performing the all-to-all. It also automatically applies padding if the split tensor dim is smaller than the number of ranks it is split across. Tests were added to cover these cases.
+* Fixed a problem with squeezing singleton dimensions in the `GaussianRandomFieldS2` noise tensor.
 * **Breaking**: default `basis_norm_mode` for `DistributedDiscreteContinuousConvS2` and `DistributedDiscreteContinuousConvTransposeS2` changed from `"mean"` to `"nodal"` to match the serial `DiscreteContinuousConvS2` / `DiscreteContinuousConvTransposeS2` defaults. Distributed and serial DISCO layers now share the same default normalization unless explicitly overridden.
 
 ### v0.9.1

--- a/tests/test_random_fields.py
+++ b/tests/test_random_fields.py
@@ -137,6 +137,42 @@ class TestGaussianRandomFieldS2(unittest.TestCase):
         self.assertEqual(u.shape, (4, nlat, 2 * nlat))
         self.assertTrue(torch.isfinite(u).all(), "output contains non-finite values")
 
+    @parameterized.expand(
+        [
+            [16, "equiangular"],
+            [16, "legendre-gauss"],
+            [16, "lobatto"],
+        ],
+        skip_on_empty=True,
+    )
+    def test_single_sample_preserves_batch_dimension(self, nlat, grid, verbose=False):
+        """Sampling one field preserves the leading batch dimension."""
+        field = GaussianRandomFieldS2(nlat, grid=grid).to(self.device)
+
+        set_seed(333)
+        u = field(1)
+
+        self.assertEqual(u.shape, (1, nlat, 2 * nlat))
+        self.assertTrue(torch.isfinite(u).all(), "output contains non-finite values")
+
+    @parameterized.expand(
+        [
+            [2, "equiangular"],
+            [2, "lobatto"],
+        ],
+        skip_on_empty=True,
+    )
+    def test_sampling_preserves_tiny_truncation_dimensions(self, nlat, grid, verbose=False):
+        """Sampling with lmax=mmax=1 preserves the sample and spectral dimensions."""
+        field = GaussianRandomFieldS2(nlat, grid=grid).to(self.device)
+
+        for num_samples in [1, 2, 4]:
+            set_seed(333)
+            u = field(num_samples)
+
+            self.assertEqual(u.shape, (num_samples, nlat, 2 * nlat))
+            self.assertTrue(torch.isfinite(u).all(), "output contains non-finite values")
+
 
 @parameterized_class(("device"), _devices)
 class TestGaussianRandomFieldS2Probabilistic(unittest.TestCase):

--- a/torch_harmonics/random_fields.py
+++ b/torch_harmonics/random_fields.py
@@ -97,7 +97,7 @@ class GaussianRandomFieldS2(torch.nn.Module):
         if xi is None:
             lmax = self.isht.lmax
             mmax = self.isht.mmax
-            xi = self.gaussian_noise.sample(torch.Size((N, lmax, mmax, 2))).squeeze()
+            xi = self.gaussian_noise.sample(torch.Size((N, lmax, mmax, 2))).squeeze(-1)
             xi = torch.view_as_complex(xi)
 
         # Karhunen-Loeve expansion.


### PR DESCRIPTION
## Summary

- Preserve only the trailing singleton distribution dimension when sampling GaussianRandomFieldS2 noise.
- Add regression coverage for single-sample output shape and tiny truncations where `lmax == mmax == 1`.

## Why

`Normal(mean=[0], var=[1]).sample((N, lmax, mmax, 2))` returns a tensor with shape `(N, lmax, mmax, 2, 1)`. The previous broad `squeeze()` could collapse any singleton sample or spectral axis before `view_as_complex`, which breaks sampled noise for valid tiny grids such as `nlat=2` with equiangular or lobatto truncation.

## Validation

- `uv run --no-project --with 'torch>=2.6.0' --with 'numpy>=1.22.4' --with parameterized --with pytest python -m pytest tests/test_random_fields.py -q`
- `uv run --no-project --with ruff ruff check torch_harmonics/random_fields.py tests/test_random_fields.py`
