### PR TITLE
Fix SpectralConvS2 bias with channel projection

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 * Improved performance of distributed attention kernels achieved by splitting the kernel into two different ones for dense and less dense rows. This happens behind the scenes and the distributed attention API is unchanged.
 * Improved distributed tests: tests now only print on rank 0 and test states are broadcast to all ranks before being triggered, to ensure clean failure on all ranks in case of failing tests.
 * Splitting logic in distributed SHT improved. Now the SHT splits all leading dims up to the spatial dims when performing the all-to-all. It also automatically applies padding if the split tensor dim is smaller than the number of ranks it is split across. Tests were added to cover these cases.
+* Fixed `SpectralConvS2` and `DistributedSpectralConvS2` spectral bias handling when input and output channel counts differ.
 * **Breaking**: default `basis_norm_mode` for `DistributedDiscreteContinuousConvS2` and `DistributedDiscreteContinuousConvTransposeS2` changed from `"mean"` to `"nodal"` to match the serial `DiscreteContinuousConvS2` / `DiscreteContinuousConvTransposeS2` defaults. Distributed and serial DISCO layers now share the same default normalization unless explicitly overridden.
 
 ### v0.9.1

--- a/tests/test_spectral_convolution.py
+++ b/tests/test_spectral_convolution.py
@@ -452,6 +452,50 @@ class TestSpectralConvS2(unittest.TestCase):
             msg="spectral_bias.grad should contain non-zero entries",
         )
 
+    @parameterized.expand(
+        [
+            # nlat, nlon, in_channels, out_channels, num_groups
+            [16, 32, 4, 8, 1],
+            [16, 32, 8, 4, 1],
+            [16, 32, 4, 8, 2],
+        ],
+        skip_on_empty=True,
+    )
+    def test_spectral_bias_supports_channel_projection(self, nlat, nlon, in_channels, out_channels, num_groups, verbose=False):
+        """Spectral bias works if input and output channel counts differ."""
+        set_seed(333)
+
+        conv = SpectralConvS2(
+            in_shape=(nlat, nlon),
+            out_shape=(nlat, nlon),
+            in_channels=in_channels,
+            out_channels=out_channels,
+            num_groups=num_groups,
+            grid_in="equiangular",
+            grid_out="equiangular",
+            bias=True,
+        ).to(self.device)
+
+        self.assertEqual(conv.spectral_bias.shape, (1, in_channels, conv.lmax, conv.mmax))
+
+        with torch.no_grad():
+            conv.spectral_bias.data.fill_(0.1)
+
+        x = torch.randn(2, in_channels, nlat, nlon, device=self.device)
+        y = conv(x)
+
+        self.assertEqual(y.shape, (2, out_channels, nlat, nlon))
+        self.assertTrue(torch.isfinite(y).all(), "output contains non-finite values")
+
+        loss = y.sum()
+        loss.backward()
+
+        self.assertIsNotNone(conv.spectral_bias.grad, msg="spectral_bias.grad should not be None")
+        self.assertTrue(
+            conv.spectral_bias.grad.abs().max().item() > 0.0,
+            msg="spectral_bias.grad should contain non-zero entries",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torch_harmonics/distributed/distributed_spectral_convolution.py
+++ b/torch_harmonics/distributed/distributed_spectral_convolution.py
@@ -149,7 +149,7 @@ class DistributedSpectralConvS2(nn.Module):
         self.weight = nn.Parameter(scale * torch.randn(*weight_shape, dtype=torch.complex64))
 
         if bias:
-            self.spectral_bias = nn.Parameter(torch.zeros(1, self.out_channels, self.lmax_local, self.mmax_local, dtype=torch.complex64))
+            self.spectral_bias = nn.Parameter(torch.zeros(1, self.in_channels, self.lmax_local, self.mmax_local, dtype=torch.complex64))
             self.quadrature = DistributedQuadratureS2(img_shape=in_shape, grid=grid_in, normalize=False)
 
     @torch.compile

--- a/torch_harmonics/spectral_convolution.py
+++ b/torch_harmonics/spectral_convolution.py
@@ -132,7 +132,7 @@ class SpectralConvS2(nn.Module):
         self.weight = nn.Parameter(scale * torch.randn(*weight_shape, dtype=torch.complex64))
 
         if bias:
-            self.spectral_bias = nn.Parameter(torch.zeros(1, self.out_channels, self.lmax, self.mmax, dtype=torch.complex64))
+            self.spectral_bias = nn.Parameter(torch.zeros(1, self.in_channels, self.lmax, self.mmax, dtype=torch.complex64))
             self.quadrature = QuadratureS2(img_shape=in_shape, grid=grid_in, normalize=False)
 
     @torch.compile


### PR DESCRIPTION
## Summary

- Shape `spectral_bias` by input channels in the serial and distributed spectral convolution layers.
- Add regression coverage for `SpectralConvS2(bias=True)` when input and output channel counts differ.

## Why

The spectral bias is applied before the grouped channel contraction, while the tensor is still shaped by input channels. It was previously initialized with `out_channels`, so `bias=True` failed for channel projections such as 4 -> 8 or 8 -> 4.

Keeping the parameter input-channel-shaped preserves the existing pre-contraction bias semantics and keeps equal-channel cases unchanged.

## Validation

- `uv run --no-project --with 'torch>=2.6.0' --with 'numpy>=1.22.4' --with parameterized --with pytest python -m pytest tests/test_spectral_convolution.py -q`
- `uv run --no-project --with ruff ruff check torch_harmonics/spectral_convolution.py torch_harmonics/distributed/distributed_spectral_convolution.py tests/test_spectral_convolution.py`
