### PR TITLE
build CUDA kernels into the released wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -347,24 +347,37 @@ jobs:
 
         echo "=== Install + import test ==="
         python -m venv /tmp/test_venv
-        /tmp/test_venv/bin/pip install --quiet torch==${{ matrix.torch-version }} --index-url https://download.pytorch.org/whl/cpu
+        # Install the torch build matching this wheel's CUDA variant, not the CPU
+        # one: the extension links libcudart, which arrives via torch's
+        # nvidia-*-cu1x dependencies. Importing a CUDA wheel against CPU torch
+        # fails with "libcudart.so.NN: cannot open shared object file". This only
+        # ever passed before because the wheels contained no CUDA code.
+        /tmp/test_venv/bin/pip install --quiet torch==${{ matrix.torch-version }} --index-url https://download.pytorch.org/whl/${{ matrix.torch-cuda }}
         /tmp/test_venv/bin/pip install --quiet pypi-wheelhouse/*cp311*.whl
         cd /tmp && /tmp/test_venv/bin/python -c "import torch_harmonics; print('import OK, version:', torch_harmonics.__version__)"
 
-    # 100 MB is PyPI's per-file limit without an exemption. CUDA wheels carry
-    # cubins for every arch in TORCH_CUDA_ARCH_LIST, so this is a real ceiling
-    # here, not a formality -- if it trips, trim the arch list rather than
-    # raising the limit.
-    - name: Check wheel sizes (must be <= 100 MB)
+    # Two different ceilings, because these wheels go to two different indexes.
+    # The CPU wheel is published to public PyPI, which caps files at 100 MB
+    # without a per-project exemption. The CUDA variants are published to
+    # pypi.nvidia.com via Kitmaker, which carries far larger wheels routinely
+    # (nvidia-cudnn-cu12 alone is several hundred MB), so 100 MB does not apply
+    # to them. 500 MB is a sanity bound, not a hard requirement: a CUDA wheel
+    # much past ~250 MB probably means the arch list grew by accident.
+    - name: Check wheel sizes
       run: |
         WHL_DIR=$([ -d pypi-wheelhouse ] && echo pypi-wheelhouse || echo wheelhouse)
-        MAX_SIZE_BYTES=100000000
+        if [ "${{ matrix.build-cuda }}" = "1" ]; then
+          MAX_SIZE_BYTES=500000000
+        else
+          MAX_SIZE_BYTES=100000000
+        fi
+        echo "Limit for this variant: $((MAX_SIZE_BYTES / 1000000)) MB"
         FAILED=0
         for whl in "$WHL_DIR"/*.whl; do
           SIZE_BYTES=$(stat -c%s "$whl")
           SIZE_MB=$(awk "BEGIN {printf \"%.2f\", $SIZE_BYTES / 1000000}")
           if [ "$SIZE_BYTES" -gt "$MAX_SIZE_BYTES" ]; then
-            echo "FAIL: $whl is ${SIZE_MB} MB (> 100 MB)"
+            echo "FAIL: $whl is ${SIZE_MB} MB (> $((MAX_SIZE_BYTES / 1000000)) MB)"
             FAILED=1
           else
             echo "OK:   $whl is ${SIZE_MB} MB"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -42,30 +42,36 @@ jobs:
           - torch-version: '2.6.0'
             torch-cuda: 'cu126'
             cuda-version: '12.6'
+            dist-tag: 'cu126'
             python-builds: 'cp310-* cp311-* cp312-*'
             build-cuda: '1'
             builder-image: 'pytorch/manylinux2_28-builder@sha256:e403d8c2bbb43e6d84704efcfa4c8c148bbe08edc2e69dac4c99546ed6c46cc7'
           - torch-version: '2.7.0'
             torch-cuda: 'cu128'
             cuda-version: '12.8'
+            dist-tag: 'cu128'
             python-builds: 'cp310-* cp311-* cp312-*'
             build-cuda: '1'
             builder-image: 'pytorch/manylinux2_28-builder@sha256:404e7cddd7a2d4d7368c5a22416aaa10630d448aa97195a7864efbd9b05fa1c0'
           - torch-version: '2.8.0'
             torch-cuda: 'cu129'
             cuda-version: '12.9'
+            dist-tag: 'cu129'
             python-builds: 'cp310-* cp311-* cp312-*'
             build-cuda: '1'
             builder-image: 'pytorch/manylinux2_28-builder@sha256:d26cd7a9489b53310296e86042de630ac947e25a71dd24b547b86ca9a0a3fc79'
           - torch-version: '2.9.1'
             torch-cuda: 'cu130'
             cuda-version: '13.0'
+            dist-tag: 'cu130'
             python-builds: 'cp310-* cp311-* cp312-*'
             build-cuda: '1'
             builder-image: 'pytorch/manylinux2_28-builder@sha256:83d73c3fd2782b23de8a1873820236273d8a6db911aea15c017766c9a40e723c'
           - torch-version: '2.11.0'
             torch-cuda: 'cu130'
             cuda-version: '13.0'
+            # newest torch on newest CUDA is published as the -cuda-latest package
+            dist-tag: 'cuda-latest'
             python-builds: 'cp310-* cp311-* cp312-*'
             build-cuda: '1'
             builder-image: 'pytorch/manylinux2_28-builder@sha256:83d73c3fd2782b23de8a1873820236273d8a6db911aea15c017766c9a40e723c'
@@ -73,6 +79,7 @@ jobs:
           - torch-version: '2.11.0'
             torch-cuda: 'cpu'
             cuda-version: 'none'
+            dist-tag: 'cpu'
             python-builds: 'cp310-* cp311-* cp312-*'
             build-cuda: '0'
             builder-image: ''
@@ -287,6 +294,41 @@ jobs:
           echo "reached the build container."
           exit 1
         fi
+
+    # Publication metadata, emitted next to the wheels so the deployment
+    # scripts can read it instead of re-deriving it. They used to reconstruct
+    # the package name and the torch pin by sed-ing the artifact filename and
+    # by keeping a hand-copied mirror of this matrix in another repository,
+    # which drifted. The matrix is the single source of truth; this file is how
+    # it travels with the artifact.
+    - name: Write build metadata
+      run: |
+        python3 - <<'PY'
+        import json, os
+        torch_version = "${{ matrix.torch-version }}"
+        # dist-tag, not torch-cuda: both cu130 rows build for CUDA 13, but the
+        # newest-torch one is published as torch-harmonics-cuda-latest. Deriving
+        # the name from torch-cuda would collide them.
+        dist_tag = "${{ matrix.dist-tag }}"
+        major, minor, _ = torch_version.split(".")
+        meta = {
+            "schema": 1,
+            "package": "torch-harmonics" if dist_tag == "cpu" else f"torch-harmonics-{dist_tag}",
+            "cuda_tag": dist_tag,
+            "cuda_version": "${{ matrix.cuda-version }}",
+            "torch_version": torch_version,
+            # ABI breaks across torch minor versions, so pin to the exact minor
+            # the extension was compiled against.
+            "torch_pin": f">={major}.{minor}.0,<{major}.{int(minor)+1}.0",
+            "base_version": "${{ env.BASE_VERSION }}",
+            "cuda_arch_list": "${{ env.TORCH_CUDA_ARCH_LIST }}",
+            "build_cuda": "${{ matrix.build-cuda }}" == "1",
+            "run_id": "${{ github.run_id }}",
+        }
+        with open("wheelhouse/build-metadata.json", "w") as f:
+            json.dump(meta, f, indent=2)
+        print(json.dumps(meta, indent=2))
+        PY
 
     - name: Upload wheel artifacts
       uses: actions/upload-artifact@v7

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -12,7 +12,12 @@ permissions:
   contents: read
 
 env:
-  CUDA_ARCH_MAP: '{"12.6": "8.0;8.6;8.9;9.0;+PTX", "12.8": "8.0;8.6;8.9;9.0;10.0;12.0;+PTX", "12.9": "8.0;8.6;8.9;9.0;10.0;12.0;+PTX", "13.0": "8.0;8.6;8.9;9.0;10.0;12.0;+PTX", "none": ""}'
+  # The "a" suffixes are load-bearing, not cosmetic: setup.py gates the kpacked
+  # WGMMA (sm_90a) and tcgen05 (sm_100a) kernels on the literal strings 9.0a /
+  # 10.0a via _torch_cuda_arch_list_has(). Plain "9.0"/"10.0" builds, but
+  # silently compiles those kernels out.
+  # 10.0a and 12.0 are omitted for CUDA 12.6: sm_100/sm_120 only exist from 12.8.
+  CUDA_ARCH_MAP: '{"12.6": "8.0;8.6;8.9;9.0a+PTX", "12.8": "8.0;8.6;8.9;9.0a;10.0a;12.0+PTX", "12.9": "8.0;8.6;8.9;9.0a;10.0a;12.0+PTX", "13.0": "8.0;8.6;8.9;9.0a;10.0a;12.0+PTX", "none": ""}'
 
 jobs:
   build-manylinux-wheels:
@@ -22,31 +27,52 @@ jobs:
         include:
           # One build per CUDA version, using the oldest torch that supports it.
           # This gives the widest torch runtime compatibility for each CUDA variant.
+          #
+          # builder-image: CUDA builds run in PyTorch's manylinux_2_28 builder,
+          # which ships the CUDA toolkit -- the stock cibuildwheel image has no
+          # nvcc, so the CUDA kernels cannot be compiled there at all. Pinned by
+          # digest for the same reason the build tooling is pinned: a silently
+          # updated builder image would change what we ship with no diff.
+          # build-cuda: forces the CUDA extension on. Auto-detection cannot work
+          # here because it requires torch.cuda.is_available(), and the build
+          # runners have no GPU.
           - torch-version: '2.6.0'
             torch-cuda: 'cu126'
             cuda-version: '12.6'
             python-builds: 'cp310-* cp311-* cp312-*'
+            build-cuda: '1'
+            builder-image: 'pytorch/manylinux2_28-builder@sha256:e403d8c2bbb43e6d84704efcfa4c8c148bbe08edc2e69dac4c99546ed6c46cc7'
           - torch-version: '2.7.0'
             torch-cuda: 'cu128'
             cuda-version: '12.8'
             python-builds: 'cp310-* cp311-* cp312-*'
+            build-cuda: '1'
+            builder-image: 'pytorch/manylinux2_28-builder@sha256:404e7cddd7a2d4d7368c5a22416aaa10630d448aa97195a7864efbd9b05fa1c0'
           - torch-version: '2.8.0'
             torch-cuda: 'cu129'
             cuda-version: '12.9'
             python-builds: 'cp310-* cp311-* cp312-*'
+            build-cuda: '1'
+            builder-image: 'pytorch/manylinux2_28-builder@sha256:d26cd7a9489b53310296e86042de630ac947e25a71dd24b547b86ca9a0a3fc79'
           - torch-version: '2.9.1'
             torch-cuda: 'cu130'
             cuda-version: '13.0'
             python-builds: 'cp310-* cp311-* cp312-*'
+            build-cuda: '1'
+            builder-image: 'pytorch/manylinux2_28-builder@sha256:83d73c3fd2782b23de8a1873820236273d8a6db911aea15c017766c9a40e723c'
           - torch-version: '2.11.0'
             torch-cuda: 'cu130'
             cuda-version: '13.0'
             python-builds: 'cp310-* cp311-* cp312-*'
-          # CPU-only build based on latest PyTorch
+            build-cuda: '1'
+            builder-image: 'pytorch/manylinux2_28-builder@sha256:83d73c3fd2782b23de8a1873820236273d8a6db911aea15c017766c9a40e723c'
+          # CPU-only build based on latest PyTorch. Stock cibuildwheel image.
           - torch-version: '2.11.0'
             torch-cuda: 'cpu'
             cuda-version: 'none'
             python-builds: 'cp310-* cp311-* cp312-*'
+            build-cuda: '0'
+            builder-image: ''
 
     steps:
     - uses: actions/checkout@v5
@@ -169,7 +195,14 @@ jobs:
         CIBW_BUILD: ${{ matrix.python-builds }}
         TORCH_CUDA_VERSION: ${{ matrix.cuda-version }}
         TORCH_CUDA_ARCH_LIST: ${{ env.TORCH_CUDA_ARCH_LIST }}
-        CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.BASE_VERSION }}+torch${{ matrix.torch-version }}.${{ matrix.torch-cuda }} TORCH_CUDA_VERSION=${{ matrix.cuda-version }} TORCH_HARMONICS_ENABLE_OPENMP=1 TORCHINDUCTOR_COMPILE_THREADS=1"
+        # CUDA builds run in PyTorch's manylinux builder (it has nvcc); the
+        # CPU-only row keeps cibuildwheel's stock image, which an empty value
+        # selects.
+        CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.builder-image }}
+        # TORCH_CUDA_ARCH_LIST must be listed here explicitly: variables set on
+        # the runner do not reach the build container, which is why the arch
+        # list previously had no effect. Quoted because it contains ';'.
+        CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.BASE_VERSION }}+torch${{ matrix.torch-version }}.${{ matrix.torch-cuda }} TORCH_CUDA_VERSION=${{ matrix.cuda-version }} TORCH_HARMONICS_BUILD_CUDA_EXTENSION=${{ matrix.build-cuda }} TORCH_CUDA_ARCH_LIST='${{ env.TORCH_CUDA_ARCH_LIST }}' TORCH_HARMONICS_ENABLE_OPENMP=1 TORCHINDUCTOR_COMPILE_THREADS=1"
         CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
           set -e
           TORCH_LIB=$(python -c "import torch, os; print(os.path.join(os.path.dirname(torch.__file__), 'lib'))")
@@ -203,6 +236,38 @@ jobs:
           done
           rm -rf "$tmpdir"
         done
+
+    # A CUDA-labelled wheel that contains no CUDA is the failure this guards
+    # against: it does not crash, it silently falls back to torch-native paths,
+    # so it survived several releases unnoticed. Assert the kernels are really
+    # in there rather than trusting the build flags.
+    - name: Verify CUDA kernels are present in the wheels
+      if: matrix.build-cuda == '1'
+      run: |
+        set -e
+        failed=0
+        for whl in wheelhouse/*.whl; do
+          tmpdir=$(mktemp -d)
+          python -m zipfile -e "$whl" "$tmpdir"
+          for so in $(find "$tmpdir" -path '*/torch_harmonics/*' -name '_C*.so'); do
+            if readelf -SW "$so" | grep -q '\.nv_fatbin' \
+               || nm -D "$so" 2>/dev/null | grep -q '__cudaRegisterFatBinary'; then
+              echo "OK:   $(basename "$whl") :: $(basename "$so") contains CUDA code"
+            else
+              echo "FAIL: $(basename "$whl") :: $(basename "$so") has NO CUDA code"
+              failed=1
+            fi
+          done
+          rm -rf "$tmpdir"
+        done
+        if [ "$failed" -ne 0 ]; then
+          echo ""
+          echo "This wheel is labelled for CUDA ${{ matrix.cuda-version }} but the"
+          echo "extension modules contain no device code. Check that nvcc is present"
+          echo "in the builder image and that TORCH_HARMONICS_BUILD_CUDA_EXTENSION"
+          echo "reached the build container."
+          exit 1
+        fi
 
     - name: Upload wheel artifacts
       uses: actions/upload-artifact@v7
@@ -267,6 +332,10 @@ jobs:
         /tmp/test_venv/bin/pip install --quiet pypi-wheelhouse/*cp311*.whl
         cd /tmp && /tmp/test_venv/bin/python -c "import torch_harmonics; print('import OK, version:', torch_harmonics.__version__)"
 
+    # 100 MB is PyPI's per-file limit without an exemption. CUDA wheels carry
+    # cubins for every arch in TORCH_CUDA_ARCH_LIST, so this is a real ceiling
+    # here, not a formality -- if it trips, trim the arch list rather than
+    # raising the limit.
     - name: Check wheel sizes (must be <= 100 MB)
       run: |
         WHL_DIR=$([ -d pypi-wheelhouse ] && echo pypi-wheelhouse || echo wheelhouse)

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,6 +23,9 @@ jobs:
   build-manylinux-wheels:
     runs-on: ubuntu-latest
     strategy:
+      # One CUDA variant failing should not hide the state of the other five:
+      # they build independently and a release needs all of them.
+      fail-fast: false
       matrix:
         include:
           # One build per CUDA version, using the oldest torch that supports it.
@@ -206,7 +209,23 @@ jobs:
         CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
           set -e
           TORCH_LIB=$(python -c "import torch, os; print(os.path.join(os.path.dirname(torch.__file__), 'lib'))")
-          EXCLUDES=$(find "$TORCH_LIB" -maxdepth 1 -name '*.so*' | xargs -I{} basename {} | sort -u | sed 's/^/--exclude /' | tr '\n' ' ')
+          # CUDA runtime libraries must be excluded as well as torch's own. They
+          # are supplied at runtime by torch's nvidia-*-cu12 dependencies, which
+          # are already loaded by the time our extension is imported. Bundling
+          # them would duplicate hundreds of MB per wheel and blow the 100 MB
+          # limit; not excluding them fails the repair outright, because
+          # libcudart lives in site-packages/nvidia/*/lib rather than torch/lib.
+          NVIDIA_LIBS=$(python -c "
+          import glob, os, site
+          dirs = []
+          for sp in site.getsitepackages():
+              dirs += glob.glob(os.path.join(sp, 'nvidia', '*', 'lib'))
+          print(' '.join(dirs))
+          ")
+          EXCLUDES=$(for d in "$TORCH_LIB" $NVIDIA_LIBS /usr/local/cuda/lib64 /usr/local/cuda/targets/x86_64-linux/lib; do
+            [ -d "$d" ] && find "$d" -maxdepth 1 -name '*.so*'
+          done | xargs -r -I{} basename {} | sort -u | sed 's/^/--exclude /' | tr '\n' ' ')
+          echo "auditwheel excludes: $EXCLUDES"
           LD_LIBRARY_PATH="$TORCH_LIB:${LD_LIBRARY_PATH:-}" auditwheel repair $EXCLUDES -w {dest_dir} {wheel}
           for whl in {dest_dir}/*.whl; do
             python -m wheel unpack "$whl" --dest /tmp/strip_tmp


### PR DESCRIPTION
The cu126/cu128/cu129/cu130 wheels have never contained device code. The stock cibuildwheel manylinux image has no nvcc, no workflow ever set FORCE_CUDA_EXTENSION or its successor, and the auto-detect fallback needs torch.cuda.is_available(), which is false on a GPU-less build runner. Verified against the shipped 0.9.1 and 0.9.2 artifacts: no CUDA symbols, no libcudart, no fatbin. It never failed loudly because the C++ kernels build fine and the layers fall back to torch-native paths, so it survived several releases.

- build the CUDA rows in pytorch/manylinux2_28-builder, pinned by digest
- set TORCH_HARMONICS_BUILD_CUDA_EXTENSION per matrix row
- pass TORCH_CUDA_ARCH_LIST into the build container; it was set on the runner only, so it never reached the build
- use arch-conditional 9.0a/10.0a, which setup.py matches literally to enable the kpacked WGMMA and tcgen05 kernels
- fail the build if a CUDA-labelled wheel contains no device code