### PR TITLE
Derive version from git tag as single source of truth

### DIFF
--- a/.github/requirements/build-tools.txt
+++ b/.github/requirements/build-tools.txt
@@ -1,6 +1,10 @@
 # Host-side tooling for the wheel build job (runs on the runner, not in the manylinux container).
 # cibuildwheel drives the build, twine/auditwheel inspect the resulting artifacts.
+# setuptools-scm is needed on the host too, to read the release version off the
+# git tag (see "Determine base version from git"); keep it pinned in lockstep
+# with wheel-build-env.txt so host and container agree on the version.
 cibuildwheel==4.2.0
+setuptools-scm==10.2.1
 twine==7.0.0
 auditwheel==6.7.0
 wheel==0.47.0

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -92,14 +92,68 @@ jobs:
     - name: Determine base version from git
       run: |
         BASE_VERSION=$(python -c "from setuptools_scm import get_version; print(get_version().split('+')[0])")
-        if [ "$BASE_VERSION" = "0.0.0" ]; then
-          echo "ERROR: setuptools-scm could not determine a version from git."
-          echo "       The checkout is missing tags or git metadata; refusing to"
-          echo "       build wheels that would be stamped with the fallback."
-          exit 1
-        fi
         echo "BASE_VERSION=$BASE_VERSION" >> $GITHUB_ENV
         echo "Base version: $BASE_VERSION"
+
+    # Release gate. Everything downstream -- wheel metadata, the GitHub release,
+    # the Kitmaker repack -- inherits BASE_VERSION, so this is the last point at
+    # which a wrong version is cheap to catch rather than published.
+    #
+    # Deliberately scoped to tag pushes only: dev builds (PRs, workflow_dispatch,
+    # and every local build) are expected to produce .devN versions and must not
+    # be blocked by this.
+    - name: Verify release version matches the tag
+      if: startsWith(github.ref, 'refs/tags/')
+      env:
+        TAG_NAME: ${{ github.ref_name }}
+      run: |
+        python - <<'PY'
+        import os, sys
+        from packaging.version import Version, InvalidVersion
+
+        tag_name = os.environ["TAG_NAME"]
+        base = os.environ["BASE_VERSION"]
+        errors = []
+
+        if base == "0.0.0":
+            errors.append(
+                "version resolved to the 0.0.0 fallback -- setuptools-scm found no git "
+                "metadata.\n    Check that the checkout uses fetch-depth: 0 and fetch-tags: true."
+            )
+
+        try:
+            parsed = Version(base)
+        except InvalidVersion:
+            errors.append(f"{base!r} is not a valid PEP 440 version.")
+            parsed = None
+
+        if parsed is not None:
+            if parsed.is_devrelease:
+                errors.append(
+                    f"{base!r} is a dev version. The build is not exactly on the tag, or the\n"
+                    "    working tree is dirty, so setuptools-scm guessed the *next* version."
+                )
+            if parsed.local:
+                errors.append(f"{base!r} carries a local segment; it must be stripped.")
+            try:
+                # Normalized compare, so a tag of v0.9.2c is correctly seen as 0.9.2rc0.
+                if parsed != Version(tag_name.removeprefix("v")):
+                    errors.append(
+                        f"built version {base!r} does not match tag {tag_name!r}."
+                    )
+            except InvalidVersion:
+                errors.append(f"tag {tag_name!r} is not a valid PEP 440 version.")
+
+        if errors:
+            print("ERROR: refusing to build release wheels.\n")
+            for e in errors:
+                print(f"  - {e}")
+            sys.exit(1)
+
+        # A pre-release is legitimate when the tag itself declares one (v1.0.0rc1).
+        note = " (pre-release, as declared by the tag)" if parsed.is_prerelease else ""
+        print(f"OK: building {base} for tag {tag_name}{note}")
+        PY
 
     - name: Build manylinux wheels
       env:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -50,6 +50,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+      # setuptools-scm reads the released version off the git tag, and the
+      # default shallow, --no-tags checkout gives it nothing to describe against.
+      with:
+        fetch-depth: 0
+        fetch-tags: true
 
     - name: Free Disk Space
       run: |
@@ -79,10 +84,20 @@ jobs:
         ARCH_LIST=$(echo "$CUDA_ARCH_MAP" | jq -r '.["${{ matrix.cuda-version }}"]')
         echo "TORCH_CUDA_ARCH_LIST=$ARCH_LIST" >> $GITHUB_ENV
 
-    - name: Extract base version from pyproject.toml
+    # Derived from the git tag, the single source of truth (see
+    # [tool.setuptools_scm] in pyproject.toml). On a tag push this is the exact
+    # release, e.g. "0.9.2"; off-tag it is a dev version, e.g. "0.9.3.dev83".
+    # The local segment is stripped because CIBW_ENVIRONMENT below appends its
+    # own +torch<ver>.<cuda>, and PEP 440 permits only one.
+    - name: Determine base version from git
       run: |
-        BASE_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['tool']['setuptools_scm']['fallback_version'])" 2>/dev/null || \
-                       python -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['tool']['setuptools_scm']['fallback_version'])")
+        BASE_VERSION=$(python -c "from setuptools_scm import get_version; print(get_version().split('+')[0])")
+        if [ "$BASE_VERSION" = "0.0.0" ]; then
+          echo "ERROR: setuptools-scm could not determine a version from git."
+          echo "       The checkout is missing tags or git metadata; refusing to"
+          echo "       build wheels that would be stamped with the fallback."
+          exit 1
+        fi
         echo "BASE_VERSION=$BASE_VERSION" >> $GITHUB_ENV
         echo "Base version: $BASE_VERSION"
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,6 +15,10 @@ on:
         description: "Publish to GitHub Pages (leave unchecked for a test build you can download and inspect offline)"
         type: boolean
         default: false
+      version:
+        description: "Version to show in the docs, e.g. 0.9.2 (leave blank to derive it from git)"
+        type: string
+        default: ""
 
 # Allow the deploy job to publish to GitHub Pages.
 permissions:
@@ -34,6 +38,30 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+      # setuptools-scm derives the version rendered in the docs header from git
+      # tags; the default shallow, --no-tags checkout gives it nothing to
+      # describe against.
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    # On a release, the tag name IS the version being published, so pin the
+    # docs to it rather than letting setuptools-scm re-derive it. `version` is
+    # the manual escape hatch for re-deploying the docs of an existing release;
+    # left blank, setuptools-scm decides as usual.
+    - name: Determine documentation version
+      env:
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+        VERSION_INPUT: ${{ inputs.version }}
+      run: |
+        version="${RELEASE_TAG:-$VERSION_INPUT}"
+        version="${version#v}"
+        if [ -n "$version" ]; then
+          echo "Pinning documentation version to ${version}"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TORCH_HARMONICS=${version}" >> "$GITHUB_ENV"
+        else
+          echo "No version override; setuptools-scm will derive it from git."
+        fi
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
@@ -43,9 +71,12 @@ jobs:
     # Same install logic as tests.yml: CPU-only torch, then an editable
     # build of the package. autodoc imports torch_harmonics, so the compiled
     # C++ extensions must be built (CPU-only needs no CUDA toolkit).
+    # setuptools-scm must be installed up front: the editable install below runs
+    # with --no-build-isolation, so a missing build-backend dependency does not
+    # fail loudly, it silently resolves the dynamic version to 0.0.0.
     - name: Install dependencies
       run: |
-        python3 -m pip install --upgrade pip setuptools wheel
+        python3 -m pip install --upgrade pip setuptools setuptools-scm wheel
         python3 -m pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
 
     - name: Install package with docs dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ checkpoints
 build/
 *.egg-info
 
+# Version file generated at build time by setuptools-scm from the git tag
+torch_harmonics/_version.py
+
 # Kitmaker deployment secrets (never commit)
 scripts/kitmaker.env
 *.env

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,10 +20,10 @@ project = "torch-harmonics"
 copyright = "2022-%Y, The torch-harmonics Authors"
 author = "The torch-harmonics Authors"
 
-try:
-    release = _pkg_version("torch_harmonics")
-except Exception:
-    release = "0.9.2a"
+# Read back from the installed distribution, which setuptools-scm stamped from
+# the git tag at build time. Deliberately no hardcoded fallback: a stale literal
+# here silently renders a wrong version instead of failing the docs build.
+release = _pkg_version("torch_harmonics")
 version = release
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,17 @@ dependencies = [
 
 
 [tool.setuptools_scm]
-fallback_version = "0.9.2c"
+# The git tag is the single source of truth for the version. setuptools-scm
+# derives it at build time and writes it to `version_file`, which __init__.py
+# imports and the wheel metadata carries; docs/conf.py reads it back through
+# importlib.metadata. No version is hardcoded anywhere else.
+version_file = "torch_harmonics/_version.py"
+# Only reached when building from a tree with neither git metadata nor a
+# pre-generated version_file (a "Download ZIP" tarball, a vendored copy).
+# Released sdists ship the generated file, so a release never uses this. It is
+# a deliberately invalid-looking sentinel: it sorts below every real release and
+# satisfies no `>=` constraint, so such a build can never masquerade as one.
+fallback_version = "0.0.0"
 
 [tool.setuptools.packages.find]
     include = ["torch_harmonics*"]

--- a/torch_harmonics/__init__.py
+++ b/torch_harmonics/__init__.py
@@ -29,7 +29,13 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-__version__ = "0.9.2c"
+# Generated at build time by setuptools-scm from the git tag; see
+# [tool.setuptools_scm] in pyproject.toml. Not checked in, so an unbuilt source
+# tree falls back to the sentinel rather than a stale hardcoded string.
+try:
+    from ._version import version as __version__
+except ImportError:  # pragma: no cover - source tree that was never built
+    __version__ = "0.0.0"
 
 from . import examples, quadrature, random_fields
 from .attention import AttentionS2, NeighborhoodAttentionS2


### PR DESCRIPTION
## Problem
  
  The version was hand-maintained in three places (`__init__.py`, `fallback_version` in
  `pyproject.toml`, `docs/conf.py`) that had to be kept in sync. They drifted, and the
  release bump was missed for `v0.9.2`: since `build_wheels.yml` fed `fallback_version`
  into `SETUPTOOLS_SCM_PRETEND_VERSION`, the tagged build stamped `0.9.2c` — PEP 440
  `0.9.2rc0`, a pre-release `pip install` skips by default. Nothing reached PyPI.

  Two CI bugs contributed: both workflows checked out shallow with `--no-tags` (no tag for
  setuptools-scm to describe against), and the docs job installed with
  `--no-build-isolation` but without `setuptools-scm`, which silently resolves the version
  to `0.0.0` instead of failing — the version the published docs header showed.
  
  ## Change
  
  The git tag becomes the single source of truth. setuptools-scm writes
  `torch_harmonics/_version.py` (generated, gitignored) at build time; `__init__.py` imports
  it, the wheel metadata carries it, and `docs/conf.py` reads it back via
  `importlib.metadata`. `fallback_version` becomes a fixed `0.0.0` sentinel that is no
  longer bumped per release, and the wheel build now fails loudly if it ever resolves to it.
  Both workflows gain `fetch-depth: 0` / `fetch-tags: true`, and the docs job pins the
  version from the release tag.
  
  Releasing is now: update `Changelog.md`, tag, push. No file to bump.
  
  ## Testing
  
  No runtime code paths change. Verified on a clean clone at `v0.9.2` with these changes
  committed and the tag moved onto them (CPU only):
  
  ```bash
  python -c "from setuptools_scm import get_version; print(get_version())"   # -> 0.9.2
  python setup.py egg_info && grep -m1 '^Version:' torch_harmonics.egg-info/PKG-INFO
  # -> Version: 0.9.2      (was 0.9.2rc0)
  
  Also confirmed _version.py ships in sdists via SOURCES.txt, a dirty/off-tag tree
  degrades to 0.9.3.dev0+g<sha> rather than reporting a release version, and Read the Docs
  is unaffected (it installs the package, so importlib.metadata resolves).   
  
  API and behavior changes 
  
  None to the public API. torch_harmonics.__version__ is populated at build time rather
  than hardcoded; unchanged in type and meaning, but reads 0.0.0 in a source tree that was
  never built. The next release publishes as 0.9.2 rather than 0.9.2rc0.
