### PR TITLE
Disable AttentionS2 dropout in eval mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 * Improved distributed tests: tests now only print on rank 0 and test states are broadcast to all ranks before being triggered, to ensure clean failure on all ranks in case of failing tests.
 * Splitting logic in distributed SHT improved. Now the SHT splits all leading dims up to the spatial dims when performing the all-to-all. It also automatically applies padding if the split tensor dim is smaller than the number of ranks it is split across. Tests were added to cover these cases.
 * Fixed a problem with squeezing singleton dimensions in the `GaussianRandomFieldS2` noise tensor.
+* Fixed `AttentionS2` to disable SDPA dropout in eval mode.
 * **Breaking**: default `basis_norm_mode` for `DistributedDiscreteContinuousConvS2` and `DistributedDiscreteContinuousConvTransposeS2` changed from `"mean"` to `"nodal"` to match the serial `DiscreteContinuousConvS2` / `DiscreteContinuousConvTransposeS2` defaults. Distributed and serial DISCO layers now share the same default normalization unless explicitly overridden.
 
 ### v0.9.1

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -609,6 +609,48 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
 
     @parameterized.expand(
         [
+            [None],
+            ["tensor"],
+        ],
+        skip_on_empty=True,
+    )
+    def test_attention_eval_disables_sdpa_dropout(self, scale_mode, verbose=False):
+        set_seed(333)
+
+        scale = None
+        if scale_mode == "tensor":
+            scale = torch.tensor(0.5, device=self.device, dtype=torch.float32)
+
+        model = AttentionS2(
+            in_channels=4,
+            out_channels=4,
+            num_heads=1,
+            in_shape=(4, 8),
+            out_shape=(4, 8),
+            grid_in="equiangular",
+            grid_out="equiangular",
+            scale=scale,
+            bias=False,
+            drop_rate=0.9,
+        ).to(self.device)
+        model.eval()
+
+        inputs = torch.randn(2, 4, 4, 8, device=self.device, dtype=torch.float32)
+
+        with torch.no_grad():
+            torch.manual_seed(101)
+            if self.device.type == "cuda":
+                torch.cuda.manual_seed(101)
+            out_a = model(inputs)
+            torch.manual_seed(202)
+            if self.device.type == "cuda":
+                torch.cuda.manual_seed(202)
+            out_b = model(inputs)
+
+        self.assertTrue(compare_tensors("eval disables SDPA dropout", out_a, out_b, atol=0.0, rtol=0.0, verbose=verbose))
+
+    @parameterized.expand(
+        [
             # Format: [batch_size, channels_in, channels_out, shape, grid, atol, rtol]
             [2, 4, 4, (4, 8), "equiangular", 1e-5, 1e-4],
             [2, 4, 8, (4, 8), "equiangular", 1e-5, 1e-4],

--- a/torch_harmonics/attention/attention.py
+++ b/torch_harmonics/attention/attention.py
@@ -196,11 +196,12 @@ class AttentionS2(nn.Module):
 
         # apply scale — if scale is a tensor (e.g. learnable), multiply into query
         # directly since SDPA only accepts a float scale
+        dropout_p = self.drop_rate if self.training else 0.0
         if isinstance(self.scale, torch.Tensor):
             query = query * self.scale
-            out = F.scaled_dot_product_attention(query, key, value, attn_mask=self.log_quad_weights, dropout_p=self.drop_rate, scale=1.0)
+            out = F.scaled_dot_product_attention(query, key, value, attn_mask=self.log_quad_weights, dropout_p=dropout_p, scale=1.0)
         else:
-            out = F.scaled_dot_product_attention(query, key, value, attn_mask=self.log_quad_weights, dropout_p=self.drop_rate, scale=self.scale)
+            out = F.scaled_dot_product_attention(query, key, value, attn_mask=self.log_quad_weights, dropout_p=dropout_p, scale=self.scale)
 
         # reshape
         B, _, _, C = out.shape


### PR DESCRIPTION
## Summary
- Pass zero dropout to SDPA when `AttentionS2` is in eval mode.
- Add regression coverage for eval determinism with nonzero `drop_rate`, covering both float and tensor scale paths.
- Add a changelog entry.

## Why
`scaled_dot_product_attention` applies dropout whenever `dropout_p` is nonzero; it does not inspect module training state. `AttentionS2` was passing `self.drop_rate` unconditionally, so eval/inference outputs could remain stochastic when dropout was configured.

## Validation
- `uv run --no-project --with 'torch>=2.6.0' --with 'numpy>=1.22.4' --with parameterized --with pytest python -m pytest tests/test_attention.py -q -k 'attention_eval_disables_sdpa_dropout'`
- `uv run --no-project --with ruff ruff check torch_harmonics/attention/attention.py tests/test_attention.py`
- `git diff --check -- torch_harmonics/attention/attention.py tests/test_attention.py Changelog.md`
