### PR TITLE
fixing stride error in torch.compile

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 * Distributed DISCO convolution now uses `reduce_scatter` instead of `all_reduce` + `scatter` for the polar reduction, cutting communicated data volume in half.
 * Added fused distributed DISCO convolution variant which reduces activation storage.
 * Improved performance for CPU based attention kernels.
+* Fixed stride problems in SHT under torch.compile on CPU.
 * Converted all Python assert statements to torch._check for better torch.compile friendliness. All asserts in cosntructors were converted into ValueErrors for streamlined and clear error handling. In C++ and CUDA compiled code, all dynamic asserts were changed to TORCH_CHECK calls.
 * Improved performance of distributed attention kernels achieved by splitting the kernel into two different ones for dense and less dense rows. This happens behind the scenes and the distributed attention API is unchanged.
 * Improved distributed tests: tests now only print on rank 0 and test states are broadcast to all ranks before being triggered, to ensure clean failure on all ranks in case of failing tests.

--- a/torch_harmonics/distributed/distributed_sht.py
+++ b/torch_harmonics/distributed/distributed_sht.py
@@ -179,7 +179,9 @@ class DistributedRealSHT(nn.Module):
         w = self.weights.to(x_re.dtype)
         out_re = torch.einsum("...mk,mlk->...lm", x_re, w)
         out_im = torch.einsum("...mk,mlk->...lm", x_im, w)
-        x = torch.complex(out_re, out_im)
+        # force contiguous: the ...lm einsum output is non-contiguous and inductor's aten.complex
+        # meta predicts a contiguous layout, tripping assert_size_stride under torch.compile.
+        x = torch.complex(out_re.contiguous(), out_im.contiguous())
 
         # transpose: after this, l is split and c is local
         if self.comm_size_polar > 1:
@@ -309,7 +311,9 @@ class DistributedInverseRealSHT(nn.Module):
         w = self.pct.to(x_re.dtype)
         out_re = torch.einsum("...ml,mkl->...km", x_re, w)
         out_im = torch.einsum("...ml,mkl->...km", x_im, w)
-        x = torch.complex(out_re, out_im)
+        # force contiguous: the einsum output is non-contiguous and inductor's aten.complex meta
+        # predicts a contiguous layout, tripping assert_size_stride under torch.compile.
+        x = torch.complex(out_re.contiguous(), out_im.contiguous())
 
         if self.comm_size_polar > 1:
             chan_shapes = compute_split_shapes(num_chans, self.comm_size_polar)

--- a/torch_harmonics/sht.py
+++ b/torch_harmonics/sht.py
@@ -129,7 +129,10 @@ class RealSHT(nn.Module):
         out_re = torch.einsum("...mk,mlk->...lm", x_re, w)
         out_im = torch.einsum("...mk,mlk->...lm", x_im, w)
 
-        return torch.complex(out_re, out_im)
+        # the ...lm einsum output is non-contiguous (l ends up stride-1, m slow); torch.complex
+        # preserves those strides, but inductor's meta kernel for aten.complex predicts a contiguous
+        # layout, tripping assert_size_stride under torch.compile(dynamic=False). Force contiguous.
+        return torch.complex(out_re.contiguous(), out_im.contiguous())
 
 
 class InverseRealSHT(nn.Module):
@@ -222,7 +225,9 @@ class InverseRealSHT(nn.Module):
         w = self.pct.to(x_re.dtype)
         out_re = torch.einsum("...ml,mkl->...km", x_re, w)
         out_im = torch.einsum("...ml,mkl->...km", x_im, w)
-        x = torch.complex(out_re, out_im)
+        # force contiguous: the einsum output is non-contiguous and inductor's aten.complex meta
+        # predicts a contiguous layout, tripping assert_size_stride under torch.compile (see fwd SHT).
+        x = torch.complex(out_re.contiguous(), out_im.contiguous())
 
         # apply the inverse (real) FFT
         x = irfft(x, n=self.nlon, dim=-1, norm="forward")


### PR DESCRIPTION
This fixes a torch.compile error for the makani losses on CPU.