### PR TITLE
Strengthening security for TH repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
       # Offical actions have moving tags like v1
       # that are used, so they don't need updates here
       - dependency-name: "actions/*"
+
+  # Keep the pinned CI tooling up to date, otherwise the pins go stale and we
+  # end up building wheels with outdated and potentially vulnerable tools
+  - package-ecosystem: "pip"
+    directory: "/.github/requirements"
+    schedule:
+      interval: "weekly"

--- a/.github/requirements/build-tools.txt
+++ b/.github/requirements/build-tools.txt
@@ -1,0 +1,6 @@
+# Host-side tooling for the wheel build job (runs on the runner, not in the manylinux container).
+# cibuildwheel drives the build, twine/auditwheel inspect the resulting artifacts.
+cibuildwheel==4.2.0
+twine==7.0.0
+auditwheel==6.7.0
+wheel==0.47.0

--- a/.github/requirements/style-tools.txt
+++ b/.github/requirements/style-tools.txt
@@ -1,0 +1,3 @@
+# Linting tooling, pinned so that style runs are reproducible and do not change under us.
+# The individual hook versions are pinned separately in .pre-commit-config.yaml.
+pre-commit==4.6.1

--- a/.github/requirements/wheel-build-env.txt
+++ b/.github/requirements/wheel-build-env.txt
@@ -1,0 +1,8 @@
+# Build environment inside the manylinux containers (see CIBW_BEFORE_BUILD in build_wheels.yml).
+# These run with --no-build-isolation, so this is the toolchain that actually compiles the
+# extension and stamps the version into the published wheels. Pinned so that a compromised or
+# simply broken upstream release cannot silently change what we ship.
+pip==26.2.1
+setuptools==83.0.0
+wheel==0.47.0
+setuptools-scm==10.2.1

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -7,6 +7,10 @@ on:
       - 'v*'
   workflow_dispatch:
 
+# wheels are only uploaded as artifacts, publishing happens outside of this workflow
+permissions:
+  contents: read
+
 env:
   CUDA_ARCH_MAP: '{"12.6": "8.0;8.6;8.9;9.0;+PTX", "12.8": "8.0;8.6;8.9;9.0;10.0;12.0;+PTX", "12.9": "8.0;8.6;8.9;9.0;10.0;12.0;+PTX", "13.0": "8.0;8.6;8.9;9.0;10.0;12.0;+PTX", "none": ""}'
 
@@ -21,11 +25,11 @@ jobs:
           - torch-version: '2.6.0'
             torch-cuda: 'cu126'
             cuda-version: '12.6'
-            python-builds: 'cp39-* cp310-* cp311-* cp312-*'
+            python-builds: 'cp310-* cp311-* cp312-*'
           - torch-version: '2.7.0'
             torch-cuda: 'cu128'
             cuda-version: '12.8'
-            python-builds: 'cp39-* cp310-* cp311-* cp312-*'
+            python-builds: 'cp310-* cp311-* cp312-*'
           - torch-version: '2.8.0'
             torch-cuda: 'cu129'
             cuda-version: '12.9'
@@ -68,7 +72,7 @@ jobs:
 
     - name: Install cibuildwheel
       run: |
-        python -m pip install cibuildwheel
+        python -m pip install -r .github/requirements/build-tools.txt
 
     - name: Set CUDA architecture list
       run: |
@@ -86,7 +90,7 @@ jobs:
       env:
         CIBW_BEFORE_BUILD: |
           set -e
-          pip install --upgrade pip setuptools wheel setuptools-scm
+          pip install --upgrade -r {project}/.github/requirements/wheel-build-env.txt
           pip install --no-cache-dir torch==${{ matrix.torch-version }} --index-url https://download.pytorch.org/whl/${{ matrix.torch-cuda }}
           pip install numpy
         CIBW_BEFORE_TEST: |
@@ -140,7 +144,7 @@ jobs:
     - name: Repack wheels for PyPI (strip local version identifier)
       if: matrix.torch-version == '2.11.0' && matrix.torch-cuda == 'cu130'
       run: |
-        pip install wheel
+        pip install -r .github/requirements/build-tools.txt
         mkdir -p pypi-wheelhouse
         for whl in wheelhouse/*.whl; do
           tmpdir=$(mktemp -d)
@@ -161,7 +165,7 @@ jobs:
     - name: Inspect repacked wheels and .so files
       if: always() && (matrix.torch-version == '2.11.0' && matrix.torch-cuda == 'cu130')
       run: |
-        pip install twine auditwheel
+        pip install -r .github/requirements/build-tools.txt
 
         echo "=== twine check ==="
         python -m twine check pypi-wheelhouse/*.whl

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     name: Run pre-commit checks
@@ -12,10 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v6
       with:
-        python-version: "3.9"
+        python-version: "3.10"
 
     # Run pre-commit directly instead of pre-commit/action@v3.0.1, whose
     # bundled sub-actions still target the deprecated Node.js 20 runtime.
@@ -27,5 +30,5 @@ jobs:
 
     - name: Run pre-commit
       run: |
-        python -m pip install --upgrade pip pre-commit
+        python -m pip install -r .github/requirements/style-tools.txt
         pre-commit run --all-files --show-diff-on-failure --color=always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# the coverage badge step authenticates with its own PAT, so the workflow token stays read-only
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Run local tests
@@ -13,10 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v6
       with:
-        python-version: "3.9"
+        python-version: "3.10"
 
     - name: Install dependencies
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ We're happy to discuss ideas before you spend time on a large change.
 
 **Requirements**
 
-- Python 3.9+
+- Python 3.10+
 - PyTorch 2.6+ (install before building; extensions compile against your local `torch`)
 - NumPy 1.22.4+
 - A C++17 compiler; CUDA toolkit optional but recommended for GPU kernel work

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Versioning
 
-### v0.9.2b
+### v0.9.2c
 
 * Added `benchmarks/` suite covering SHT, DISCO convolution (self and downsampling), and spherical attention (global, neighborhood self, neighborhood cross-resolution) across resolutions, dtypes, and channel counts. Entry point: `python benchmarks/run.py`. Supports baseline CSV comparison for regression tracking in performance PRs.
 * Fused DISCO kernel for serial convolution: fuses the sparse psi contraction and weight multiplication into a single autograd region, avoiding the K-expanded intermediate activation in the graph and reducing memory footprint by a factor of K. Enabled via `fused=True` on `DiscreteContinuousConvS2`.
@@ -18,6 +18,9 @@
 * Fixed `SpectralConvS2` and `DistributedSpectralConvS2` spectral bias handling when input and output channel counts differ.
 * Fixed a problem with squeezing singleton dimensions in the `GaussianRandomFieldS2` noise tensor.
 * Fixed `AttentionS2` to disable SDPA dropout in eval mode.
+* Hardened the 2D3DS example dataset downloader: archives are verified against SHA-256 checksums and tar members which resolve outside the target directory are rejected. Also fixes HTTP error handling, the temporary file location and resuming interrupted downloads, and makes the `2d3ds` extra installable again.
+* Pinned the CI build tooling and restricted workflow token permissions to read-only.
+* **Breaking**: minimum supported Python version is now 3.10, since 3.9 has reached its end of life. No cp39 wheels are built anymore.
 * **Breaking**: default `basis_norm_mode` for `DistributedDiscreteContinuousConvS2` and `DistributedDiscreteContinuousConvTransposeS2` changed from `"mean"` to `"nodal"` to match the serial `DiscreteContinuousConvS2` / `DiscreteContinuousConvTransposeS2` defaults. Distributed and serial DISCO layers now share the same default normalization unless explicitly overridden.
 
 ### v0.9.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,11 @@ dynamic = ["version"]
 
 description = "Differentiable signal processing on the sphere for PyTorch."
 license = { file = "LICENSE.txt" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Operating System :: OS Independent",
 ]
 
@@ -71,7 +71,6 @@ docs = [
 ]
 2d3ds = [
     "requests",
-    "tarfile",
     "tqdm",
     "pillow",
     "h5py",
@@ -106,8 +105,8 @@ ignore = [
 known-first-party = ["torch_harmonics"]
 
 [tool.cibuildwheel]
-# Build for Python 3.9, 3.10, 3.11, 3.12
-build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+# Build for Python 3.10, 3.11, 3.12
+build = ["cp310-*", "cp311-*", "cp312-*"]
 build-frontend = "pip; args: --no-build-isolation"
 
 # Use manylinux for Linux wheels

--- a/torch_harmonics/examples/stanford_2d3ds_dataset.py
+++ b/torch_harmonics/examples/stanford_2d3ds_dataset.py
@@ -29,7 +29,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+import hashlib
 import os
+from typing import Dict, Optional
 
 import numpy as np
 import torch
@@ -51,6 +53,20 @@ DEFAULT_TAR_FILE_PAIRS = [
 ]
 DEFAULT_LABELS_URL = "https://raw.githubusercontent.com/alexsax/2D-3D-Semantics/refs/heads/master/assets/semantic_labels.json"
 
+# SHA-256 checksums of the tar files, keyed by filename. Downloads are verified against these
+# before extraction, so that a compromised server or an intercepted connection cannot feed us a
+# manipulated archive. Files without an entry here are downloaded but not verified, in which case
+# a warning is printed. Compute new entries with `sha256sum <tar file>` on a trusted copy.
+DEFAULT_TAR_FILE_CHECKSUMS = {
+    "area_1_no_xyz.tar": "b02d3b12198a419bfecb0aebb7c0ad13e2f4d017bbc6e93606e9316248a8d374",
+    "area_2_no_xyz.tar": "4b23df4e987ffbac7a1e3943bb0cf14ad9e136a5a050c64d7485af01937111f1",
+    "area_3_no_xyz.tar": "6ddb3c2742dc870ef361e542d5075c846f9dc464b7b27d01c7aac3eedc32e36c",
+    "area_4_no_xyz.tar": "741824ebf7085273410d73e65a3a6e6e293359fb63d1ba5f0ae447be70cd0b58",
+    "area_5a_no_xyz.tar": "4541dcff9cc7121c76d72bffff88226361c653d8de43bc1b7815ef3de2fc897e",
+    "area_5b_no_xyz.tar": "feec8f709f750ea7a38303b353fdb6cd08f902ec82511b2c17f95d3109204f10",
+    "area_6_no_xyz.tar": "ff7dda619a555f0031860ba42c963b3c65487a4db55e90fce4ddd54428e190ed",
+}
+
 
 class Stanford2D3DSDownloader:
     """
@@ -62,6 +78,9 @@ class Stanford2D3DSDownloader:
         Base URL for downloading the dataset, by default DEFAULT_BASE_URL
     local_dir : str, optional
         Local directory to store downloaded files, by default "data"
+    checksums : dict, optional
+        Mapping of filename to expected SHA-256 checksum, by default DEFAULT_TAR_FILE_CHECKSUMS.
+        Pass a custom mapping when downloading from a mirror, or None to disable verification.
 
     Returns
     -------
@@ -75,11 +94,36 @@ class Stanford2D3DSDownloader:
     :cite:`Armeni2017`
     """
 
-    def __init__(self, base_url: str = DEFAULT_BASE_URL, local_dir: str = "data"):
+    def __init__(self, base_url: str = DEFAULT_BASE_URL, local_dir: str = "data", checksums: Optional[Dict[str, str]] = DEFAULT_TAR_FILE_CHECKSUMS):
 
         self.base_url = base_url
         self.local_dir = local_dir
+        self.checksums = checksums if checksums is not None else {}
+        self.verify_checksums = checksums is not None
         os.makedirs(self.local_dir, exist_ok=True)
+
+    def _compute_sha256(self, local_path):
+
+        sha256 = hashlib.sha256()
+        with open(local_path, "rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                sha256.update(chunk)
+
+        return sha256.hexdigest()
+
+    def _verify_checksum(self, filename, local_path):
+
+        if not self.verify_checksums:
+            return
+
+        expected = self.checksums.get(filename)
+        if expected is None:
+            print(f"Warning: No checksum known for {filename}, skipping integrity check")
+            return
+
+        digest = self._compute_sha256(local_path)
+        if digest != expected:
+            raise RuntimeError(f"Checksum mismatch for {filename}: expected {expected}, but got {digest}. " f"Remove {local_path} and retry the download.")
 
     def _download_file(self, filename):
 
@@ -90,10 +134,11 @@ class Stanford2D3DSDownloader:
         local_path = os.path.join(self.local_dir, filename)
         if os.path.exists(local_path):
             print(f"Note: Skipping download for {filename}, because it already exists")
+            self._verify_checksum(filename, local_path)
             return local_path
 
         print(f"Downloading {filename}...")
-        temp_path = local_path.split(".")[0] + ".part"
+        temp_path = os.path.splitext(local_path)[0] + ".part"
 
         # Resume logic
         headers = {}
@@ -101,26 +146,48 @@ class Stanford2D3DSDownloader:
             headers = {"Range": f"bytes={os.stat(temp_path).st_size}-"}
 
         response = requests.get(url, headers=headers, stream=True, timeout=30)
-        if os.path.exists(temp_path):
-            total_size = int(response.headers.get("content-length", 0)) + os.stat(temp_path).st_size
-        else:
-            total_size = int(response.headers.get("content-length", 0))
+        response.raise_for_status()
 
-        with open(temp_path, "ab") as f, tqdm(desc=filename, total=total_size, unit="B", unit_scale=True, unit_divisor=1024, initial=os.stat(temp_path).st_size) as pbar:
+        # only append if the server honored our range request, otherwise we start from scratch
+        resume = os.path.exists(temp_path) and response.status_code == 206
+        offset = os.stat(temp_path).st_size if resume else 0
+        total_size = int(response.headers.get("content-length", 0)) + offset
+
+        with open(temp_path, "ab" if resume else "wb") as f, tqdm(desc=filename, total=total_size, unit="B", unit_scale=True, unit_divisor=1024, initial=offset) as pbar:
             for chunk in response.iter_content(chunk_size=1024):
                 if chunk:
                     f.write(chunk)
                     pbar.update(len(chunk))
 
         os.rename(temp_path, local_path)
+        self._verify_checksum(filename, local_path)
+
         return local_path
+
+    def _check_tar_members(self, tar):
+        # guard against path traversal: reject members which would end up outside local_dir
+        base_dir = os.path.abspath(self.local_dir)
+        for member in tar.getmembers():
+            member_path = os.path.abspath(os.path.join(base_dir, member.name))
+            if member_path != base_dir and not member_path.startswith(base_dir + os.sep):
+                raise RuntimeError(f"Refusing to extract {member.name}, because it points outside of {self.local_dir}")
+            if member.issym() or member.islnk():
+                link_path = os.path.abspath(os.path.join(os.path.dirname(member_path), member.linkname))
+                if link_path != base_dir and not link_path.startswith(base_dir + os.sep):
+                    raise RuntimeError(f"Refusing to extract link {member.name}, because it points outside of {self.local_dir}")
 
     def _extract_tar(self, tar_path):
 
         import tarfile
 
         with tarfile.open(tar_path) as tar:
-            tar.extractall(path=self.local_dir)
+            # the data filter is available in python 3.12+ and in backports of older versions,
+            # otherwise we validate the member paths manually
+            if hasattr(tarfile, "data_filter"):
+                tar.extractall(path=self.local_dir, filter="data")
+            else:
+                self._check_tar_members(tar)
+                tar.extractall(path=self.local_dir)
             tar_filenames = tar.getnames()
             extracted_dir = tar_filenames[0]
             os.remove(tar_path)


### PR DESCRIPTION
 # Harden the 2D3DS dataset downloader and CI supply chain
  
  ## Problem

  Two security issues were reported against `torch_harmonics/examples/stanford_2d3ds_dataset.py`,
  which ships as part of the installable `torch_harmonics.examples` package:
  
  1. **Path traversal on extraction.** `_extract_tar()` called `tar.extractall()` with no member
     filtering. A tar entry with `../` components — or a symlink pointing outside the tree — could
     write anywhere the process has permission. `base_url` is user-controllable, so a malicious
     mirror or a compromised upstream server turns this into arbitrary file write.

 2. **No download integrity check.** `_download_file()` fetched multi-GB tars over HTTPS with no
     checksum or signature, so a compromised server or an intercepted connection (TLS interception
     is common in corporate environments) could substitute a crafted archive. Combined with (1), 
     this is a supply-chain path into a user's filesystem.
  
  While fixing these, three latent bugs surfaced in the same download path, plus some CI hardening
  that addresses the same class of risk on the build side.

  ## Changes
  
  ### Dataset downloader
  
  - **Path traversal guard.** Extraction now uses `tar.extractall(filter="data")` where available.
    `data_filter` was backported to 3.10.12+, so 3.10.0–3.10.11 remain in the supported range and
    fall back to `_check_tar_members()`, which validates each member path against the destination
    and additionally checks symlink/hardlink targets (a name-only check misses `area_1/x ->
    ../../../etc/passwd`).
  - **SHA-256 verification.** New `DEFAULT_TAR_FILE_CHECKSUMS` table covering all seven archives,
    verified after download *and* on the "file already exists" path, so a poisoned or truncated
    file left from an earlier run is not silently trusted. New `checksums` constructor argument
    accepts a custom mapping for mirrors, or `None` to opt out.
  - **Fix: missing `raise_for_status()`.** HTTP error bodies were written to disk as `.tar` files
    and handed to `tarfile`; the visible symptom was `ReadError: not a gzip file` from a saved 404 page.
  - **Fix: `.part` path.** `local_path.split(".")[0] + ".part"` breaks on any `local_dir` containing
    a dot — `./data` wrote the partial file into the *current working directory*, `v1.0/data`
    produced `v1.part`. Now uses `os.path.splitext`.
  - **Fix: resume corruption.** The `Range` resume path appended unconditionally. If the server
    ignored the header and replied `200` with a full body, the partial file was corrupted. Resume
    now requires a `206`, otherwise the download restarts cleanly.

 ### Packaging
    
  - **Minimum Python raised to 3.10** (`requires-python`, trove classifier, cibuildwheel `build`,
    the wheel matrix in `build_wheels.yml`, setup-python in `tests`/`style`, CONTRIBUTING).
    3.9 reached end of life in October 2025.
  - **Removed `tarfile` from the `2d3ds` extra.** `tarfile` is stdlib and the name is unregistered
    on PyPI, so `pip install torch-harmonics[2d3ds]` failed at resolution with
    "No matching distribution found for tarfile".
  
  ### CI supply chain
  
  - **`permissions: contents: read`** added to `build_wheels.yml`, `tests.yml`, and `style.yml`.
    The repo default was "read and write", so every job — including the one producing published
    wheels — ran with a token that could push commits and move tags. `docs.yaml` already scoped
    its own permissions and is unchanged. (The repo-level default and "Allow GitHub Actions to
    create and approve pull requests" were also turned off in repo settings.)
  - **Pinned build tooling** in `.github/requirements/`: `cibuildwheel`, `twine`, `auditwheel`,
    `wheel` (host); `pip`, `setuptools`, `wheel`, `setuptools-scm` (inside the manylinux
    containers); `pre-commit` (style). These previously resolved to whatever was latest at build
    time and run inside the job that produces the published wheels. Pinned to the versions CI was
    already resolving, so this is behavior-neutral today.
  - **Dependabot `pip` entry** on `/.github/requirements` so the pins don't go stale.

## Testing 
    
  No GPU or kernel code is touched, so the kernel/benchmark workflow does not apply.
  
  **Dataset downloader** — exercised end to end against a local HTTP server serving crafted tars
  (Python 3.12, torch 2.9.0), rather than the 225 GB real dataset: 
    
  | Scenario | Result | 
  |---|---| 
  | Valid tar, matching checksum | downloads, verifies, extracts | 
  | Server serves bytes other than expected | `RuntimeError` before extraction; target dir never created |
  | Malicious tar (`../../pwned.txt`), checksum matches | blocked by extract filter; nothing written outside dest |
  | Symlink escaping the destination | blocked on the manual fallback path | 
  | Corrupt file already on disk | rejected on the skip-download path |
  | Interrupted download resumed via `Range` | resumes, final checksum verifies, no stray `.part` in cwd |
  | HTTP 404 | `HTTPError`, nothing written to disk |
  | `checksums=None` | verification skipped as intended |
  
  Both extraction paths were tested — the stdlib `data_filter` and, with `tarfile.data_filter`
  deleted to simulate 3.10.0–3.10.11, the manual fallback.
  
  The `Range` fix was additionally confirmed against the real ETH server: `area_4` resumed from
  94% after an interrupted run and hashed to the expected digest.
    
  **Checksums** — all seven archives (225 GB) were downloaded from `cvg-data.inf.ethz.ch` on
  2026-08-05 via the library's own `_download_file()`, hashed, and deleted. The committed table
  was verified to match the recorded digests exactly and to cover every entry in
  `DEFAULT_TAR_FILE_PAIRS`, so no file falls through to the unverified warning path.
  
  **Packaging / CI** — `pyproject.toml` and all four workflow YAMLs parse; the three requirements
  files resolve with no version conflicts; `cibuildwheel` 4.2.0's `{project}` placeholder
  substitution in `before_build` was confirmed in its source (`platforms/linux.py:287`).

 ## Behavior changes
  
  - `Stanford2D3DSDownloader.__init__` gains a `checksums` keyword argument (defaulted; existing
    positional calls are unaffected).
  - Downloads whose checksum does not match now raise `RuntimeError` instead of extracting.
  - Tar members resolving outside `local_dir` now raise instead of being written.
  - Python 3.9 is no longer supported: source installs fail on `Requires-Python`, no cp39 wheels
    are built, and 3.9 users on `pip install torch-harmonics` silently resolve to the last 3.9-
    compatible release.
  - No numerical or API changes to any transform, convolution, or attention path.


 ## Notes and limitations
  
  - The checksums pin what the ETH server served on 2026-08-05. This defends against future
    tampering, MITM, and silent re-uploads, but cannot retroactively prove those bytes are the
    2D-3D-S authors' originals; cross-checking a second mirror would be needed for that.
  - Pinned tooling covers direct dependencies only — transitive deps still float. Hash-pinned
    lockfiles (`--generate-hashes` + `--require-hashes`) would close that and can follow separately.
  - `pip install numpy` in `CIBW_BEFORE_BUILD`/`BEFORE_TEST` was left unpinned deliberately: it
    tests the declared runtime dependency and should track current numpy.
  - Recommend a `workflow_dispatch` run of `build_wheels.yml` before the next release tag to
    confirm the pinned toolchain in the real manylinux containers.

