### PR TITLE
Update CUDA extension environment variable for build

### DIFF
--- a/Dockerfile.examples
+++ b/Dockerfile.examples
@@ -55,7 +55,7 @@ RUN cd /opt && git clone https://github.com/SHI-Labs/NATTEN natten  && \
 COPY . /workspace/torch_harmonics
 
 # The custom CUDA extension does not suppport architerctures < 7.0
-ENV FORCE_CUDA_EXTENSION=1
+ENV TORCH_HARMONICS_BUILD_CUDA_EXTENSION=1
 ENV TORCH_HARMONICS_ENABLE_OPENMP=1
 ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 9.0a 10.0a+PTX"
 RUN cd /workspace/torch_harmonics && NVCC_THREADS=4 MAX_JOBS=8 pip install --no-deps --no-build-isolation .


### PR DESCRIPTION
We renamed FORCE_CUDA_EXTENSION to TORCH_HARMONICS_BUILD_CUDA_EXTENSION but I forgot to change it in one Dockerfile. This MR fixes this. 