### PR TITLE
Streamline docstrings and fix documentation rendering bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ __pycache__
 *.so
 checkpoints
 
+# Build artifacts
+build/
+*.egg-info
+
 # Kitmaker deployment secrets (never commit)
 scripts/kitmaker.env
 *.env

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,10 @@ bibtex_default_style = "unsrt"
 bibtex_reference_style = "label"
 
 templates_path = ["_templates"]
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+# "jupyter_execute" holds myst-nb's copies of the rendered notebooks; without it
+# a rebuild picks them up as source documents and warns about duplicate labels
+# and pages missing from the toctree.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "jupyter_execute"]
 
 # MyST (Markdown) options
 myst_enable_extensions = [
@@ -67,6 +70,11 @@ autodoc_default_options = {
 }
 autodoc_typehints = "description"
 autodoc_member_order = "bysource"
+# Methods we do not document ourselves (e.g. an undocumented ``forward`` or
+# ``to``) would otherwise inherit ``torch.nn.Module``'s docstring, which renders
+# generic PyTorch boilerplate ("Define the computation performed at every call")
+# on our pages and emits cross-references to targets torch does not publish.
+autodoc_inherit_docstrings = False
 # NOTE: torch_harmonics registers custom ops at import time and has no
 # pure-Python fallback for its compiled helper modules, so the package must be
 # *installed* (``pip install -e ".[docs]"``) before building the docs. A
@@ -107,7 +115,28 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "torch": ("https://pytorch.org/docs/stable/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
 }
+
+# -- nitpicky mode -----------------------------------------------------------
+
+# Build with -n so that a typo'd or stale cross-reference is reported. Combined
+# with the CI "-W" flag this turns broken references into build failures.
+nitpicky = True
+
+# References that can never resolve and are not worth rewriting:
+nitpick_ignore = [
+    # Napoleon renders a numpydoc type of "float, optional" as the type field
+    # "float, optional"; the Python domain then tries to resolve the trailing
+    # "optional" as if it were a class.
+    ("py:class", "optional"),
+    # Not published in torch's objects.inv.
+    ("py:class", "torch.distributed.ProcessGroup"),
+    ("py:func", "torch.distributed.new_subgroups_by_enumeration"),
+    # Abstract base shown by "show-inheritance"; intentionally not part of the
+    # public API reference, so there is no page to link to.
+    ("py:class", "torch_harmonics.disco.convolution.DiscreteContinuousConv"),
+]
 
 # -- HTML output -------------------------------------------------------------
 

--- a/torch_harmonics/attention/attention.py
+++ b/torch_harmonics/attention/attention.py
@@ -67,24 +67,24 @@ class AttentionS2(nn.Module):
     :class:`~torch_harmonics.NeighborhoodAttentionS2`.
 
     Parameters
-    -----------
-    in_channels: int
+    ----------
+    in_channels : int
         number of channels of the input signal (corresponds to embed_dim in MHA in PyTorch)
-    num_heads: int
+    num_heads : int
         number of attention heads
-    in_shape: tuple
+    in_shape : tuple
         shape of the input grid
-    out_shape: tuple
+    out_shape : tuple
         shape of the output grid
-    grid_in: str, optional
+    grid_in : str, optional
         input grid type, ``"equiangular"`` by default
-    grid_out: str, optional
+    grid_out : str, optional
         output grid type, ``"equiangular"`` by default
-    bias: bool, optional
+    bias : bool, optional
         if specified, adds bias to input / output projection layers
-    k_channels: int
+    k_channels : int
         number of dimensions for interior inner product in the attention matrix (corresponds to kdim in MHA in PyTorch)
-    out_channels: int, optional
+    out_channels : int, optional
         number of dimensions for interior inner product in the attention matrix (corresponds to vdim in MHA in PyTorch)
 
     References
@@ -175,11 +175,11 @@ class AttentionS2(nn.Module):
 
         Parameters
         ----------
-        query: torch.Tensor
+        query : torch.Tensor
             Query signal of shape ``(batch, in_channels, nlat_out, nlon_out)`` (sampled on the output grid).
-        key: torch.Tensor, optional
+        key : torch.Tensor, optional
             Key signal of shape ``(batch, in_channels, nlat_in, nlon_in)``. Defaults to ``query`` (self-attention).
-        value: torch.Tensor, optional
+        value : torch.Tensor, optional
             Value signal of shape ``(batch, in_channels, nlat_in, nlon_in)``. Defaults to ``query`` (self-attention).
 
         Returns
@@ -278,29 +278,29 @@ class NeighborhoodAttentionS2(nn.Module):
     depends on their contribution to the softmax as well as their quadrature weights.
 
     Parameters
-    -----------
-    in_channels: int
+    ----------
+    in_channels : int
         number of channels of the input signal (corresponds to embed_dim in MHA in PyTorch)
-    in_shape: tuple
+    in_shape : tuple
         shape of the input grid
-    out_shape: tuple
+    out_shape : tuple
         shape of the output grid
-    grid_in: str, optional
+    grid_in : str, optional
         input grid type, ``"equiangular"`` by default
-    grid_out: str, optional
+    grid_out : str, optional
         output grid type, ``"equiangular"`` by default
-    bias: bool, optional
+    bias : bool, optional
         if specified, adds bias to input / output projection layers
-    theta_cutoff: float, optional
+    theta_cutoff : float, optional
         Angular radius of the geodesic neighborhood disk, in radians. Input points
         farther than this from an output location are excluded from its attention.
         If None (default), it is set to one latitudinal grid spacing of the coarser
         of the input and output grids, i.e. ``pi / (nlat - 1)``. Must be positive.
-    k_channels: int
+    k_channels : int
         number of dimensions for interior inner product in the attention matrix (corresponds to kdim in MHA in PyTorch)
-    out_channels: int, optional
+    out_channels : int, optional
         number of dimensions for interior inner product in the attention matrix (corresponds to vdim in MHA in PyTorch)
-    optimized_kernel: Optional[bool]
+    optimized_kernel : Optional[bool]
         Whether to use the optimized kernel (if available)
 
     References
@@ -456,12 +456,12 @@ class NeighborhoodAttentionS2(nn.Module):
 
         Parameters
         ----------
-        query: torch.Tensor
+        query : torch.Tensor
             Query signal of shape ``(batch, in_channels, nlat_out, nlon_out)`` (sampled on the output grid).
-        key: torch.Tensor, optional
+        key : torch.Tensor, optional
             Key signal of shape ``(batch, in_channels, nlat_in, nlon_in)`` (sampled on the input grid).
             Defaults to ``query`` (self-attention, which requires matching input and output grids).
-        value: torch.Tensor, optional
+        value : torch.Tensor, optional
             Value signal of shape ``(batch, in_channels, nlat_in, nlon_in)`` (sampled on the input grid).
             Defaults to ``query`` (self-attention, which requires matching input and output grids).
 

--- a/torch_harmonics/cache.py
+++ b/torch_harmonics/cache.py
@@ -43,7 +43,7 @@ def lru_cache(maxsize=20, typed=False, copy=False):
     deep copies of cached results to prevent unintended modifications to cached objects.
 
     Parameters
-    -----------
+    ----------
     maxsize : int, optional
         Maximum number of items to cache, by default 20
     typed : bool, optional
@@ -56,8 +56,8 @@ def lru_cache(maxsize=20, typed=False, copy=False):
     function
         Decorated function with LRU caching
 
-    Example
-    -------
+    Examples
+    --------
     >>> @lru_cache(maxsize=10, copy=True)
     ... def expensive_function(x):
     ...     return [x, x*2, x*3]

--- a/torch_harmonics/disco/convolution.py
+++ b/torch_harmonics/disco/convolution.py
@@ -93,36 +93,36 @@ def _normalize_convolution_tensor_s2(
     quantity, avoiding the per-(ikernel, ilat_out) Python double loop.
 
     Parameters
-    -----------
-    psi_idx: torch.Tensor
+    ----------
+    psi_idx : torch.Tensor
         Index tensor for the sparse convolution tensor.
-    psi_vals: torch.Tensor
+    psi_vals : torch.Tensor
         Value tensor for the sparse convolution tensor.
-    in_shape: Tuple[int]
+    in_shape : Tuple[int]
         Tuple of (nlat_in, nlon_in) representing input grid dimensions.
-    out_shape: Tuple[int]
+    out_shape : Tuple[int]
         Tuple of (nlat_out, nlon_out) representing output grid dimensions.
-    kernel_size: int
+    kernel_size : int
         Number of kernel basis functions.
-    quad_weights: torch.Tensor
+    quad_weights : torch.Tensor
         Quadrature weights for numerical integration.
-    theta_cutoff: float
+    theta_cutoff : float
         Angular cutoff of the filter support (radians). Required by the "geometric" mode,
         which normalizes by the theoretical area measure of the spherical cap of half-angle
         theta_cutoff; unused by other modes.
-    transpose_normalization: bool
+    transpose_normalization : bool
         If True, applies normalization in transpose direction.
-    basis_norm_mode: str
+    basis_norm_mode : str
         Normalization mode, one of ["none", "nodal", "modal", "mean", "support", "geometric"].
         The legacy names "individual" and "area ratio" are accepted as deprecated aliases
         for "nodal" and "geometric" respectively; each emits a DeprecationWarning.
-    merge_quadrature: bool
+    merge_quadrature : bool
         If True, multiplies values by quadrature weights.
-    isotropic_mask: Optional[Sequence[bool]]
+    isotropic_mask : Optional[Sequence[bool]]
         Per-kernel-index boolean mask; True marks an axisymmetric (m=0) basis function.
         Used by the "modal" mode to decide which kernels get a weighted-mean bias
         subtraction (anisotropic only). If None, only kernel index 0 is treated as isotropic.
-    eps: float
+    eps : float
         Small epsilon value to prevent division by zero.
 
     Returns
@@ -261,33 +261,33 @@ def _precompute_convolution_tensor_s2(
     $$
 
     Parameters
-    -----------
-    in_shape: Tuple[int]
+    ----------
+    in_shape : Tuple[int]
         Input shape of the convolution tensor
-    out_shape: Tuple[int]
+    out_shape : Tuple[int]
         Output shape of the convolution tensor
-    filter_basis: FilterBasis
+    filter_basis : FilterBasis
         Filter basis functions
-    grid_in: str
+    grid_in : str
         Input grid type
-    grid_out: str
+    grid_out : str
         Output grid type
-    theta_cutoff: float
+    theta_cutoff : float
         Theta cutoff for the filter basis functions
-    theta_eps: float
+    theta_eps : float
         Epsilon for the theta cutoff
-    transpose_normalization: bool
+    transpose_normalization : bool
         Whether to normalize the convolution tensor in the transpose direction
-    basis_norm_mode: str
+    basis_norm_mode : str
         Mode for basis normalization
-    merge_quadrature: bool
+    merge_quadrature : bool
         Whether to merge the quadrature weights into the convolution tensor
 
     Returns
     -------
-    out_idx: torch.Tensor
+    out_idx : torch.Tensor
         Index tensor of the convolution tensor
-    out_vals: torch.Tensor
+    out_vals : torch.Tensor
         Values tensor of the convolution tensor
 
     """
@@ -398,23 +398,23 @@ class DiscreteContinuousConv(nn.Module, metaclass=abc.ABCMeta):
     Abstract base class for discrete-continuous convolutions
 
     Parameters
-    -----------
-    in_channels: int
+    ----------
+    in_channels : int
         Number of input channels
-    out_channels: int
+    out_channels : int
         Number of output channels
-    kernel_shape: Union[int, Tuple[int], Tuple[int, int]]
+    kernel_shape : Union[int, Tuple[int], Tuple[int, int]]
         Shape of the kernel
-    basis_type: Optional[str]
+    basis_type : Optional[str]
         Type of the basis functions
-    groups: Optional[int]
+    groups : Optional[int]
         Number of groups
-    bias: Optional[bool]
+    bias : Optional[bool]
         Whether to use bias
 
     Returns
     -------
-    out: torch.Tensor
+    torch.Tensor
         Output tensor
     """
 
@@ -493,34 +493,34 @@ class DiscreteContinuousConvS2(DiscreteContinuousConv):
             visualisations, and worked examples.
 
     Parameters
-    -----------
-    in_channels: int
+    ----------
+    in_channels : int
         Number of input channels
-    out_channels: int
+    out_channels : int
         Number of output channels
-    in_shape: Tuple[int]
+    in_shape : Tuple[int]
         Input shape of the convolution tensor
-    out_shape: Tuple[int]
+    out_shape : Tuple[int]
         Output shape of the convolution tensor
-    kernel_shape: Union[int, Tuple[int], Tuple[int, int]]
+    kernel_shape : Union[int, Tuple[int], Tuple[int, int]]
         Shape of the kernel
-    basis_type: Optional[str]
+    basis_type : Optional[str]
         Type of the basis functions
-    basis_norm_mode: Optional[str]
+    basis_norm_mode : Optional[str]
         Mode for basis normalization
-    groups: Optional[int]
+    groups : Optional[int]
         Number of groups
-    grid_in: Optional[str]
+    grid_in : Optional[str]
         Input grid type
-    grid_out: Optional[str]
+    grid_out : Optional[str]
         Output grid type
-    bias: Optional[bool]
+    bias : Optional[bool]
         Whether to use bias
-    theta_cutoff: Optional[float]
+    theta_cutoff : Optional[float]
         Theta cutoff for the filter basis functions
-    optimized_kernel: Optional[bool]
+    optimized_kernel : Optional[bool]
         Whether to use the optimized kernel (if available)
-    fused: Optional[bool]
+    fused : Optional[bool]
         When True, fuses the sparse contraction and weight multiplication into a single
         autograd region to avoid storing the K-expanded intermediate in the graph.
         Trades one extra contraction recompute in backward for K× memory savings.
@@ -683,7 +683,7 @@ class DiscreteContinuousConvS2(DiscreteContinuousConv):
 
         Parameters
         ----------
-        x: torch.Tensor
+        x : torch.Tensor
             Input signal of shape ``(batch, in_channels, nlat_in, nlon_in)``.
 
         Returns
@@ -863,32 +863,32 @@ class DiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
             visualisations, and worked examples.
 
     Parameters
-    -----------
-    in_channels: int
+    ----------
+    in_channels : int
         Number of input channels
-    out_channels: int
+    out_channels : int
         Number of output channels
-    in_shape: Tuple[int]
+    in_shape : Tuple[int]
         Input shape of the convolution tensor
-    out_shape: Tuple[int]
+    out_shape : Tuple[int]
         Output shape of the convolution tensor
-    kernel_shape: Union[int, Tuple[int], Tuple[int, int]]
+    kernel_shape : Union[int, Tuple[int], Tuple[int, int]]
         Shape of the kernel
-    basis_type: Optional[str]
+    basis_type : Optional[str]
         Type of the basis functions
-    basis_norm_mode: Optional[str]
+    basis_norm_mode : Optional[str]
         Mode for basis normalization
-    groups: Optional[int]
+    groups : Optional[int]
         Number of groups
-    grid_in: Optional[str]
+    grid_in : Optional[str]
         Input grid type
-    grid_out: Optional[str]
+    grid_out : Optional[str]
         Output grid type
-    bias: Optional[bool]
+    bias : Optional[bool]
         Whether to use bias
-    theta_cutoff: Optional[float]
+    theta_cutoff : Optional[float]
         Theta cutoff for the filter basis functions
-    optimized_kernel: Optional[bool]
+    optimized_kernel : Optional[bool]
         Whether to use the optimized kernel (if available)
 
     References
@@ -977,7 +977,7 @@ class DiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
 
         Parameters
         ----------
-        x: torch.Tensor
+        x : torch.Tensor
             Input signal of shape ``(batch, in_channels, nlat_in, nlon_in)``.
 
         Returns

--- a/torch_harmonics/distributed/distributed_attention.py
+++ b/torch_harmonics/distributed/distributed_attention.py
@@ -454,7 +454,7 @@ class DistributedNeighborhoodAttentionS2(NeighborhoodAttentionS2):
     of key/value chunks over the azimuth group so that every output point can
     attend to its full spherical neighborhood.
 
-    Inherits learnable parameters from :class:`NeighborhoodAttentionS2`.
+    Inherits learnable parameters from :class:`torch_harmonics.NeighborhoodAttentionS2`.
 
     .. seealso::
         :class:`torch_harmonics.NeighborhoodAttentionS2`

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -80,20 +80,20 @@ def _split_distributed_convolution_tensor_s2(
 
     Parameters
     ----------
-    idx: torch.Tensor
+    idx : torch.Tensor
         Indices of the pre-computed convolution tensor
-    vals: torch.Tensor
+    vals : torch.Tensor
         Values of the pre-computed convolution tensor
-    in_shape: Tuple[int]
+    in_shape : Tuple[int]
         Shape of the input tensor (nlat_in, nlon_in)
-    out_shape: Tuple[int]
+    out_shape : Tuple[int]
         Shape of the output tensor (nlat_out, nlon_out)
 
     Returns
     -------
-    idx: torch.Tensor
+    idx : torch.Tensor
         Filtered indices corresponding to the local latitude slice
-    vals: torch.Tensor
+    vals : torch.Tensor
         Filtered values corresponding to the local latitude slice
     """
 
@@ -149,33 +149,33 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
 
     Parameters
     ----------
-    in_channels: int
+    in_channels : int
         Number of input channels
-    out_channels: int
+    out_channels : int
         Number of output channels
-    in_shape: Tuple[int]
+    in_shape : Tuple[int]
         Shape of the input tensor
-    out_shape: Tuple[int]
+    out_shape : Tuple[int]
         Shape of the output tensor
-    kernel_shape: Union[int, Tuple[int], Tuple[int, int]]
+    kernel_shape : Union[int, Tuple[int], Tuple[int, int]]
         Shape of the kernel
-    basis_type: Optional[str]
+    basis_type : Optional[str]
         Type of basis to use
-    basis_norm_mode: Optional[str]
+    basis_norm_mode : Optional[str]
         Normalization mode for the filter basis
-    groups: Optional[int]
+    groups : Optional[int]
         Number of groups
-    grid_in: Optional[str]
+    grid_in : Optional[str]
         Grid type for the input tensor
-    grid_out: Optional[str]
+    grid_out : Optional[str]
         Grid type for the output tensor
-    bias: Optional[bool]
+    bias : Optional[bool]
         Whether to use bias
-    theta_cutoff: Optional[float]
+    theta_cutoff : Optional[float]
         Theta cutoff for the filter basis
-    optimized_kernel: Optional[bool]
+    optimized_kernel : Optional[bool]
         Use the optimized CUDA contraction kernel. Required when ``fused=True``.
-    fused: bool
+    fused : bool
         Mirrors the serial conv. ``False`` (default): standard all-to-all
         (the K-expanded intermediate is saved for backward). ``True``:
         reordered all-to-all — the weight einsum runs before the collectives
@@ -185,7 +185,7 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
 
     Returns
     -------
-    out: torch.Tensor
+    torch.Tensor
         Output tensor
 
     References
@@ -450,34 +450,34 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
 
     Parameters
     ----------
-    in_channels: int
+    in_channels : int
         Number of input channels
-    out_channels: int
+    out_channels : int
         Number of output channels
-    in_shape: Tuple[int]
+    in_shape : Tuple[int]
         Shape of the input tensor
-    out_shape: Tuple[int]
+    out_shape : Tuple[int]
         Shape of the output tensor
-    kernel_shape: Union[int, Tuple[int], Tuple[int, int]]
+    kernel_shape : Union[int, Tuple[int], Tuple[int, int]]
         Shape of the kernel
-    basis_type: Optional[str]
+    basis_type : Optional[str]
         Type of basis to use
-    basis_norm_mode: Optional[str]
+    basis_norm_mode : Optional[str]
         Normalization mode for the filter basis
-    groups: Optional[int]
+    groups : Optional[int]
         Number of groups
-    grid_in: Optional[str]
+    grid_in : Optional[str]
         Grid type for the input tensor
-    grid_out: Optional[str]
+    grid_out : Optional[str]
         Grid type for the output tensor
-    bias: Optional[bool]
+    bias : Optional[bool]
         Whether to use bias
-    theta_cutoff: Optional[float]
+    theta_cutoff : Optional[float]
         Theta cutoff for the filter basis
 
     Returns
     -------
-    out: torch.Tensor
+    torch.Tensor
         Output tensor
 
     References

--- a/torch_harmonics/distributed/distributed_quadrature.py
+++ b/torch_harmonics/distributed/distributed_quadrature.py
@@ -51,13 +51,13 @@ class DistributedQuadratureS2(torch.nn.Module):
             documentation.
 
     Parameters
-    -----------
-    img_shape: Tuple[int]
+    ----------
+    img_shape : Tuple[int]
         Spatial grid shape ``(nlat, nlon)``.
-    grid: str, optional
+    grid : str, optional
         Quadrature grid type (``"equiangular"``, ``"legendre-gauss"``,
         ``"lobatto"``, ``"equiangular-trapezoidal"``), by default ``"equiangular"``.
-    normalize: bool, optional
+    normalize : bool, optional
         If ``True``, divides weights by ``4π`` to return an average instead of
         an integral, by default ``False``.
 

--- a/torch_harmonics/distributed/distributed_resample.py
+++ b/torch_harmonics/distributed/distributed_resample.py
@@ -56,7 +56,7 @@ class DistributedResampleS2(nn.Module):
             documentation.
 
     Parameters
-    -----------
+    ----------
     nlat_in : int
         Number of input latitude points
     nlon_in : int

--- a/torch_harmonics/distributed/distributed_sht.py
+++ b/torch_harmonics/distributed/distributed_sht.py
@@ -88,24 +88,24 @@ class DistributedRealSHT(nn.Module):
 
     Parameters
     ----------
-    nlat: int
+    nlat : int
         Number of latitude points
-    nlon: int
+    nlon : int
         Number of longitude points
-    lmax: int
+    lmax : int
         Maximum spherical harmonic degree
-    mmax: int
+    mmax : int
         Maximum spherical harmonic order
-    grid: str
+    grid : str
         Grid type (``"equiangular"``, ``"legendre-gauss"``, ``"lobatto"``, ``"equiangular-trapezoidal"``), by default ``"equiangular"``
-    norm: str
+    norm : str
         Normalization type (``"ortho"``, ``"schmidt"``, ``"unnorm"``), by default ``"ortho"``
-    csphase: bool
+    csphase : bool
         Whether to apply the Condon-Shortley phase factor, by default True
 
     Returns
     -------
-    x: torch.Tensor
+    torch.Tensor
         Tensor of shape (..., lmax, mmax)
 
     References
@@ -259,24 +259,24 @@ class DistributedInverseRealSHT(nn.Module):
 
     Parameters
     ----------
-    nlat: int
+    nlat : int
         Number of latitude points
-    nlon: int
+    nlon : int
         Number of longitude points
-    lmax: int
+    lmax : int
         Maximum spherical harmonic degree
-    mmax: int
+    mmax : int
         Maximum spherical harmonic order
-    grid: str
+    grid : str
         Grid type (``"equiangular"``, ``"legendre-gauss"``, ``"lobatto"``, ``"equiangular-trapezoidal"``), by default ``"equiangular"``
-    norm: str
+    norm : str
         Normalization type (``"ortho"``, ``"schmidt"``, ``"unnorm"``), by default ``"ortho"``
-    csphase: bool
+    csphase : bool
         Whether to apply the Condon-Shortley phase factor, by default True
 
     Returns
     -------
-    x: torch.Tensor
+    torch.Tensor
         Tensor of shape (..., lmax, mmax)
 
     References
@@ -409,24 +409,24 @@ class DistributedRealVectorSHT(nn.Module):
 
     Parameters
     ----------
-    nlat: int
+    nlat : int
         Number of latitude points
-    nlon: int
+    nlon : int
         Number of longitude points
-    lmax: int
+    lmax : int
         Maximum spherical harmonic degree
-    mmax: int
+    mmax : int
         Maximum spherical harmonic order
-    grid: str
+    grid : str
         Grid type (``"equiangular"``, ``"legendre-gauss"``, ``"lobatto"``, ``"equiangular-trapezoidal"``), by default ``"equiangular"``
-    norm: str
+    norm : str
         Normalization type (``"ortho"``, ``"schmidt"``, ``"unnorm"``), by default ``"ortho"``
-    csphase: bool
+    csphase : bool
         Whether to apply the Condon-Shortley phase factor, by default True
 
     Returns
     -------
-    x: torch.Tensor
+    torch.Tensor
         Tensor of shape (..., lmax, mmax)
 
     References
@@ -572,24 +572,24 @@ class DistributedInverseRealVectorSHT(nn.Module):
 
     Parameters
     ----------
-    nlat: int
+    nlat : int
         Number of latitude points
-    nlon: int
+    nlon : int
         Number of longitude points
-    lmax: int
+    lmax : int
         Maximum spherical harmonic degree
-    mmax: int
+    mmax : int
         Maximum spherical harmonic order
-    grid: str
+    grid : str
         Grid type (``"equiangular"``, ``"legendre-gauss"``, ``"lobatto"``, ``"equiangular-trapezoidal"``), by default ``"equiangular"``
-    norm: str
+    norm : str
         Normalization type (``"ortho"``, ``"schmidt"``, ``"unnorm"``), by default ``"ortho"``
-    csphase: bool
+    csphase : bool
         Whether to apply the Condon-Shortley phase factor, by default True
 
     Returns
     -------
-    x: torch.Tensor
+    torch.Tensor
         Tensor of shape (..., lmax, mmax)
 
     References

--- a/torch_harmonics/distributed/distributed_spectral_convolution.py
+++ b/torch_harmonics/distributed/distributed_spectral_convolution.py
@@ -85,24 +85,24 @@ class DistributedSpectralConvS2(nn.Module):
             documentation.
 
     Parameters
-    -----------
-    in_shape: Tuple[int]
+    ----------
+    in_shape : Tuple[int]
         Spatial input grid shape ``(nlat, nlon)``.
-    out_shape: Tuple[int]
+    out_shape : Tuple[int]
         Spatial output grid shape ``(nlat, nlon)``.
-    in_channels: int
+    in_channels : int
         Number of input channels.
-    out_channels: int
+    out_channels : int
         Number of output channels.
-    num_groups: int, optional
+    num_groups : int, optional
         Number of channel groups for grouped spectral weights, by default 1.
-    grid_in: str, optional
+    grid_in : str, optional
         Grid used for the forward distributed SHT (``"equiangular"``,
         ``"legendre-gauss"``, ``"lobatto"``, ``"equiangular-trapezoidal"``), by default
         ``"equiangular"``.
-    grid_out: str, optional
+    grid_out : str, optional
         Grid used for the inverse distributed SHT, same options as ``grid_in``.
-    bias: bool, optional
+    bias : bool, optional
         If ``True``, adds a learnable spectral bias computed from the spatial
         integral (replicated across process groups as needed), by default
         ``False``.
@@ -115,7 +115,7 @@ class DistributedSpectralConvS2(nn.Module):
 
     Returns
     -------
-    x: torch.Tensor
+    torch.Tensor
         Tensor of shape ``(..., out_channels, out_shape[0], out_shape[1])``.
 
     Notes

--- a/torch_harmonics/examples/losses.py
+++ b/torch_harmonics/examples/losses.py
@@ -60,7 +60,7 @@ class DiceLossS2(nn.Module):
     Dice loss for spherical segmentation tasks.
 
     Parameters
-    -----------
+    ----------
     nlat : int
         Number of latitude points
     nlon : int
@@ -139,7 +139,7 @@ class CrossEntropyLossS2(nn.Module):
     Cross-entropy loss for spherical classification tasks.
 
     Parameters
-    -----------
+    ----------
     nlat : int
         Number of latitude points
     nlon : int
@@ -185,7 +185,7 @@ class FocalLossS2(nn.Module):
     Focal loss for spherical classification tasks.
 
     Parameters
-    -----------
+    ----------
     nlat : int
         Number of latitude points
     nlon : int
@@ -256,12 +256,17 @@ class SphericalLossBase(nn.Module, ABC):
     def _compute_loss_term(self, prd: torch.Tensor, tar: torch.Tensor) -> torch.Tensor:
         """Abstract method that must be implemented by child classes to compute loss terms.
 
-        Args:
-            prd (torch.Tensor): Prediction tensor
-            tar (torch.Tensor): Target tensor
+        Parameters
+        ----------
+        prd : torch.Tensor
+            Prediction tensor
+        tar : torch.Tensor
+            Target tensor
 
-        Returns:
-            torch.Tensor: Computed loss term before integration
+        Returns
+        -------
+        torch.Tensor
+            Computed loss term before integration
         """
         pass
 
@@ -272,13 +277,19 @@ class SphericalLossBase(nn.Module, ABC):
     def forward(self, prd: torch.Tensor, tar: torch.Tensor, mask: Optional[torch.Tensor] = None) -> torch.Tensor:
         """Common forward pass that handles masking and reduction.
 
-        Args:
-            prd (torch.Tensor): Prediction tensor
-            tar (torch.Tensor): Target tensor
-            mask (Optional[torch.Tensor], optional): Mask tensor. Defaults to None.
+        Parameters
+        ----------
+        prd : torch.Tensor
+            Prediction tensor
+        tar : torch.Tensor
+            Target tensor
+        mask : torch.Tensor, optional
+            Mask tensor, by default None
 
-        Returns:
-            torch.Tensor: Final loss value
+        Returns
+        -------
+        torch.Tensor
+            Final loss value
         """
         loss_term = self._compute_loss_term(prd, tar)
         # Integrate over the sphere for each item in the batch

--- a/torch_harmonics/examples/metrics.py
+++ b/torch_harmonics/examples/metrics.py
@@ -56,7 +56,7 @@ def _get_stats_multiclass(
     to account for the spherical geometry.
 
     Parameters
-    -----------
+    ----------
     output : torch.LongTensor
         Predicted class labels
     target : torch.LongTensor
@@ -116,7 +116,7 @@ def _predict_classes(logits: torch.Tensor) -> torch.Tensor:
     Convert logits to class predictions using softmax and argmax.
 
     Parameters
-    -----------
+    ----------
     logits : torch.Tensor
         Input logits tensor
 
@@ -137,7 +137,7 @@ class BaseMetricS2(nn.Module):
     on the sphere.
 
     Parameters
-    -----------
+    ----------
     nlat : int
         Number of latitude points
     nlon : int
@@ -206,7 +206,7 @@ class IntersectionOverUnionS2(BaseMetricS2):
     properly weighted by quadrature weights to account for spherical geometry.
 
     Parameters
-    -----------
+    ----------
     nlat : int
         Number of latitude points
     nlon : int
@@ -252,7 +252,7 @@ class AccuracyS2(BaseMetricS2):
     properly weighted by quadrature weights to account for spherical geometry.
 
     Parameters
-    -----------
+    ----------
     nlat : int
         Number of latitude points
     nlon : int

--- a/torch_harmonics/examples/models/_layers.py
+++ b/torch_harmonics/examples/models/_layers.py
@@ -86,16 +86,16 @@ def trunc_normal_(tensor, mean=0.0, std=1.0, a=-2.0, b=2.0):
     best when :math:`a \\leq \text{mean} \\leq b`.
 
     Parameters
-    -----------
-    tensor: torch.Tensor
+    ----------
+    tensor : torch.Tensor
         an n-dimensional `torch.Tensor`
-    mean: float
+    mean : float
         the mean of the normal distribution
-    std: float
+    std : float
         the standard deviation of the normal distribution
-    a: float
+    a : float
         the minimum cutoff value, by default -2.0
-    b: float
+    b : float
         the maximum cutoff value
     Examples
     --------
@@ -280,7 +280,7 @@ class RealFFT2(nn.Module):
     the interface of spherical harmonic transforms for consistency.
 
     Parameters
-    -----------
+    ----------
     nlat : int
         Number of latitude points
     nlon : int
@@ -314,7 +314,7 @@ class InverseRealFFT2(nn.Module):
     the interface of inverse spherical harmonic transforms for consistency.
 
     Parameters
-    -----------
+    ----------
     nlat : int
         Number of latitude points
     nlon : int
@@ -527,7 +527,7 @@ class SpectralPositionEmbedding(PositionEmbedding):
     spherical data processing.
 
     Parameters
-    -----------
+    ----------
     img_shape : tuple, optional
         Image shape (height, width), by default (480, 960)
     grid : str, optional

--- a/torch_harmonics/examples/models/lsno.py
+++ b/torch_harmonics/examples/models/lsno.py
@@ -432,8 +432,8 @@ class LocalSphericalNeuralOperator(nn.Module):
     bias : bool, optional
         Whether to use a bias, by default False
 
-    Example
-    ----------
+    Examples
+    --------
     >>> model = LocalSphericalNeuralOperator(
     ...         img_shape=(128, 256),
     ...         scale_factor=4,

--- a/torch_harmonics/examples/models/s2segformer.py
+++ b/torch_harmonics/examples/models/s2segformer.py
@@ -54,7 +54,7 @@ class OverlapPatchMerging(nn.Module):
     convolutions on the sphere, followed by layer normalization.
 
     Parameters
-    -----------
+    ----------
     in_shape : tuple, optional
         Input shape (nlat, nlon), by default (721, 1440)
     out_shape : tuple, optional
@@ -139,7 +139,7 @@ class MixFFN(nn.Module):
     with discrete-continuous convolutions on the sphere.
 
     Parameters
-    -----------
+    ----------
     shape : tuple
         Shape (nlat, nlon) of the input
     inout_channels : int
@@ -256,7 +256,7 @@ class AttentionWrapper(nn.Module):
     normalization and drop path regularization.
 
     Parameters
-    -----------
+    ----------
     channels : int
         Number of channels
     shape : tuple
@@ -343,7 +343,7 @@ class TransformerBlock(nn.Module):
     in a hierarchical structure for processing spherical data.
 
     Parameters
-    -----------
+    ----------
     in_shape : tuple
         Input shape (nlat, nlon)
     out_shape : tuple
@@ -491,7 +491,7 @@ class Upsampling(nn.Module):
     or bilinear resampling on spherical data.
 
     Parameters
-    -----------
+    ----------
     in_shape : tuple
         Input shape (nlat, nlon)
     out_shape : tuple
@@ -588,7 +588,7 @@ class SphericalSegformer(nn.Module):
     Spherical segformer model designed to approximate mappings from spherical signals to spherical segmentation masks
 
     Parameters
-    -----------
+    ----------
     img_size : tuple, optional
         Shape of the input channels, by default (128, 256)
     grid : str, optional
@@ -603,9 +603,9 @@ class SphericalSegformer(nn.Module):
         Dimension of the embeddings for each block, has to be the same length as heads
     heads : List[int], optional
         Number of heads for each block in the network, has to be the same length as embed_dims
-    depths: List[int], optional
+    depths : List[int], optional
         Number of repetitions of attentions blocks and ffn mixers per layer. Has to be the same length as embed_dims and heads
-    scale_factor: int, optional
+    scale_factor : int, optional
         Scale factor to use, by default 2
     activation_function : str, optional
         Activation function to use, by default "gelu"
@@ -628,8 +628,8 @@ class SphericalSegformer(nn.Module):
     bias : bool, optional
         Whether to use bias, by default True
 
-    Example
-    -----------
+    Examples
+    --------
     >>> model = SphericalSegformer(
     ...         img_size=(128, 256),
     ...         scale_factor=4,

--- a/torch_harmonics/examples/models/s2transformer.py
+++ b/torch_harmonics/examples/models/s2transformer.py
@@ -54,7 +54,7 @@ class DiscreteContinuousEncoder(nn.Module):
     reducing the spatial resolution while maintaining the spectral properties of the data.
 
     Parameters
-    -----------
+    ----------
     in_shape : tuple, optional
         Input shape (nlat, nlon), by default (721, 1440)
     out_shape : tuple, optional
@@ -127,7 +127,7 @@ class DiscreteContinuousDecoder(nn.Module):
     followed by discrete-continuous convolutions to restore spatial resolution.
 
     Parameters
-    -----------
+    ----------
     in_shape : tuple, optional
         Input shape (nlat, nlon), by default (480, 960)
     out_shape : tuple, optional
@@ -212,7 +212,7 @@ class SphericalAttentionBlock(nn.Module):
     or neighborhood attention on spherical data, followed by an optional MLP.
 
     Parameters
-    -----------
+    ----------
     in_shape : tuple, optional
         Input shape (nlat, nlon), by default (480, 960)
     out_shape : tuple, optional
@@ -367,7 +367,7 @@ class SphericalTransformer(nn.Module):
     Spherical transformer model designed to approximate mappings from spherical signals to spherical signals
 
     Parameters
-    -----------
+    ----------
     img_size : tuple, optional
         Shape of the input channels, by default (128, 256)
     grid : str, optional
@@ -417,8 +417,8 @@ class SphericalTransformer(nn.Module):
     theta_cutoff : float, optional
         Cutoff radius for neighborhood attention, by default None
 
-    Example
-    -----------
+    Examples
+    --------
     >>> model = SphericalTransformer(
     ...         img_size=(128, 256),
     ...         scale_factor=4,

--- a/torch_harmonics/examples/models/s2unet.py
+++ b/torch_harmonics/examples/models/s2unet.py
@@ -53,7 +53,7 @@ class DownsamplingBlock(nn.Module):
     using discrete-continuous convolutions to maintain spectral properties.
 
     Parameters
-    -----------
+    ----------
     in_shape : tuple
         Input shape (nlat, nlon)
     out_shape : tuple
@@ -219,7 +219,7 @@ class UpsamplingBlock(nn.Module):
     using discrete-continuous convolutions to maintain spectral properties.
 
     Parameters
-    -----------
+    ----------
     in_shape : tuple
         Input shape (nlat, nlon)
     out_shape : tuple
@@ -406,7 +406,7 @@ class SphericalUNet(nn.Module):
     Spherical U-Net model designed to approximate mappings from spherical signals to spherical segmentation masks
 
     Parameters
-    -----------
+    ----------
     img_size : tuple, optional
         Shape of the input channels, by default (128, 256)
     grid : str, optional
@@ -442,8 +442,8 @@ class SphericalUNet(nn.Module):
     upsampling_mode : str, optional
         Upsampling mode ("bilinear", "conv"), by default "bilinear"
 
-    Example
-    -----------
+    Examples
+    --------
     >>> model = SphericalUNet(
     ...         img_size=(128, 256),
     ...         scale_factor=4,

--- a/torch_harmonics/examples/models/sfno.py
+++ b/torch_harmonics/examples/models/sfno.py
@@ -218,8 +218,8 @@ class SphericalFourierNeuralOperator(nn.Module):
     bias : bool, optional
         Whether to use a bias, by default False
 
-    Example:
-    ----------
+    Examples
+    --------
     >>> model = SphericalFourierNeuralOperator(
     ...         img_size=(128, 256),
     ...         scale_factor=4,

--- a/torch_harmonics/examples/pde_sphere.py
+++ b/torch_harmonics/examples/pde_sphere.py
@@ -47,7 +47,7 @@ class SphereSolver(nn.Module):
     - Ginzburg-Landau equation
 
     Parameters
-    -----------
+    ----------
     nlat : int
         Number of latitude points
     nlon : int
@@ -150,7 +150,7 @@ class SphereSolver(nn.Module):
         Plot data on the sphere grid. Requires cartopy for 3d plots.
 
         Parameters
-        -----------
+        ----------
         data : torch.Tensor
             Data to plot
         fig : matplotlib.figure.Figure

--- a/torch_harmonics/examples/shallow_water_equations.py
+++ b/torch_harmonics/examples/shallow_water_equations.py
@@ -48,7 +48,7 @@ class ShallowWaterSolver(nn.Module):
     on a rotating sphere using spectral methods.
 
     Parameters
-    -----------
+    ----------
     nlat : int
         Number of latitude points
     nlon : int

--- a/torch_harmonics/examples/stanford_2d3ds_dataset.py
+++ b/torch_harmonics/examples/stanford_2d3ds_dataset.py
@@ -131,7 +131,7 @@ class Stanford2D3DSDownloader:
         Download and extract the complete dataset.
 
         Parameters
-        -----------
+        ----------
         file_extracted_directory_pairs : list, optional
             List of (filename, extracted_folder_name) pairs, by default DEFAULT_TAR_FILE_PAIRS
 
@@ -196,7 +196,7 @@ class Stanford2D3DSDownloader:
         Convert the downloaded dataset to HDF5 format for efficient loading.
 
         Parameters
-        -----------
+        ----------
         data_folders : list
             List of extracted data folder names
         class_labels : list

--- a/torch_harmonics/legendre.py
+++ b/torch_harmonics/legendre.py
@@ -55,23 +55,23 @@ def legpoly(mmax: int, lmax: int, x: torch.Tensor, norm: Optional[str] = "ortho"
     would be O(nmax^2) kernel launches into O(nmax).
 
     Parameters
-    -----------
-    mmax: int
+    ----------
+    mmax : int
         Maximum order of the spherical harmonics
-    lmax: int
+    lmax : int
         Maximum degree of the spherical harmonics
-    x: torch.Tensor
+    x : torch.Tensor
         Tensor of positions at which to evaluate the Legendre polynomials
-    norm: Optional[str]
+    norm : Optional[str]
         Normalization of the Legendre polynomials
-    inverse: Optional[bool]
+    inverse : Optional[bool]
         Whether to compute the inverse Legendre polynomials
-    csphase: Optional[bool]
+    csphase : Optional[bool]
         Whether to apply the Condon-Shortley phase (-1)^m
 
     Returns
     -------
-    out: torch.Tensor
+    torch.Tensor
         Tensor of Legendre polynomial values
 
     References
@@ -124,23 +124,23 @@ def _precompute_legpoly(mmax: int, lmax: int, t: torch.Tensor, norm: Optional[st
     The resulting tensor has shape (mmax, lmax, len(t)).
 
     Parameters
-    -----------
-    mmax: int
+    ----------
+    mmax : int
         Maximum order of the spherical harmonics
-    lmax: int
+    lmax : int
         Maximum degree of the spherical harmonics
-    t: torch.Tensor
+    t : torch.Tensor
         Tensor of positions at which to evaluate the Legendre polynomials
-    norm: Optional[str]
+    norm : Optional[str]
         Normalization of the Legendre polynomials
-    inverse: Optional[bool]
+    inverse : Optional[bool]
         Whether to compute the inverse Legendre polynomials
-    csphase: Optional[bool]
+    csphase : Optional[bool]
         Whether to apply the Condon-Shortley phase (-1)^m
 
     Returns
     -------
-    out: torch.Tensor
+    torch.Tensor
         Tensor of Legendre polynomial values
     """
     return legpoly(mmax, lmax, torch.cos(t), norm=norm, inverse=inverse, csphase=csphase)
@@ -159,23 +159,23 @@ def _precompute_dlegpoly(mmax: int, lmax: int, t: torch.Tensor, norm: Optional[s
     precomputed associated Legendre table -- so both ``m`` and ``l`` axes are vectorized at once.
 
     Parameters
-    -----------
-    mmax: int
+    ----------
+    mmax : int
         Maximum order of the spherical harmonics
-    lmax: int
+    lmax : int
         Maximum degree of the spherical harmonics
-    t: torch.Tensor
+    t : torch.Tensor
         Tensor of positions at which to evaluate the Legendre polynomials
-    norm: Optional[str]
+    norm : Optional[str]
         Normalization of the Legendre polynomials
-    inverse: Optional[bool]
+    inverse : Optional[bool]
         Whether to compute the inverse Legendre polynomials
-    csphase: Optional[bool]
+    csphase : Optional[bool]
         Whether to apply the Condon-Shortley phase (-1)^m
 
     Returns
     -------
-    out: torch.Tensor
+    torch.Tensor
         Tensor of derivative Legendre polynomial values
 
     References

--- a/torch_harmonics/plotting.py
+++ b/torch_harmonics/plotting.py
@@ -62,7 +62,7 @@ def get_projection(
     Get a cartopy projection object for map plotting.
 
     Parameters
-    -----------
+    ----------
     projection : str
         Projection type ("orthographic", "robinson", "platecarree", "mollweide")
     central_latitude : float, optional
@@ -113,7 +113,7 @@ def plot_sphere(
     Plots a function defined on the sphere using pcolormesh
 
     Parameters
-    -----------
+    ----------
     data : numpy.ndarray or torch.Tensor
         Data to plot with shape (nlat, nlon)
     fig : matplotlib.figure.Figure, optional
@@ -196,7 +196,7 @@ def imshow_sphere(data, fig=None, projection="robinson", title=None, central_lat
     Displays an image on the sphere
 
     Parameters
-    -----------
+    ----------
     data : numpy.ndarray or torch.Tensor
         Data to display with shape (nlat, nlon)
     fig : matplotlib.figure.Figure, optional

--- a/torch_harmonics/quadrature.py
+++ b/torch_harmonics/quadrature.py
@@ -45,7 +45,7 @@ def _precompute_quadrature_weights(
     Precompute grid points and quadrature weights for various quadrature rules.
 
     Parameters
-    -----------
+    ----------
     n : int
         Number of grid points
     grid : str, optional
@@ -98,7 +98,7 @@ def precompute_longitudes(nlon: int):
 
     Returns
     -------
-    lons : torch.Tensor
+    torch.Tensor
         Tensor of longitude values in radians, shape ``(nlon,)``.
     """
     lons = torch.linspace(0, 2 * math.pi, nlon + 1, dtype=torch.float64, requires_grad=False)[:-1]
@@ -143,21 +143,21 @@ def trapezoidal_weights(n: int, a: Optional[float] = -1.0, b: Optional[float] = 
     on the interval [a, b]
 
     Parameters
-    -----------
-    n: int
+    ----------
+    n : int
         Number of quadrature nodes
-    a: Optional[float]
+    a : Optional[float]
         Lower bound of the interval
-    b: Optional[float]
+    b : Optional[float]
         Upper bound of the interval
-    periodic: Optional[bool]
+    periodic : Optional[bool]
         Whether the grid is periodic
 
     Returns
     -------
-    xlg: torch.Tensor
+    xlg : torch.Tensor
         Tensor of quadrature nodes
-    wlg: torch.Tensor
+    wlg : torch.Tensor
         Tensor of quadrature weights
     """
 
@@ -177,19 +177,19 @@ def legendre_gauss_weights(n: int, a: Optional[float] = -1.0, b: Optional[float]
     on the interval [a, b]
 
     Parameters
-    -----------
-    n: int
+    ----------
+    n : int
         Number of quadrature nodes
-    a: Optional[float]
+    a : Optional[float]
         Lower bound of the interval
-    b: Optional[float]
+    b : Optional[float]
         Upper bound of the interval
 
     Returns
     -------
-    xlg: torch.Tensor
+    xlg : torch.Tensor
         Tensor of quadrature nodes
-    wlg: torch.Tensor
+    wlg : torch.Tensor
         Tensor of quadrature weights
     """
 
@@ -208,23 +208,23 @@ def lobatto_weights(n: int, a: Optional[float] = -1.0, b: Optional[float] = 1.0,
     on the interval [a, b]
 
     Parameters
-    -----------
-    n: int
+    ----------
+    n : int
         Number of quadrature nodes
-    a: Optional[float]
+    a : Optional[float]
         Lower bound of the interval
-    b: Optional[float]
+    b : Optional[float]
         Upper bound of the interval
-    tol: Optional[float]
+    tol : Optional[float]
         Tolerance for the iteration
-    maxiter: Optional[int]
+    maxiter : Optional[int]
         Maximum number of iterations
 
     Returns
     -------
-    tlg: torch.Tensor
+    tlg : torch.Tensor
         Tensor of quadrature nodes
-    wlg: torch.Tensor
+    wlg : torch.Tensor
         Tensor of quadrature weights
 
     """
@@ -271,19 +271,19 @@ def clenshaw_curtiss_weights(n: int, a: Optional[float] = -1.0, b: Optional[floa
     This implementation follows
 
     Parameters
-    -----------
-    n: int
+    ----------
+    n : int
         Number of quadrature nodes
-    a: Optional[float]
+    a : Optional[float]
         Lower bound of the interval
-    b: Optional[float]
+    b : Optional[float]
         Upper bound of the interval
 
     Returns
     -------
-    tcc: torch.Tensor
+    tcc : torch.Tensor
         Tensor of quadrature nodes
-    wcc: torch.Tensor
+    wcc : torch.Tensor
         Tensor of quadrature weights
 
     References
@@ -364,13 +364,13 @@ class QuadratureS2(torch.nn.Module):
         \bar{f} = \frac{1}{4\pi} \int_{S^2} f\; dA
 
     Parameters
-    -----------
-    img_shape: Tuple[int]
+    ----------
+    img_shape : Tuple[int]
         Spatial grid shape ``(nlat, nlon)``.
-    grid: str, optional
+    grid : str, optional
         Quadrature grid type (``"equiangular"``, ``"legendre-gauss"``,
         ``"lobatto"``, ``"equiangular-trapezoidal"``), by default ``"equiangular"``.
-    normalize: bool, optional
+    normalize : bool, optional
         If ``True``, divides weights by :math:`4\pi` to return a spherical mean
         instead of an integral, by default ``False``.
 
@@ -446,7 +446,7 @@ class QuadratureS2(torch.nn.Module):
 
         Parameters
         ----------
-        x: torch.Tensor
+        x : torch.Tensor
             Input signal of shape ``(..., nlat, nlon)``. Integration is over the last two
             (spatial) dimensions.
 

--- a/torch_harmonics/resample.py
+++ b/torch_harmonics/resample.py
@@ -77,7 +77,7 @@ class ResampleS2(nn.Module):
       :math:`\sin(x) \approx x` for small :math:`x` to the above expression.
 
     Parameters
-    -----------
+    ----------
     nlat_in : int
         Number of latitude points in the input grid
     nlon_in : int
@@ -224,7 +224,7 @@ class ResampleS2(nn.Module):
 
         Parameters
         ----------
-        x: torch.Tensor
+        x : torch.Tensor
             Input signal of shape ``(..., nlat_in, nlon_in)``. Resampling acts on the
             last two (spatial) dimensions; any leading batch/channel dimensions are
             preserved.

--- a/torch_harmonics/sht.py
+++ b/torch_harmonics/sht.py
@@ -62,22 +62,22 @@ class RealSHT(nn.Module):
             conventions, grid types, and worked examples.
 
     Parameters
-    -----------
-    nlat: int
+    ----------
+    nlat : int
         Number of latitude points
-    nlon: int
+    nlon : int
         Number of longitude points
-    lmax: int
+    lmax : int
         Maximum spherical harmonic degree
-    mmax: int
+    mmax : int
         Maximum spherical harmonic order
-    grid: str
+    grid : str
         Grid type (``"equiangular"``, ``"legendre-gauss"``, ``"lobatto"``,
         ``"equiangular-trapezoidal"``), by default ``"equiangular"``
-    norm: str
+    norm : str
         Normalization convention (``"ortho"``, ``"schmidt"``, ``"unnorm"``),
         by default ``"ortho"``.
-    csphase: bool
+    csphase : bool
         Whether to include the Condon--Shortley phase factor :math:`(-1)^m`,
         by default ``True``.
 
@@ -154,7 +154,7 @@ class RealSHT(nn.Module):
 
         Parameters
         ----------
-        x: torch.Tensor
+        x : torch.Tensor
             Real-valued signal on the sphere of shape ``(..., nlat, nlon)``.
 
         Returns
@@ -206,22 +206,22 @@ class InverseRealSHT(nn.Module):
             conventions, grid types, and worked examples.
 
     Parameters
-    -----------
-    nlat: int
+    ----------
+    nlat : int
         Number of latitude points
-    nlon: int
+    nlon : int
         Number of longitude points
-    lmax: int
+    lmax : int
         Maximum spherical harmonic degree
-    mmax: int
+    mmax : int
         Maximum spherical harmonic order
-    grid: str
+    grid : str
         Grid type (``"equiangular"``, ``"legendre-gauss"``, ``"lobatto"``,
         ``"equiangular-trapezoidal"``), by default ``"equiangular"``
-    norm: str
+    norm : str
         Normalization convention (``"ortho"``, ``"schmidt"``, ``"unnorm"``),
         by default ``"ortho"``.
-    csphase: bool
+    csphase : bool
         Whether to include the Condon--Shortley phase factor :math:`(-1)^m`,
         by default ``True``.
 
@@ -308,7 +308,7 @@ class InverseRealSHT(nn.Module):
 
         Parameters
         ----------
-        x: torch.Tensor
+        x : torch.Tensor
             Complex spherical harmonic coefficients of shape ``(..., lmax, mmax)``.
 
         Returns
@@ -359,22 +359,22 @@ class RealVectorSHT(nn.Module):
             formulas, normalization conventions, and worked examples.
 
     Parameters
-    -----------
-    nlat: int
+    ----------
+    nlat : int
         Number of latitude points
-    nlon: int
+    nlon : int
         Number of longitude points
-    lmax: int
+    lmax : int
         Maximum spherical harmonic degree
-    mmax: int
+    mmax : int
         Maximum spherical harmonic order
-    grid: str
+    grid : str
         Grid type (``"equiangular"``, ``"legendre-gauss"``, ``"lobatto"``,
         ``"equiangular-trapezoidal"``), by default ``"equiangular"``
-    norm: str
+    norm : str
         Normalization convention (``"ortho"``, ``"schmidt"``, ``"unnorm"``),
         by default ``"ortho"``.
-    csphase: bool
+    csphase : bool
         Whether to include the Condon--Shortley phase factor :math:`(-1)^m`,
         by default ``True``.
 
@@ -456,7 +456,7 @@ class RealVectorSHT(nn.Module):
 
         Parameters
         ----------
-        x: torch.Tensor
+        x : torch.Tensor
             Real-valued tangential vector field of shape ``(..., 2, nlat, nlon)``, where the
             size-2 dimension holds the two tangential (colatitude, longitude) components.
 
@@ -510,22 +510,22 @@ class InverseRealVectorSHT(nn.Module):
             vector SHT formulas, normalization conventions, and worked examples.
 
     Parameters
-    -----------
-    nlat: int
+    ----------
+    nlat : int
         Number of latitude points
-    nlon: int
+    nlon : int
         Number of longitude points
-    lmax: int
+    lmax : int
         Maximum spherical harmonic degree
-    mmax: int
+    mmax : int
         Maximum spherical harmonic order
-    grid: str
+    grid : str
         Grid type (``"equiangular"``, ``"legendre-gauss"``, ``"lobatto"``,
         ``"equiangular-trapezoidal"``), by default ``"equiangular"``
-    norm: str
+    norm : str
         Normalization convention (``"ortho"``, ``"schmidt"``, ``"unnorm"``),
         by default ``"ortho"``.
-    csphase: bool
+    csphase : bool
         Whether to include the Condon--Shortley phase factor :math:`(-1)^m`,
         by default ``True``.
 
@@ -608,7 +608,7 @@ class InverseRealVectorSHT(nn.Module):
 
         Parameters
         ----------
-        x: torch.Tensor
+        x : torch.Tensor
             Complex vector harmonic coefficients of shape ``(..., 2, lmax, mmax)``, where the
             size-2 dimension holds the spheroidal and toroidal components.
 

--- a/torch_harmonics/spectral_convolution.py
+++ b/torch_harmonics/spectral_convolution.py
@@ -100,23 +100,23 @@ class SpectralConvS2(nn.Module):
     content into all spectral modes.
 
     Parameters
-    -----------
-    in_shape: Tuple[int]
+    ----------
+    in_shape : Tuple[int]
         Spatial input grid shape ``(nlat, nlon)``.
-    out_shape: Tuple[int]
+    out_shape : Tuple[int]
         Spatial output grid shape ``(nlat, nlon)``.
-    in_channels: int
+    in_channels : int
         Number of input channels.
-    out_channels: int
+    out_channels : int
         Number of output channels.
-    num_groups: int, optional
+    num_groups : int, optional
         Number of channel groups for grouped spectral weights, by default 1.
-    grid_in: str, optional
+    grid_in : str, optional
         Grid used for the forward SHT (``"equiangular"``, ``"legendre-gauss"``,
         ``"lobatto"``, ``"equiangular-trapezoidal"``), by default ``"equiangular"``.
-    grid_out: str, optional
+    grid_out : str, optional
         Grid used for the inverse SHT, same options as ``grid_in``.
-    bias: bool, optional
+    bias : bool, optional
         If ``True``, adds a learnable spectral bias computed from the spatial
         integral, by default ``False``.
 
@@ -206,7 +206,7 @@ class SpectralConvS2(nn.Module):
 
         Parameters
         ----------
-        x: torch.Tensor
+        x : torch.Tensor
             Input signal of shape ``(batch, in_channels, nlat_in, nlon_in)``.
 
         Returns


### PR DESCRIPTION
  Problem
  
  Docstring conventions had drifted across the package, and a few inconsistencies were actually breaking autodoc output. Since the docs have not been published yet, this is a good time to
  normalize them.
  
  Changes
  
  Rendering bugs (visible in the built HTML)
  
  - examples/losses.py: two docstrings (incl. the public forward on the loss base class) were Google-style, but conf.py sets napoleon_google_docstring = False — they rendered as literal prose
  with no parameter table. Converted to NumPy style.
  - examples/models/sfno.py: Example: with a trailing colon isn't recognized by napoleon, so the header and its underline leaked into the page as raw text.
  - 10 API pages published PyTorch's boilerplate ("Define the computation performed at every call") because forward/to lack docstrings and autodoc inherits from nn.Module. Fixed with
  autodoc_inherit_docstrings = False.
  
  Consistency (no rendering change)
  
  - 237 × name: type → name : type; 63 underline lengths corrected; 6 × Example → Examples.
  - Returns unified: single-value → bare type, multi-value → named entries (numpydoc convention).

Docs config
  
  - nitpicky = True with a small nitpick_ignore; with CI's existing -W, a broken cross-reference now fails the build instead of accumulating silently.
  - Added matplotlib to intersphinx_mapping; excluded jupyter_execute (myst-nb copies were rediscovered as source on rebuild).
  - Qualified one :class: reference in distributed_attention.py.
  
  Testing
  
  Full Sphinx build against the working tree: 0 warnings (down from 104 in nitpicky mode). Verified nitpicky is genuinely active by injecting a bogus reference — caught with the new config,
  silent under -D nitpicky=0.
  
  Rendered-output diff through napoleon is exactly 12 lines, all intended Returns changes — confirming the 237 colon and 63 underline edits are render-neutral. AST comparison with docstrings
  stripped shows 0 non-docstring differences across all 27 files.
  
  API / numerical behavior
  
  None. Docstrings, docs/conf.py, and one cross-reference only; no code paths touched.