### PR TITLE
Attention fwd: neighbor-groups + segment-based psi iteration (remove per-neighbor integer division)

### DIFF
--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -398,7 +398,9 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
         qw = torch.randn(2, nlat, nlon, channels, device=self.device, dtype=torch.float32)
 
         with torch.autocast(self.device.type, dtype=autocast_dtype):
-            out = torch.ops.attention_kernels._neighborhood_s2_attention_optimized(kw, vw, qw, model.quad_weights, model.psi_col_idx, model.psi_roff_idx, 1, nlon, nlat, nlon)
+            out = torch.ops.attention_kernels._neighborhood_s2_attention_optimized(
+                kw, vw, qw, model.quad_weights, model.psi_col_idx, model.psi_roff_idx, model.psi_seg, model.psi_seg_off, 1, nlon, nlat, nlon
+            )
 
         self.assertEqual(out.dtype, autocast_dtype, f"autocast output dtype {out.dtype} != {autocast_dtype}")
 

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -43,6 +43,7 @@ from torch.library import opcheck
 # from torch.autograd import gradcheck
 from torch_harmonics import AttentionS2, NeighborhoodAttentionS2
 from torch_harmonics.attention import cuda_kernels_is_available, optimized_kernels_is_available
+from torch_harmonics.attention._attention_utils import _build_psi_segments, _expand_psi_segments
 from torch_harmonics.attention._layout import to_nhwc
 from torch_harmonics.attention.kernels_torch.attention_torch import (
     _neighborhood_s2_attention_bwd_dk_torch,
@@ -1473,6 +1474,61 @@ class TestPsiArcStructure(unittest.TestCase):
                 )
 
         self.assertGreater(checked, 0, msg=f"{name}: psi was empty, nothing verified")
+
+    @parameterized.expand(
+        [
+            ["self_equiangular", (64, 128), (64, 128), "equiangular", "equiangular", 0.05],
+            ["self_legendre_gauss", (64, 128), (64, 128), "legendre-gauss", "legendre-gauss", 0.05],
+            ["self_lobatto", (64, 128), (64, 128), "lobatto", "lobatto", 0.05],
+            ["self_wide_cutoff", (64, 128), (64, 128), "equiangular", "equiangular", 0.25],
+            ["downsample", (64, 128), (32, 64), "equiangular", "equiangular", 0.05],
+            ["upsample", (32, 64), (64, 128), "equiangular", "equiangular", 0.05],
+            ["odd_lat_down", (65, 128), (33, 64), "equiangular", "equiangular", 0.05],
+            ["odd_lat_up", (33, 64), (65, 128), "equiangular", "equiangular", 0.05],
+            ["lon_only_down", (64, 128), (64, 64), "equiangular", "equiangular", 0.05],
+        ]
+    )
+    def test_segments_reproduce_col_idx(self, name, in_shape, out_shape, grid_in, grid_out, theta_cutoff):
+        """(hi, lo, len) segments expand back to exactly psi_col_idx.
+
+        Stronger than the arc property above and closer to what a kernel relies on: it
+        is not enough that the arcs are contiguous, the segment table has to describe
+        the *same* sparsity. A segment whose start is off by one -- which is what a
+        mishandled wrapping arc produces -- still passes the contiguity check while
+        silently attending to the wrong cells.
+        """
+
+        nlat_in, nlon_in = in_shape
+        nlat_out, nlon_out = out_shape
+
+        att = NeighborhoodAttentionS2(
+            in_channels=8,
+            num_heads=1,
+            in_shape=in_shape,
+            out_shape=out_shape,
+            grid_in=grid_in,
+            grid_out=grid_out,
+            theta_cutoff=theta_cutoff,
+            bias=False,
+            optimized_kernel=False,
+        )
+
+        upsample = (nlat_out > nlat_in) or (nlon_out > nlon_in)
+        nlon_decode = nlon_out if upsample else nlon_in
+
+        col = att.psi_col_idx.cpu()
+        roff = att.psi_roff_idx.cpu()
+        seg, seg_off = _build_psi_segments(col, roff, nlon_decode)
+        expanded = _expand_psi_segments(seg, seg_off, nlon_decode)
+
+        self.assertEqual(seg_off.numel() - 1, roff.numel() - 1, msg=f"{name}: row count mismatch")
+        for row in range(roff.numel() - 1):
+            want = sorted(col[int(roff[row]) : int(roff[row + 1])].tolist())
+            self.assertEqual(
+                want,
+                expanded[row],
+                msg=f"{name}: row {row} segments do not reproduce psi_col_idx",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -194,6 +194,18 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
             # row uses C in {4, 8} and therefore only exercises the vector branch.
             [4, 6, 6, 2, (6, 12), (12, 24), "equiangular", "equiangular", False, torch.float16, 2e-2, 1e-2],
             [4, 6, 6, 2, (6, 12), (12, 24), "equiangular", "equiangular", False, torch.bfloat16, 5e-2, 5e-2],
+            # Vectorized-load coverage. The CUDA dispatch only takes the vector path when
+            # the vectorized channel count still fills the block -- nchans_per_head / 4 >=
+            # bdimx, i.e. >= 128 channels per head. Every other row in this grid has <= 8,
+            # so without these the float4 / half4 / bf164 loads are compiled but never
+            # executed. 256 channels over 2 heads also gives 128 per head, which checks
+            # that the gate reads the per-head count rather than the packed extent.
+            [1, 128, 128, 1, (6, 12), (6, 12), "equiangular", "equiangular", False, torch.float32, 1e-5, 1e-3],
+            [1, 128, 128, 1, (6, 12), (6, 12), "equiangular", "equiangular", False, torch.float16, 2e-2, 1e-2],
+            [1, 128, 128, 1, (6, 12), (6, 12), "equiangular", "equiangular", False, torch.bfloat16, 5e-2, 5e-2],
+            [1, 256, 256, 2, (6, 12), (6, 12), "equiangular", "equiangular", False, torch.float16, 2e-2, 1e-2],
+            [1, 128, 128, 1, (12, 24), (6, 12), "equiangular", "equiangular", False, torch.float16, 2e-2, 1e-2],
+            [1, 128, 128, 1, (6, 12), (12, 24), "equiangular", "equiangular", False, torch.float16, 2e-2, 1e-2],
             # gather with QK norm enabled
             [4, 4, 4, 1, (6, 12), (6, 12), "equiangular", "equiangular", True, torch.float16, 2e-2, 1e-2],
             [4, 4, 4, 1, (6, 12), (6, 12), "equiangular", "equiangular", True, torch.bfloat16, 5e-2, 5e-2],

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -1386,5 +1386,94 @@ class TestSplitCsrRows(unittest.TestCase):
         )
 
 
+class TestPsiArcStructure(unittest.TestCase):
+    """psi's sparsity is a union of contiguous longitude arcs, one per (row, input lat).
+
+    This is a geometric consequence of the neighborhood being a geodesic ball: a ball
+    intersects a latitude circle in a single arc, never in disjoint pieces. It is not
+    an accident of one grid or cutoff, and the kernels are entitled to rely on it.
+
+    Why pin it down: it means the neighbor longitudes for a row can be described by
+    (start, width) instead of an explicit column list, so a kernel can compute a
+    neighbor's address arithmetically -- wip = (lo + j + pscale*wo) % nlon_in -- rather
+    than loading it from psi_col_idx. That removes a dependent load from the inner loop
+    and makes the k/v accesses stride-1 in longitude. If a future change to how psi is
+    built ever introduces holes, every such kernel silently reads the wrong elements,
+    and this test is what catches it.
+
+    Device-independent: psi is built on CPU at construction time.
+    """
+
+    @staticmethod
+    def _is_single_arc(wi, nlon):
+        """True if the longitudes form one contiguous arc on the circle (wrap allowed)."""
+
+        w = torch.unique(wi).sort().values
+        if w.numel() <= 1:
+            return True
+        # A single arc has exactly one gap larger than 1 -- the complement. Count the
+        # seam between last and first as a gap too, which is what makes a wrapping arc
+        # (e.g. {718, 719, 0, 1}) register as contiguous rather than as two pieces.
+        interior = int((torch.diff(w) > 1).sum())
+        seam = 1 if (w[0] + nlon) - w[-1] > 1 else 0
+        return interior + seam <= 1
+
+    @parameterized.expand(
+        [
+            # name, in_shape, out_shape, grid_in, grid_out, theta_cutoff
+            ["self_equiangular", (64, 128), (64, 128), "equiangular", "equiangular", 0.05],
+            ["self_legendre_gauss", (64, 128), (64, 128), "legendre-gauss", "legendre-gauss", 0.05],
+            ["self_lobatto", (64, 128), (64, 128), "lobatto", "lobatto", 0.05],
+            ["self_wide_cutoff", (64, 128), (64, 128), "equiangular", "equiangular", 0.25],
+            ["downsample", (64, 128), (32, 64), "equiangular", "equiangular", 0.05],
+            ["upsample", (32, 64), (64, 128), "equiangular", "equiangular", 0.05],
+            ["odd_lat_down", (65, 128), (33, 64), "equiangular", "equiangular", 0.05],
+            ["odd_lat_up", (33, 64), (65, 128), "equiangular", "equiangular", 0.05],
+            ["lon_only_down", (64, 128), (64, 64), "equiangular", "equiangular", 0.05],
+        ]
+    )
+    def test_rows_are_contiguous_arcs(self, name, in_shape, out_shape, grid_in, grid_out, theta_cutoff):
+        nlat_in, nlon_in = in_shape
+        nlat_out, nlon_out = out_shape
+
+        att = NeighborhoodAttentionS2(
+            in_channels=8,
+            num_heads=1,
+            in_shape=in_shape,
+            out_shape=out_shape,
+            grid_in=grid_in,
+            grid_out=grid_out,
+            theta_cutoff=theta_cutoff,
+            bias=False,
+            optimized_kernel=False,
+        )
+
+        col = att.psi_col_idx.cpu()
+        roff = att.psi_roff_idx.cpu()
+
+        # The scatter (upsample) psi is keyed by input latitude and its columns index
+        # the output grid; the gather psi is the other way round.
+        upsample = (nlat_out > nlat_in) or (nlon_out > nlon_in)
+        nlon_decode = nlon_out if upsample else nlon_in
+
+        nrows = roff.numel() - 1
+        checked = 0
+        for row in range(nrows):
+            beg, end = int(roff[row]), int(roff[row + 1])
+            if end <= beg:
+                continue
+            cols = col[beg:end]
+            lat = cols // nlon_decode
+            lon = cols - lat * nlon_decode
+            for h in torch.unique(lat):
+                checked += 1
+                self.assertTrue(
+                    self._is_single_arc(lon[lat == h], nlon_decode),
+                    msg=f"{name}: row {row}, input lat {int(h)} has non-contiguous longitudes; " f"kernels that derive addresses arithmetically would read the wrong cells",
+                )
+
+        self.assertGreater(checked, 0, msg=f"{name}: psi was empty, nothing verified")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -881,6 +881,8 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
             att.quad_weights,
             att.psi_col_idx,
             att.psi_roff_idx,
+            att.psi_seg,
+            att.psi_seg_off,
             att.num_heads,
             nlon_in,
             nlat_out,

--- a/torch_harmonics/attention/_attention_utils.py
+++ b/torch_harmonics/attention/_attention_utils.py
@@ -98,3 +98,82 @@ def _setup_context_attention_backward(ctx, inputs, output):
     ctx.nlon_in = nlon_in
     ctx.nlat_out = nlat_out
     ctx.nlon_out = nlon_out
+
+
+def _build_psi_segments(col_idx: torch.Tensor, roff_idx: torch.Tensor, nlon: int):
+    """
+    Re-express psi's column list as contiguous longitude arcs.
+
+    psi's sparsity is a union of arcs: for a given output row and input latitude, the
+    neighbor longitudes are contiguous on the circle (possibly wrapping). This is
+    geometric -- a geodesic ball meets a latitude circle in one arc -- and is pinned by
+    TestPsiArcStructure.
+
+    That lets a kernel iterate (hi, lo, len) segments and derive each neighbor's column
+    by counting, instead of loading it from col_idx and recovering hi with a 64-bit
+    integer division. The GPU has no integer divide instruction, so that division costs
+    ~70-100 emulated instructions per neighbor against roughly four instructions of
+    useful math; profiling showed the forward kernel at 80% compute throughput while
+    delivering ~2.4% of peak FLOPs.
+
+    Returns
+    -------
+    seg : int32 tensor of shape (nsegs, 3), columns (hi, lo, len)
+    seg_off : int32 tensor of shape (nrows + 1,), row -> segment range
+
+    Notes
+    -----
+    Relies on col_idx being sorted ascending within each row, which is how
+    _precompute_convolution_tensor_s2 emits it. A wrapping arc therefore appears as
+    two runs at the ends of the sorted list, which is handled explicitly.
+    """
+
+    col = col_idx.cpu().to(torch.int64)
+    roff = roff_idx.cpu().to(torch.int64)
+    nrows = roff.numel() - 1
+
+    seg_rows = []
+    segs = []
+    for row in range(nrows):
+        beg, end = int(roff[row]), int(roff[row + 1])
+        n_before = len(segs)
+        if end > beg:
+            cols = col[beg:end]
+            hi = torch.div(cols, nlon, rounding_mode="floor")
+            wi = cols - hi * nlon
+            for h in torch.unique(hi):
+                w = torch.unique(wi[hi == h]).sort().values
+                count = int(w.numel())
+                lo, hi_w = int(w[0]), int(w[-1])
+                if hi_w - lo + 1 == count:
+                    # plain arc
+                    start, length = lo, count
+                else:
+                    # wraps the seam: sorted as [0..a] u [b..nlon-1]; the arc starts at
+                    # b, which is one past the single interior gap
+                    gaps = torch.diff(w)
+                    split = int(torch.argmax(gaps))
+                    start = int(w[split + 1])
+                    length = count
+                segs.append((int(h), start, length))
+        seg_rows.append(len(segs) - n_before)
+
+    seg = torch.tensor(segs, dtype=torch.int32).reshape(-1, 3)
+    seg_off = torch.zeros(nrows + 1, dtype=torch.int32)
+    seg_off[1:] = torch.tensor(seg_rows, dtype=torch.int32).cumsum(0)
+    return seg, seg_off
+
+
+def _expand_psi_segments(seg: torch.Tensor, seg_off: torch.Tensor, nlon: int):
+    """Expand segments back to a per-row column list. Inverse of _build_psi_segments,
+    used to verify the two representations describe the same sparsity."""
+
+    out = []
+    for row in range(seg_off.numel() - 1):
+        cols = []
+        for s in range(int(seg_off[row]), int(seg_off[row + 1])):
+            hi, lo, length = (int(x) for x in seg[s])
+            for j in range(length):
+                cols.append(hi * nlon + (lo + j) % nlon)
+        out.append(sorted(cols))
+    return out

--- a/torch_harmonics/attention/_attention_utils.py
+++ b/torch_harmonics/attention/_attention_utils.py
@@ -92,7 +92,11 @@ def _check_dtypes_match(tensors) -> None:
 # Shared backward-context helper used by both the torch reference kernels
 # (in kernels_torch/) and the optimized custom_op path (in optimized/).
 def _setup_context_attention_backward(ctx, inputs, output):
-    kw, vw, qw, quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out = inputs
+    # seg / seg_off are unpacked but not saved: the backward op still consumes the
+    # column list, so only col_idx and row_off need to survive into backward. They
+    # appear here because the unpack is positional and must match the forward op's
+    # argument list exactly.
+    kw, vw, qw, quad_weights, col_idx, row_off, seg, seg_off, nh, nlon_in, nlat_out, nlon_out = inputs
     ctx.save_for_backward(col_idx, row_off, quad_weights, kw, vw, qw)
     ctx.nh = nh
     ctx.nlon_in = nlon_in

--- a/torch_harmonics/attention/attention.py
+++ b/torch_harmonics/attention/attention.py
@@ -37,7 +37,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from attention_helpers import optimized_kernels_is_available
 
-from torch_harmonics.attention._attention_utils import _check_dtypes_match, _check_extent, _check_ndim
+from torch_harmonics.attention._attention_utils import _build_psi_segments, _check_dtypes_match, _check_extent, _check_ndim
 from torch_harmonics.attention._layout import to_nchw, to_nhwc
 from torch_harmonics.attention.kernels_torch.attention_torch import _neighborhood_s2_attention_torch
 from torch_harmonics.attention.optimized.attention_optimized import _neighborhood_s2_attention_optimized
@@ -408,6 +408,20 @@ class NeighborhoodAttentionS2(nn.Module):
         self.register_buffer("psi_col_idx", col_idx, persistent=False)
         self.register_buffer("psi_roff_idx", roff_idx, persistent=False)
 
+        # Contiguous-arc form of the same sparsity, consumed by the CUDA kernels: it
+        # lets them derive a neighbour's column by counting instead of recovering it
+        # from col_idx with a per-neighbour 64-bit integer division, which the GPU has
+        # no instruction for. col_idx is kept because the CPU and torch reference paths
+        # still use it -- which is what keeps the reference independent of this
+        # derivation. See _build_psi_segments and TestPsiArcStructure.
+        #
+        # For the scatter (upsample) psi the rows are keyed by input latitude and the
+        # columns index the output grid, so the decode width differs.
+        nlon_decode = self.nlon_out if (self.nlat_out > self.nlat_in or self.nlon_out > self.nlon_in) else self.nlon_in
+        psi_seg, psi_seg_off = _build_psi_segments(col_idx, roff_idx, nlon_decode)
+        self.register_buffer("psi_seg", psi_seg, persistent=False)
+        self.register_buffer("psi_seg_off", psi_seg_off, persistent=False)
+
         # learnable parameters — Xavier uniform init matching PyTorch MHA convention:
         # bound = sqrt(6 / (fan_in + fan_out)) for each projection
         if self.k_channels % self.num_heads != 0:
@@ -557,6 +571,8 @@ class NeighborhoodAttentionS2(nn.Module):
             self.quad_weights,
             self.psi_col_idx,
             self.psi_roff_idx,
+            self.psi_seg,
+            self.psi_seg_off,
             self.num_heads,
             self.nlon_in,
             self.nlat_out,

--- a/torch_harmonics/attention/kernels_torch/attention_torch.py
+++ b/torch_harmonics/attention/kernels_torch/attention_torch.py
@@ -398,6 +398,8 @@ def _neighborhood_s2_attention_torch(
     quad_weights: torch.Tensor,
     col_idx: torch.Tensor,
     row_off: torch.Tensor,
+    seg: torch.Tensor,
+    seg_off: torch.Tensor,
     nh: int,
     nlon_in: int,
     nlat_out: int,
@@ -455,6 +457,8 @@ def _(
     quad_weights: torch.Tensor,
     col_idx: torch.Tensor,
     row_off: torch.Tensor,
+    seg: torch.Tensor,
+    seg_off: torch.Tensor,
     nh: int,
     nlon_in: int,
     nlat_out: int,
@@ -531,7 +535,9 @@ def _neighborhood_s2_attention_bwd_torch(ctx, grad_output):
     else:
         dqw = None
 
-    return dkw, dvw, dqw, None, None, None, None, None, None, None
+    # one gradient per forward input: kw, vw, qw, then None for quad_weights,
+    # col_idx, row_off, seg, seg_off, nh, nlon_in, nlat_out, nlon_out
+    return dkw, dvw, dqw, None, None, None, None, None, None, None, None, None
 
 
 # register backward
@@ -547,10 +553,12 @@ torch.library.register_autograd("attention_kernels::_neighborhood_s2_attention_t
 # needs its own key.
 def _make_autocast_impl(device_type):
     @torch.library.impl("attention_kernels::_neighborhood_s2_attention_torch", f"Autocast{device_type.upper()}")
-    def _(kw, vw, qw, quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out):
+    def _(kw, vw, qw, quad_weights, col_idx, row_off, seg, seg_off, nh, nlon_in, nlat_out, nlon_out):
         cast_dtype = torch.get_autocast_dtype(device_type)
         with torch.amp.autocast(device_type, enabled=False):
-            return _neighborhood_s2_attention_torch(kw.to(cast_dtype), vw.to(cast_dtype), qw.to(cast_dtype), quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out)
+            return _neighborhood_s2_attention_torch(
+                kw.to(cast_dtype), vw.to(cast_dtype), qw.to(cast_dtype), quad_weights, col_idx, row_off, seg, seg_off, nh, nlon_in, nlat_out, nlon_out
+            )
 
     return _
 

--- a/torch_harmonics/attention/optimized/attention_interface.cpp
+++ b/torch_harmonics/attention/optimized/attention_interface.cpp
@@ -111,8 +111,13 @@ namespace attention_kernels
         //              applies the integer p-shift  wip = wi + pscale*wo  internally,
         //              where pscale = nlon_in / nlon_out).
         // Requires nlon_in % nlon_out == 0.
-        m.def("forward(Tensor kx, Tensor vx, Tensor qy, Tensor quad_weights, Tensor col_idx, Tensor row_off, int "
-              "num_heads, int nlon_in, int nlat_out, int nlon_out) -> Tensor",
+        // seg / seg_off are the contiguous-arc form of psi (see _build_psi_segments):
+        // seg is (nsegs, 3) int32 holding (input_lat, lon_start, arc_len), seg_off maps
+        // an output row to its segment range. The CUDA kernels use them instead of
+        // col_idx; col_idx and row_off stay because the CPU and torch reference paths
+        // still consume them -- which is what keeps the reference independent.
+        m.def("forward(Tensor kx, Tensor vx, Tensor qy, Tensor quad_weights, Tensor col_idx, Tensor row_off, "
+              "Tensor seg, Tensor seg_off, int num_heads, int nlon_in, int nlat_out, int nlon_out) -> Tensor",
               {at::Tag::pt2_compliant_tag});
         m.def("backward(Tensor kx, Tensor vx, Tensor qy, Tensor dy, Tensor quad_weights, Tensor col_idx, Tensor "
               "row_off, int num_heads, int nlon_in, int nlat_out, int nlon_out) -> (Tensor, Tensor, Tensor)",

--- a/torch_harmonics/attention/optimized/attention_optimized.py
+++ b/torch_harmonics/attention/optimized/attention_optimized.py
@@ -48,6 +48,8 @@ if optimized_kernels_is_available():
         quad_weights: torch.Tensor,
         col_idx: torch.Tensor,
         row_off: torch.Tensor,
+        seg: torch.Tensor,
+        seg_off: torch.Tensor,
         num_heads: int,
         nlon_in: int,
         nlat_out: int,
@@ -235,6 +237,8 @@ if optimized_kernels_is_available():
         quad_weights: torch.Tensor,
         col_idx: torch.Tensor,
         row_off: torch.Tensor,
+        seg: torch.Tensor,
+        seg_off: torch.Tensor,
         nh: int,
         nlon_in: int,
         nlat_out: int,
@@ -252,7 +256,7 @@ if optimized_kernels_is_available():
         vw = vw.contiguous()
         qw = qw.contiguous()
 
-        return attention_kernels.forward.default(kw, vw, qw, quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out)
+        return attention_kernels.forward.default(kw, vw, qw, quad_weights, col_idx, row_off, seg, seg_off, nh, nlon_in, nlat_out, nlon_out)
 
     @torch.library.register_fake("attention_kernels::_neighborhood_s2_attention_optimized")
     def _(
@@ -262,6 +266,8 @@ if optimized_kernels_is_available():
         quad_weights: torch.Tensor,
         col_idx: torch.Tensor,
         row_off: torch.Tensor,
+        seg: torch.Tensor,
+        seg_off: torch.Tensor,
         nh: int,
         nlon_in: int,
         nlat_out: int,
@@ -288,7 +294,9 @@ def _neighborhood_s2_attention_bwd_optimized(ctx, grad_output):
 
     dkw, dvw, dqw = attention_kernels.backward.default(kw, vw, qw, grad_output, quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out)
 
-    return dkw, dvw, dqw, None, None, None, None, None, None, None
+    # one gradient per forward input: kw, vw, qw, then None for quad_weights,
+    # col_idx, row_off, seg, seg_off, nh, nlon_in, nlat_out, nlon_out
+    return dkw, dvw, dqw, None, None, None, None, None, None, None, None, None
 
 
 # register backward
@@ -309,11 +317,11 @@ if optimized_kernels_is_available():
     # what makes the requirement hold.
     def _make_autocast_impl(device_type):
         @torch.library.impl("attention_kernels::_neighborhood_s2_attention_optimized", f"Autocast{device_type.upper()}")
-        def _(kw, vw, qw, quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out):
+        def _(kw, vw, qw, quad_weights, col_idx, row_off, seg, seg_off, nh, nlon_in, nlat_out, nlon_out):
             cast_dtype = torch.get_autocast_dtype(device_type)
             with torch.amp.autocast(device_type, enabled=False):
                 return _neighborhood_s2_attention_optimized(
-                    kw.to(cast_dtype), vw.to(cast_dtype), qw.to(cast_dtype), quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out
+                    kw.to(cast_dtype), vw.to(cast_dtype), qw.to(cast_dtype), quad_weights, col_idx, row_off, seg, seg_off, nh, nlon_in, nlat_out, nlon_out
                 )
 
         return _

--- a/torch_harmonics/attention/optimized/kernels_cpu/attention_cpu_fwd.cpp
+++ b/torch_harmonics/attention/optimized/kernels_cpu/attention_cpu_fwd.cpp
@@ -65,8 +65,8 @@ namespace attention_kernels
     // contiguous; the result is returned in the same layout. Layout is never
     // inferred from strides -- the caller states it by construction.
     torch::Tensor s2_attention_fwd_cpu(at::Tensor kx, at::Tensor vx, at::Tensor qy, at::Tensor quad_weights,
-                                       at::Tensor col_idx, at::Tensor row_off, int64_t num_heads, int64_t nlon_in,
-                                       int64_t nlat_out, int64_t nlon_out)
+                                       at::Tensor col_idx, at::Tensor row_off, at::Tensor seg, at::Tensor seg_off,
+                                       int64_t num_heads, int64_t nlon_in, int64_t nlat_out, int64_t nlon_out)
     {
         CHECK_CPU_INPUT_TENSOR(kx);
         CHECK_CPU_INPUT_TENSOR(vx);
@@ -82,6 +82,14 @@ namespace attention_kernels
         const bool upsample = (nlon_out % nlon_in == 0);
         TORCH_CHECK(downsample || upsample, "either nlon_in (", nlon_in, ") must be an integer multiple of nlon_out (",
                     nlon_out, "), or vice versa");
+
+        // seg / seg_off are accepted for ABI parity with the CUDA path but not used
+        // here: this is a correctness reference, and the CPU accessors have no
+        // equivalent of the GPU's missing integer-divide instruction, which is the
+        // whole reason the CUDA kernels switched to arcs. Optimizing the CPU path is
+        // a separate question.
+        (void)seg;
+        (void)seg_off;
 
         TORCH_CHECK(num_heads >= 1, "num_heads must be positive, got ", num_heads);
         TORCH_CHECK(qy.size(3) % num_heads == 0, "q/k channel count (", qy.size(3),

--- a/torch_harmonics/attention/optimized/kernels_cpu/attention_cpu_fwd.h
+++ b/torch_harmonics/attention/optimized/kernels_cpu/attention_cpu_fwd.h
@@ -206,8 +206,8 @@ namespace attention_kernels
     // NHWC ABI with heads packed along the channel dimension; see the definition
     // in attention_cpu_fwd.cpp.
     torch::Tensor s2_attention_fwd_cpu(at::Tensor kx, at::Tensor vx, at::Tensor qy, at::Tensor quad_weights,
-                                       at::Tensor col_idx, at::Tensor row_off, int64_t num_heads, int64_t nlon_in,
-                                       int64_t nlat_out, int64_t nlon_out);
+                                       at::Tensor col_idx, at::Tensor row_off, at::Tensor seg, at::Tensor seg_off,
+                                       int64_t num_heads, int64_t nlon_in, int64_t nlat_out, int64_t nlon_out);
 
     // head packing helpers, defined in attention_cpu_fwd.cpp
     at::Tensor fold_heads(const at::Tensor &t, int64_t num_heads);

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda.cuh
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda.cuh
@@ -46,8 +46,9 @@ namespace attention_kernels
     // NHWC ABI with heads packed along the channel dimension; see the definitions
     // in attention_cuda_fwd.cu / attention_cuda_bwd.cu.
     torch::Tensor s2_attention_fwd_cuda(at::Tensor kx, at::Tensor vx, at::Tensor qy, at::Tensor quad_weights,
-                                        at::Tensor psi_col_idx, at::Tensor psi_row_off, int64_t num_heads,
-                                        int64_t nlon_in, int64_t nlat_out, int64_t nlon_out);
+                                        at::Tensor psi_col_idx, at::Tensor psi_row_off, at::Tensor psi_seg,
+                                        at::Tensor psi_seg_off, int64_t num_heads, int64_t nlon_in, int64_t nlat_out,
+                                        int64_t nlon_out);
 
     std::tuple<at::Tensor, at::Tensor, at::Tensor>
     s2_attention_bwd_dkvq_cuda(at::Tensor kx, at::Tensor vx, at::Tensor qy, at::Tensor dy, at::Tensor quad_weights,

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_bwd.cu
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_bwd.cu
@@ -188,7 +188,7 @@ namespace attention_kernels
             const int hi = col / nlon_in;
             const int wi = col - (hi * nlon_in);
             const int wi_wo = wi + pscale * wo;
-            const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+            const int wip = wrap_lon(wi_wo, nlon_in);
 
             const STORAGE_T *_kx = kx + int64_t(hi) * nlon_in * ldi + int64_t(wip) * ldi;
             const STORAGE_T *_vx = vx + int64_t(hi) * nlon_in * ldo + int64_t(wip) * ldo;
@@ -245,7 +245,7 @@ namespace attention_kernels
             const int hi = col / nlon_in;
             const int wi = col - (hi * nlon_in);
             const int wi_wo = wi + pscale * wo;
-            const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+            const int wip = wrap_lon(wi_wo, nlon_in);
 
             const STORAGE_T *_kx = kx + int64_t(hi) * nlon_in * ldi + int64_t(wip) * ldi;
             const STORAGE_T *_vx = vx + int64_t(hi) * nlon_in * ldo + int64_t(wip) * ldo;
@@ -450,7 +450,7 @@ namespace attention_kernels
             const int hi = col / nlon_in;
             const int wi = col - (hi * nlon_in);
             const int wi_wo = wi + pscale * wo;
-            const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+            const int wip = wrap_lon(wi_wo, nlon_in);
 
             const STORAGE_T *_kx = kx + int64_t(hi) * nlon_in * ldi + int64_t(wip) * ldi;
             const STORAGE_T *_vx = vx + int64_t(hi) * nlon_in * ldo + int64_t(wip) * ldo;
@@ -542,7 +542,7 @@ namespace attention_kernels
             const int hi = col / nlon_in;
             const int wi = col - (hi * nlon_in);
             const int wi_wo = wi + pscale * wo;
-            const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+            const int wip = wrap_lon(wi_wo, nlon_in);
 
             const STORAGE_T *_kx = kx + int64_t(hi) * nlon_in * ldi + int64_t(wip) * ldi;
             const STORAGE_T *_vx = vx + int64_t(hi) * nlon_in * ldo + int64_t(wip) * ldo;

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_bwd_ring.cu
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_bwd_ring.cu
@@ -162,7 +162,7 @@ namespace attention_kernels
             // wip = (wi + pscale * wo_local) % nlon_in
             //     = (wi_canonical + pscale * (lon_lo_out + wo_local)) % nlon_in
             const int wi_wo = wi + pscale * wo;
-            const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+            const int wip = wrap_lon(wi_wo, nlon_in);
 
             if (wip < lon_lo_kx || wip >= lon_lo_kx + nlon_kx) continue;
 
@@ -351,7 +351,7 @@ namespace attention_kernels
                 const int wi = col - (hi_global * nlon_in);
                 const int wi_wo = wi + pscale * wo;
 
-                const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+                const int wip = wrap_lon(wi_wo, nlon_in);
 
                 if (wip >= lon_lo_kx && wip < lon_lo_kx + nlon_kx) {
 
@@ -609,7 +609,7 @@ namespace attention_kernels
                 const int wi = col - (hi_global * nlon_in);
                 const int wi_wo = wi + pscale * wo;
 
-                const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+                const int wip = wrap_lon(wi_wo, nlon_in);
 
                 if (wip >= lon_lo_kx && wip < lon_lo_kx + nlon_kx) {
 
@@ -933,7 +933,7 @@ namespace attention_kernels
                 const int wi = col - (hi_global * nlon_in);
                 const int wi_wo = wi + pscale * wo;
 
-                const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+                const int wip = wrap_lon(wi_wo, nlon_in);
 
                 if (wip >= lon_lo_kx && wip < lon_lo_kx + nlon_kx) {
 
@@ -1384,7 +1384,7 @@ namespace attention_kernels
             // wip = (wi + pscale * wo_local) % nlon_in
             //     = (wi_canonical + pscale * (lon_lo_out + wo_local)) % nlon_in
             const int wi_wo = wi + pscale * wo;
-            const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+            const int wip = wrap_lon(wi_wo, nlon_in);
 
             if (wip < lon_lo_kx || wip >= lon_lo_kx + nlon_kx) continue;
 
@@ -1609,7 +1609,7 @@ namespace attention_kernels
                 const int wi = col - (hi_global * nlon_in);
                 const int wi_wo = wi + pscale * wo;
 
-                const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+                const int wip = wrap_lon(wi_wo, nlon_in);
 
                 if (wip >= lon_lo_kx && wip < lon_lo_kx + nlon_kx) {
                     hi_local = hi_global - lat_halo_start;

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_fwd.cu
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_fwd.cu
@@ -266,7 +266,115 @@ namespace attention_kernels
 
         const int rlen = rend - rbeg;
 
-        for (int off = 0; off < rlen; off++) {
+        // Neighbors are processed in groups of NB.
+        //
+        // The one-at-a-time form this replaces had a fully serial dependency chain per
+        // neighbor: col_idx -> address -> load k -> warp reduce -> softmax -> load v.
+        // Nothing was in flight while a ~500-cycle k load resolved, and with nchan_in
+        // = 64 over BDIM_X = 32 lanes there were only two independent loads inside the
+        // channel loop to hide it with. Measured 1.6 TFLOP/s on H100 -- about 2% of
+        // this GPU's scalar fp32 peak and ~300x off its bandwidth roofline, i.e. the
+        // kernel was latency-bound, not compute- or bandwidth-bound.
+        //
+        // Grouping issues NB independent k loads (and later NB v loads) before any is
+        // consumed, which is the entire point: memory-level parallelism, not fewer
+        // flops. The online softmax is applied once per group instead of once per
+        // neighbor. That is algebraically the same reduction -- one running max, one
+        // rescale of locy per group rather than NB of them -- and is if anything
+        // better conditioned, since it rescales less often.
+        constexpr int NB = 4;
+
+        int off = 0;
+        for (; off + NB <= rlen; off += NB) {
+
+            const STORAGE_T *kp[NB];
+            const STORAGE_T *vp[NB];
+            float qw[NB];
+
+#pragma unroll
+            for (int u = 0; u < NB; u++) {
+                const int64_t col = col_idx[off + u];
+                const int hi = col / nlon_in;
+                const int wi = col - (hi * nlon_in);
+                const int wi_wo = wi + pscale * wo;
+                const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+                kp[u] = kx + int64_t(hi) * nlon_in * ldi + int64_t(wip) * ldi;
+                vp[u] = vx + int64_t(hi) * nlon_in * ldo + int64_t(wip) * ldo;
+                qw[u] = quad_weights[hi];
+            }
+
+            COMPUTE_T acc[NB];
+#pragma unroll
+            for (int u = 0; u < NB; u++) { acc[u] = __vset<COMPUTE_T>(0.f); }
+
+            // one channel loop feeding NB accumulators, so NB loads are outstanding
+            // per channel step rather than one
+            if constexpr (CHIN_AS_OUT) {
+#pragma unroll
+                for (int i = 0; i < NLOC_M1; i++) {
+                    const COMPUTE_T q = shq[i * BDIM_X];
+#pragma unroll
+                    for (int u = 0; u < NB; u++) { acc[u] = __vadd(acc[u], __vmul(q, vload(kp[u], i * BDIM_X))); }
+                }
+                if (NLOC_M1 * BDIM_X + tidx < nchan_in) {
+                    const COMPUTE_T q = shq[NLOC_M1 * BDIM_X];
+#pragma unroll
+                    for (int u = 0; u < NB; u++) { acc[u] = __vadd(acc[u], __vmul(q, vload(kp[u], NLOC_M1 * BDIM_X))); }
+                }
+            } else {
+                for (int chan = tidx; chan < nchan_in; chan += BDIM_X) {
+                    const COMPUTE_T q = shq[chan];
+#pragma unroll
+                    for (int u = 0; u < NB; u++) { acc[u] = __vadd(acc[u], __vmul(q, vload(kp[u], chan))); }
+                }
+            }
+
+            float qdotk[NB];
+#pragma unroll
+            for (int u = 0; u < NB; u++) {
+                float t = __vred(acc[u]);
+                if constexpr (BDIM_X == 32) {
+                    t = __warp_sum(t);
+                } else {
+                    t = __block_sum<BDIM_X>(t);
+                }
+                qdotk[u] = t;
+            }
+
+            // group-wise online softmax: one running max and one rescale for all NB
+            float qdotk_max_tmp = qdotk_max;
+#pragma unroll
+            for (int u = 0; u < NB; u++) { qdotk_max_tmp = max(qdotk_max_tmp, qdotk[u]); }
+            const float exp_save = expf(qdotk_max - qdotk_max_tmp);
+
+            float alpha[NB];
+            float alpha_grp = 0.0f;
+#pragma unroll
+            for (int u = 0; u < NB; u++) {
+                alpha[u] = expf(qdotk[u] - qdotk_max_tmp) * qw[u];
+                alpha_grp += alpha[u];
+            }
+            alpha_sum = alpha_grp + alpha_sum * exp_save;
+
+#pragma unroll
+            for (int i = 0; i < NLOC_M1; i++) {
+                COMPUTE_T t = __vscale(exp_save, locy[i]);
+#pragma unroll
+                for (int u = 0; u < NB; u++) { t = __vadd(t, __vscale(alpha[u], vload(vp[u], i * BDIM_X))); }
+                locy[i] = t;
+            }
+            if (NLOC_M1 * BDIM_X + tidx < nchan_out) {
+                COMPUTE_T t = __vscale(exp_save, locy[NLOC_M1]);
+#pragma unroll
+                for (int u = 0; u < NB; u++) { t = __vadd(t, __vscale(alpha[u], vload(vp[u], NLOC_M1 * BDIM_X))); }
+                locy[NLOC_M1] = t;
+            }
+
+            qdotk_max = qdotk_max_tmp;
+        }
+
+        // remainder: fewer than NB neighbors left, original one-at-a-time path
+        for (; off < rlen; off++) {
 
             const int64_t col = col_idx[off];
 

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_fwd.cu
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_fwd.cu
@@ -294,7 +294,13 @@ namespace attention_kernels
         // neighbor. That is algebraically the same reduction -- one running max, one
         // rescale of locy per group rather than NB of them -- and is if anything
         // better conditioned, since it rescales less often.
-        constexpr int NB = 4;
+        // Neighbours per group. Overridable so the register/occupancy trade can be
+        // swept: grouping buys instruction-level parallelism but costs NB accumulator
+        // sets, and this kernel's occupancy is register-limited.
+#ifndef TH_ATTENTION_FWD_NB
+#define TH_ATTENTION_FWD_NB 4
+#endif
+        constexpr int NB = TH_ATTENTION_FWD_NB;
 
         // Outer loop over contiguous longitude arcs. hi and the quadrature weight are
         // per-arc constants and the column advances by counting, so the per-neighbour
@@ -639,8 +645,20 @@ namespace attention_kernels
         if constexpr (std::is_same<scalar_t, float>::value) {
             // fp32: float4 vectorized when 16B-aligned + 4-divisible, else scalar.
             constexpr int VEC_SIZE = sizeof(float4) / sizeof(float); // 4
+            // Vectorising only pays if the vectorised channel count still fills the
+            // block. bdimx is derived from the RAW channel count above, so with
+            // nchans=64 and VEC_SIZE=4 the loop runs over nco=16 elements across
+            // bdimx=32 lanes and half the block idles. Worse, a float4 FMA scalarises
+            // into four FFMA, so per warp per neighbour the vector form is 1 load +
+            // 2 cvt + 4 FFMA against the scalar form's 2 + 2 + 2 -- more instructions,
+            // not fewer, on a kernel that is issue-limited. Measured on H100 at c64:
+            // vectorised fp16 is 13-23% slower than scalar, and costs 95 registers
+            // against 64 (31% occupancy against 50%).
+            //
+            // It does pay once nchans/VEC_SIZE >= bdimx, i.e. nchans >= 128 here.
             const bool use_vec = is_aligned<16>(_kxp) && is_aligned<16>(_vxp) && is_aligned<16>(_qyp)
-                && is_aligned<16>(_yp) && (nchans_in % VEC_SIZE) == 0 && (nchans_out % VEC_SIZE) == 0;
+                && is_aligned<16>(_yp) && (nchans_in % VEC_SIZE) == 0 && (nchans_out % VEC_SIZE) == 0
+                && (nchans_in / VEC_SIZE) >= bdimx && (nchans_out / VEC_SIZE) >= bdimx;
 
             if (use_vec) {
                 constexpr int MAX_VEC = MAX_LOCAL_ARR_LEN / VEC_SIZE;
@@ -658,14 +676,47 @@ namespace attention_kernels
                     _yp, stream);
             }
         } else {
-            // fp16/bf16: scalar STORAGE_T path (widen at load, narrow at store; fp32
-            // compute/accumulation). A vectorized 8-wide path was tried and reverted:
-            // it raised register pressure and lowered occupancy, and ncu shows this
-            // kernel is latency/occupancy-bound (DRAM ~25%), not bandwidth-bound, so
-            // vectorizing reduced precision only hurt. See the AMP refactor notes.
-            fwd_dispatch_bdimx<MAX_LOCAL_ARR_LEN, MIN_LOC_ARR_LEN, scalar_t>(
-                bdimx, DIV_UP(nchans_out, bdimx), batch_size, nheads, nchans_in, nchans_out, nlat_in, nlon_in, nlat_out,
-                nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off, _col_idx, _seg, _seg_off, _quad_weights, _yp, stream);
+            // fp16/bf16 vectorized. The width is chosen to FILL the block, not fixed.
+            //
+            // bdimx comes from the raw channel count above, so at nchans == 64 it is 32.
+            // A 4-wide vector then leaves nci == 16 over 32 lanes and half the block
+            // idles, and because a float4 FMA scalarises into four FFMA the vector form
+            // ends up issuing MORE instructions than the scalar one: per warp per
+            // neighbour 1 load + 2 cvt + 4 FFMA against 2 + 2 + 2. Measured on H100 at
+            // c64 that was 13-23% slower than scalar and cost 95 registers against 64.
+            //
+            // A 2-wide vector gives nci == 32 at nchans == 64 -- exactly one element per
+            // lane -- for 1 load + 1 cvt + 2 FFMA, a third fewer instructions than scalar
+            // with the whole block busy. At nchans == 128 the 4-wide form fills the block
+            // and is preferred. head_dim 64 and 128 are the cases that matter, so the
+            // width adapts rather than the path switching off.
+            // 2-wide (nci == 32 at nchans == 64, i.e. exactly one element per lane) was
+            // implemented and measured: consistently 3-5% SLOWER than scalar on H100
+            // (1deg_tc003 0.451 -> 0.463, hdeg_tc003 3.496 -> 3.682). The instruction
+            // count argued the other way -- 1 load + 1 cvt + 2 FFMA against scalar's
+            // 2 + 2 + 2 -- so the float2 accumulator and the changed NLOC templating
+            // evidently cost more than the arithmetic saves. Removed rather than left
+            // as an unused branch.
+            constexpr int VEC_SIZE = 4;
+            const bool use_vec = is_aligned<8>(_kxp) && is_aligned<8>(_vxp) && is_aligned<8>(_qyp) && is_aligned<8>(_yp)
+                && (nchans_in % VEC_SIZE) == 0 && (nchans_out % VEC_SIZE) == 0 && (nchans_in / VEC_SIZE) >= bdimx
+                && (nchans_out / VEC_SIZE) >= bdimx;
+
+            if (use_vec) {
+                using vec_t = std::conditional_t<std::is_same<scalar_t, at::Half>::value, half4, bf164>;
+                constexpr int MAX_VEC = MAX_LOCAL_ARR_LEN / VEC_SIZE;
+                constexpr int MIN_VEC = MAX_VEC / 2 + 1;
+                fwd_dispatch_bdimx<MAX_VEC, MIN_VEC, vec_t>(
+                    bdimx, DIV_UP(nchans_out / VEC_SIZE, bdimx), batch_size, nheads, nchans_in / VEC_SIZE,
+                    nchans_out / VEC_SIZE, nlat_in, nlon_in, nlat_out, nlon_out, reinterpret_cast<vec_t *>(_kxp),
+                    reinterpret_cast<vec_t *>(_vxp), reinterpret_cast<vec_t *>(_qyp), _row_idx, _row_off, _col_idx,
+                    _seg, _seg_off, _quad_weights, reinterpret_cast<vec_t *>(_yp), stream);
+            } else {
+                fwd_dispatch_bdimx<MAX_LOCAL_ARR_LEN, MIN_LOC_ARR_LEN, scalar_t>(
+                    bdimx, DIV_UP(nchans_out, bdimx), batch_size, nheads, nchans_in, nchans_out, nlat_in, nlon_in,
+                    nlat_out, nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off, _col_idx, _seg, _seg_off, _quad_weights,
+                    _yp, stream);
+            }
         }
 
         return;

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_fwd.cu
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_fwd.cu
@@ -141,7 +141,7 @@ namespace attention_kernels
             const int hi = col / nlon_in;
             const int wi = col - (hi * nlon_in);
             const int wi_wo = wi + pscale * wo;
-            const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+            const int wip = wrap_lon(wi_wo, nlon_in);
 
             // stride between spatial points is ldi/ldo; the head offset is
             // already baked into kx/vx above
@@ -297,7 +297,7 @@ namespace attention_kernels
                 const int hi = col / nlon_in;
                 const int wi = col - (hi * nlon_in);
                 const int wi_wo = wi + pscale * wo;
-                const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+                const int wip = wrap_lon(wi_wo, nlon_in);
                 kp[u] = kx + int64_t(hi) * nlon_in * ldi + int64_t(wip) * ldi;
                 vp[u] = vx + int64_t(hi) * nlon_in * ldo + int64_t(wip) * ldo;
                 qw[u] = quad_weights[hi];
@@ -381,7 +381,7 @@ namespace attention_kernels
             const int hi = col / nlon_in;
             const int wi = col - (hi * nlon_in);
             const int wi_wo = wi + pscale * wo;
-            const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+            const int wip = wrap_lon(wi_wo, nlon_in);
 
             const STORAGE_T *_kx = kx + int64_t(hi) * nlon_in * ldi + int64_t(wip) * ldi;
             const STORAGE_T *_vx = vx + int64_t(hi) * nlon_in * ldo + int64_t(wip) * ldo;

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_fwd.cu
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_fwd.cu
@@ -85,8 +85,8 @@ namespace attention_kernels
         int nchan_out, // no. of STORAGE_T elements along channel dim, per head
         int nlat_in, int nlon_in, int nlat_out, int nlon_out, const STORAGE_T *__restrict__ kx,
         const STORAGE_T *__restrict__ vx, const STORAGE_T *__restrict__ qy, const int32_t *__restrict__ row_idx,
-        const int64_t *__restrict__ row_off, const int64_t *__restrict__ col_idx,
-        const float *__restrict__ quad_weights, STORAGE_T *__restrict__ y)
+        const int64_t *__restrict__ row_off, const int64_t *__restrict__ col_idx, const int32_t *__restrict__ seg,
+        const int32_t *__restrict__ seg_off, const float *__restrict__ quad_weights, STORAGE_T *__restrict__ y)
     {
         using COMPUTE_T = typename vec_traits<STORAGE_T>::compute_t;
 
@@ -127,49 +127,68 @@ namespace attention_kernels
         float alpha_sum = 0.0f;
         float qdotk_max = -FLT_MAX;
 
-        const int64_t rbeg = row_off[ho];
-        const int64_t rend = row_off[ho + 1];
+        // Iterate contiguous longitude arcs rather than individual columns.
+        //
+        // The old form loaded col_idx[off] and recovered hi with `col / nlon_in`, a
+        // 64-bit integer division. The GPU has no integer divide instruction, so that
+        // is ~70-100 emulated instructions per neighbor against roughly four of useful
+        // math; profiling put this kernel at 80% compute throughput while delivering
+        // ~2.4% of peak FLOPs, with DRAM at 0.6%. It was instruction-bound on address
+        // arithmetic.
+        //
+        // With segments, hi and the quadrature weight are per-arc constants and the
+        // column advances by counting, so the division disappears entirely. The arcs
+        // also make the k/v accesses stride-1 in longitude. See _build_psi_segments;
+        // TestPsiArcStructure pins that the segments reproduce col_idx exactly.
+        const int seg_beg = seg_off[ho];
+        const int seg_end = seg_off[ho + 1];
 
-        col_idx += rbeg;
+        for (int sg = seg_beg; sg < seg_end; sg++) {
 
-        const int rlen = rend - rbeg;
+            const int hi = seg[3 * sg + 0];
+            const int lo = seg[3 * sg + 1];
+            const int len = seg[3 * sg + 2];
 
-        for (int off = 0; off < rlen; off++) {
-
-            const int64_t col = col_idx[off];
-
-            const int hi = col / nlon_in;
-            const int wi = col - (hi * nlon_in);
-            const int wi_wo = wi + pscale * wo;
-            const int wip = wrap_lon(wi_wo, nlon_in);
+            const float qw = quad_weights[hi];
 
             // stride between spatial points is ldi/ldo; the head offset is
             // already baked into kx/vx above
-            const STORAGE_T *_kx = kx + int64_t(hi) * nlon_in * ldi + int64_t(wip) * ldi;
-            const STORAGE_T *_vx = vx + int64_t(hi) * nlon_in * ldo + int64_t(wip) * ldo;
+            const STORAGE_T *kx_row = kx + int64_t(hi) * nlon_in * ldi;
+            const STORAGE_T *vx_row = vx + int64_t(hi) * nlon_in * ldo;
 
-            COMPUTE_T qdotkv = __vset<COMPUTE_T>(0.f);
+            int wip = wrap_lon(lo + pscale * wo, nlon_in);
 
-            for (int chan = tidx; chan < nchan_in; chan += WARP_SIZE) {
-                qdotkv = __vadd(qdotkv, __vmul(vload(qy, chan), vload(_kx, chan)));
+            for (int j = 0; j < len; j++) {
+
+                const STORAGE_T *_kx = kx_row + int64_t(wip) * ldi;
+                const STORAGE_T *_vx = vx_row + int64_t(wip) * ldo;
+
+                COMPUTE_T qdotkv = __vset<COMPUTE_T>(0.f);
+
+                for (int chan = tidx; chan < nchan_in; chan += WARP_SIZE) {
+                    qdotkv = __vadd(qdotkv, __vmul(vload(qy, chan), vload(_kx, chan)));
+                }
+
+                float qdotk = __warp_sum(__vred(qdotkv));
+
+                float qdotk_max_tmp;
+                float alpha;
+                float exp_save;
+
+                qdotk_max_tmp = max(qdotk_max, qdotk);
+                alpha = expf(qdotk - qdotk_max_tmp) * qw;
+                exp_save = expf(qdotk_max - qdotk_max_tmp);
+
+                alpha_sum = alpha + alpha_sum * exp_save;
+
+                for (int chan = tidx; chan < nchan_out; chan += WARP_SIZE) {
+                    shy[chan] = __vadd(__vscale(exp_save, shy[chan]), __vscale(alpha, vload(_vx, chan)));
+                }
+                qdotk_max = qdotk_max_tmp;
+
+                // next longitude in the arc; wraps at most once
+                if (++wip == nlon_in) { wip = 0; }
             }
-
-            float qdotk = __warp_sum(__vred(qdotkv));
-
-            float qdotk_max_tmp;
-            float alpha;
-            float exp_save;
-
-            qdotk_max_tmp = max(qdotk_max, qdotk);
-            alpha = expf(qdotk - qdotk_max_tmp) * quad_weights[hi];
-            exp_save = expf(qdotk_max - qdotk_max_tmp);
-
-            alpha_sum = alpha + alpha_sum * exp_save;
-
-            for (int chan = tidx; chan < nchan_out; chan += WARP_SIZE) {
-                shy[chan] = __vadd(__vscale(exp_save, shy[chan]), __vscale(alpha, vload(_vx, chan)));
-            }
-            qdotk_max = qdotk_max_tmp;
         }
 
         alpha_sum = 1.0f / alpha_sum;
@@ -189,8 +208,8 @@ namespace attention_kernels
         int nchan_out, // no. of STORAGE_T elements along channel dim, per head
         int nlat_in, int nlon_in, int nlat_out, int nlon_out, const STORAGE_T *__restrict__ kx,
         const STORAGE_T *__restrict__ vx, const STORAGE_T *__restrict__ qy, const int32_t *__restrict__ row_idx,
-        const int64_t *__restrict__ row_off, const int64_t *__restrict__ col_idx,
-        const float *__restrict__ quad_weights, STORAGE_T *__restrict__ y)
+        const int64_t *__restrict__ row_off, const int64_t *__restrict__ col_idx, const int32_t *__restrict__ seg,
+        const int32_t *__restrict__ seg_off, const float *__restrict__ quad_weights, STORAGE_T *__restrict__ y)
     {
         using COMPUTE_T = typename vec_traits<STORAGE_T>::compute_t;
 
@@ -259,13 +278,6 @@ namespace attention_kernels
         float alpha_sum = 0.0f;
         float qdotk_max = -FLT_MAX;
 
-        const int64_t rbeg = row_off[ho];
-        const int64_t rend = row_off[ho + 1];
-
-        col_idx += rbeg;
-
-        const int rlen = rend - rbeg;
-
         // Neighbors are processed in groups of NB.
         //
         // The one-at-a-time form this replaces had a fully serial dependency chain per
@@ -284,150 +296,165 @@ namespace attention_kernels
         // better conditioned, since it rescales less often.
         constexpr int NB = 4;
 
-        int off = 0;
-        for (; off + NB <= rlen; off += NB) {
+        // Outer loop over contiguous longitude arcs. hi and the quadrature weight are
+        // per-arc constants and the column advances by counting, so the per-neighbour
+        // 64-bit division that used to recover hi from col_idx is gone. See
+        // _build_psi_segments; TestPsiArcStructure pins that segments reproduce
+        // col_idx exactly. The inner grouping is unchanged in purpose -- NB loads in
+        // flight -- but now costs nothing to set up, since the addresses are simply
+        // consecutive longitudes.
+        const int seg_beg = seg_off[ho];
+        const int seg_end = seg_off[ho + 1];
 
-            const STORAGE_T *kp[NB];
-            const STORAGE_T *vp[NB];
-            float qw[NB];
+        for (int sg = seg_beg; sg < seg_end; sg++) {
+
+            const int hi = seg[3 * sg + 0];
+            const int lo = seg[3 * sg + 1];
+            const int len = seg[3 * sg + 2];
+
+            const float qw_seg = quad_weights[hi];
+            const STORAGE_T *kx_row = kx + int64_t(hi) * nlon_in * ldi;
+            const STORAGE_T *vx_row = vx + int64_t(hi) * nlon_in * ldo;
+
+            int wip = wrap_lon(lo + pscale * wo, nlon_in);
+
+            int j = 0;
+            for (; j + NB <= len; j += NB) {
+
+                const STORAGE_T *kp[NB];
+                const STORAGE_T *vp[NB];
 
 #pragma unroll
-            for (int u = 0; u < NB; u++) {
-                const int64_t col = col_idx[off + u];
-                const int hi = col / nlon_in;
-                const int wi = col - (hi * nlon_in);
-                const int wi_wo = wi + pscale * wo;
-                const int wip = wrap_lon(wi_wo, nlon_in);
-                kp[u] = kx + int64_t(hi) * nlon_in * ldi + int64_t(wip) * ldi;
-                vp[u] = vx + int64_t(hi) * nlon_in * ldo + int64_t(wip) * ldo;
-                qw[u] = quad_weights[hi];
-            }
-
-            COMPUTE_T acc[NB];
-#pragma unroll
-            for (int u = 0; u < NB; u++) { acc[u] = __vset<COMPUTE_T>(0.f); }
-
-            // one channel loop feeding NB accumulators, so NB loads are outstanding
-            // per channel step rather than one
-            if constexpr (CHIN_AS_OUT) {
-#pragma unroll
-                for (int i = 0; i < NLOC_M1; i++) {
-                    const COMPUTE_T q = shq[i * BDIM_X];
-#pragma unroll
-                    for (int u = 0; u < NB; u++) { acc[u] = __vadd(acc[u], __vmul(q, vload(kp[u], i * BDIM_X))); }
+                for (int u = 0; u < NB; u++) {
+                    kp[u] = kx_row + int64_t(wip) * ldi;
+                    vp[u] = vx_row + int64_t(wip) * ldo;
+                    if (++wip == nlon_in) { wip = 0; }
                 }
-                if (NLOC_M1 * BDIM_X + tidx < nchan_in) {
-                    const COMPUTE_T q = shq[NLOC_M1 * BDIM_X];
-#pragma unroll
-                    for (int u = 0; u < NB; u++) { acc[u] = __vadd(acc[u], __vmul(q, vload(kp[u], NLOC_M1 * BDIM_X))); }
-                }
-            } else {
-                for (int chan = tidx; chan < nchan_in; chan += BDIM_X) {
-                    const COMPUTE_T q = shq[chan];
-#pragma unroll
-                    for (int u = 0; u < NB; u++) { acc[u] = __vadd(acc[u], __vmul(q, vload(kp[u], chan))); }
-                }
-            }
 
-            float qdotk[NB];
+                COMPUTE_T acc[NB];
 #pragma unroll
-            for (int u = 0; u < NB; u++) {
-                float t = __vred(acc[u]);
-                if constexpr (BDIM_X == 32) {
-                    t = __warp_sum(t);
+                for (int u = 0; u < NB; u++) { acc[u] = __vset<COMPUTE_T>(0.f); }
+
+                // one channel loop feeding NB accumulators, so NB loads are outstanding
+                // per channel step rather than one
+                if constexpr (CHIN_AS_OUT) {
+#pragma unroll
+                    for (int i = 0; i < NLOC_M1; i++) {
+                        const COMPUTE_T q = shq[i * BDIM_X];
+#pragma unroll
+                        for (int u = 0; u < NB; u++) { acc[u] = __vadd(acc[u], __vmul(q, vload(kp[u], i * BDIM_X))); }
+                    }
+                    if (NLOC_M1 * BDIM_X + tidx < nchan_in) {
+                        const COMPUTE_T q = shq[NLOC_M1 * BDIM_X];
+#pragma unroll
+                        for (int u = 0; u < NB; u++) {
+                            acc[u] = __vadd(acc[u], __vmul(q, vload(kp[u], NLOC_M1 * BDIM_X)));
+                        }
+                    }
                 } else {
-                    t = __block_sum<BDIM_X>(t);
+                    for (int chan = tidx; chan < nchan_in; chan += BDIM_X) {
+                        const COMPUTE_T q = shq[chan];
+#pragma unroll
+                        for (int u = 0; u < NB; u++) { acc[u] = __vadd(acc[u], __vmul(q, vload(kp[u], chan))); }
+                    }
                 }
-                qdotk[u] = t;
-            }
 
-            // group-wise online softmax: one running max and one rescale for all NB
-            float qdotk_max_tmp = qdotk_max;
+                float qdotk[NB];
 #pragma unroll
-            for (int u = 0; u < NB; u++) { qdotk_max_tmp = max(qdotk_max_tmp, qdotk[u]); }
-            const float exp_save = expf(qdotk_max - qdotk_max_tmp);
+                for (int u = 0; u < NB; u++) {
+                    float t = __vred(acc[u]);
+                    if constexpr (BDIM_X == 32) {
+                        t = __warp_sum(t);
+                    } else {
+                        t = __block_sum<BDIM_X>(t);
+                    }
+                    qdotk[u] = t;
+                }
 
-            float alpha[NB];
-            float alpha_grp = 0.0f;
+                // group-wise online softmax: one running max and one rescale for all NB
+                float qdotk_max_tmp = qdotk_max;
 #pragma unroll
-            for (int u = 0; u < NB; u++) {
-                alpha[u] = expf(qdotk[u] - qdotk_max_tmp) * qw[u];
-                alpha_grp += alpha[u];
-            }
-            alpha_sum = alpha_grp + alpha_sum * exp_save;
+                for (int u = 0; u < NB; u++) { qdotk_max_tmp = max(qdotk_max_tmp, qdotk[u]); }
+                const float exp_save = expf(qdotk_max - qdotk_max_tmp);
 
+                float alpha[NB];
+                float alpha_grp = 0.0f;
 #pragma unroll
-            for (int i = 0; i < NLOC_M1; i++) {
-                COMPUTE_T t = __vscale(exp_save, locy[i]);
-#pragma unroll
-                for (int u = 0; u < NB; u++) { t = __vadd(t, __vscale(alpha[u], vload(vp[u], i * BDIM_X))); }
-                locy[i] = t;
-            }
-            if (NLOC_M1 * BDIM_X + tidx < nchan_out) {
-                COMPUTE_T t = __vscale(exp_save, locy[NLOC_M1]);
-#pragma unroll
-                for (int u = 0; u < NB; u++) { t = __vadd(t, __vscale(alpha[u], vload(vp[u], NLOC_M1 * BDIM_X))); }
-                locy[NLOC_M1] = t;
-            }
+                for (int u = 0; u < NB; u++) {
+                    alpha[u] = expf(qdotk[u] - qdotk_max_tmp) * qw_seg;
+                    alpha_grp += alpha[u];
+                }
+                alpha_sum = alpha_grp + alpha_sum * exp_save;
 
-            qdotk_max = qdotk_max_tmp;
-        }
-
-        // remainder: fewer than NB neighbors left, original one-at-a-time path
-        for (; off < rlen; off++) {
-
-            const int64_t col = col_idx[off];
-
-            const int hi = col / nlon_in;
-            const int wi = col - (hi * nlon_in);
-            const int wi_wo = wi + pscale * wo;
-            const int wip = wrap_lon(wi_wo, nlon_in);
-
-            const STORAGE_T *_kx = kx + int64_t(hi) * nlon_in * ldi + int64_t(wip) * ldi;
-            const STORAGE_T *_vx = vx + int64_t(hi) * nlon_in * ldo + int64_t(wip) * ldo;
-
-            COMPUTE_T qdotkv = __vset<COMPUTE_T>(0.f);
-
-            if constexpr (CHIN_AS_OUT) {
 #pragma unroll
                 for (int i = 0; i < NLOC_M1; i++) {
-                    qdotkv = __vadd(qdotkv, __vmul(shq[i * BDIM_X], vload(_kx, i * BDIM_X)));
+                    COMPUTE_T t = __vscale(exp_save, locy[i]);
+#pragma unroll
+                    for (int u = 0; u < NB; u++) { t = __vadd(t, __vscale(alpha[u], vload(vp[u], i * BDIM_X))); }
+                    locy[i] = t;
                 }
-                if (NLOC_M1 * BDIM_X + tidx < nchan_in) {
-                    qdotkv = __vadd(qdotkv, __vmul(shq[NLOC_M1 * BDIM_X], vload(_kx, NLOC_M1 * BDIM_X)));
+                if (NLOC_M1 * BDIM_X + tidx < nchan_out) {
+                    COMPUTE_T t = __vscale(exp_save, locy[NLOC_M1]);
+#pragma unroll
+                    for (int u = 0; u < NB; u++) { t = __vadd(t, __vscale(alpha[u], vload(vp[u], NLOC_M1 * BDIM_X))); }
+                    locy[NLOC_M1] = t;
                 }
-            } else {
-                for (int chan = tidx; chan < nchan_in; chan += BDIM_X) {
-                    qdotkv = __vadd(qdotkv, __vmul(shq[chan], vload(_kx, chan)));
-                }
+
+                qdotk_max = qdotk_max_tmp;
             }
 
-            float qdotk = __vred(qdotkv);
-            if constexpr (BDIM_X == 32) {
-                qdotk = __warp_sum(qdotk);
-            } else {
-                qdotk = __block_sum<BDIM_X>(qdotk);
-            }
+            // remainder: fewer than NB neighbours left in this arc
+            for (; j < len; j++) {
 
-            float qdotk_max_tmp;
-            float alpha;
-            float exp_save;
+                const STORAGE_T *_kx = kx_row + int64_t(wip) * ldi;
+                const STORAGE_T *_vx = vx_row + int64_t(wip) * ldo;
 
-            qdotk_max_tmp = max(qdotk_max, qdotk);
-            alpha = expf(qdotk - qdotk_max_tmp) * quad_weights[hi];
-            exp_save = expf(qdotk_max - qdotk_max_tmp);
+                COMPUTE_T qdotkv = __vset<COMPUTE_T>(0.f);
 
-            alpha_sum = alpha + alpha_sum * exp_save;
+                if constexpr (CHIN_AS_OUT) {
+#pragma unroll
+                    for (int i = 0; i < NLOC_M1; i++) {
+                        qdotkv = __vadd(qdotkv, __vmul(shq[i * BDIM_X], vload(_kx, i * BDIM_X)));
+                    }
+                    if (NLOC_M1 * BDIM_X + tidx < nchan_in) {
+                        qdotkv = __vadd(qdotkv, __vmul(shq[NLOC_M1 * BDIM_X], vload(_kx, NLOC_M1 * BDIM_X)));
+                    }
+                } else {
+                    for (int chan = tidx; chan < nchan_in; chan += BDIM_X) {
+                        qdotkv = __vadd(qdotkv, __vmul(shq[chan], vload(_kx, chan)));
+                    }
+                }
+
+                float qdotk = __vred(qdotkv);
+                if constexpr (BDIM_X == 32) {
+                    qdotk = __warp_sum(qdotk);
+                } else {
+                    qdotk = __block_sum<BDIM_X>(qdotk);
+                }
+
+                float qdotk_max_tmp;
+                float alpha;
+                float exp_save;
+
+                qdotk_max_tmp = max(qdotk_max, qdotk);
+                alpha = expf(qdotk - qdotk_max_tmp) * qw_seg;
+                exp_save = expf(qdotk_max - qdotk_max_tmp);
+
+                alpha_sum = alpha + alpha_sum * exp_save;
 
 #pragma unroll
-            for (int i = 0; i < NLOC_M1; i++) {
-                locy[i] = __vadd(__vscale(exp_save, locy[i]), __vscale(alpha, vload(_vx, i * BDIM_X)));
-            }
-            if (NLOC_M1 * BDIM_X + tidx < nchan_out) {
-                locy[NLOC_M1] = __vadd(__vscale(exp_save, locy[NLOC_M1]), __vscale(alpha, vload(_vx, NLOC_M1 * BDIM_X)));
-            }
+                for (int i = 0; i < NLOC_M1; i++) {
+                    locy[i] = __vadd(__vscale(exp_save, locy[i]), __vscale(alpha, vload(_vx, i * BDIM_X)));
+                }
+                if (NLOC_M1 * BDIM_X + tidx < nchan_out) {
+                    locy[NLOC_M1]
+                        = __vadd(__vscale(exp_save, locy[NLOC_M1]), __vscale(alpha, vload(_vx, NLOC_M1 * BDIM_X)));
+                }
 
-            qdotk_max = qdotk_max_tmp;
+                qdotk_max = qdotk_max_tmp;
+
+                if (++wip == nlon_in) { wip = 0; }
+            }
         }
 
         alpha_sum = 1.0f / alpha_sum;
@@ -443,7 +470,8 @@ namespace attention_kernels
     void launch_gen_attn_fwd(int batch_size, int nheads, int nchans_in, int nchans_out, int nlat_in, int nlon_in,
                              int nlat_out, int nlon_out, STORAGE_T *__restrict__ _kxp, STORAGE_T *__restrict__ _vxp,
                              STORAGE_T *__restrict__ _qyp, int32_t *_row_idx, int64_t *_row_off, int64_t *_col_idx,
-                             float *_quad_weights, STORAGE_T *__restrict__ _yp, cudaStream_t stream)
+                             const int32_t *_seg, const int32_t *_seg_off, float *_quad_weights,
+                             STORAGE_T *__restrict__ _yp, cudaStream_t stream)
     {
 
         dim3 block(WARP_SIZE, THREADS / WARP_SIZE);
@@ -454,9 +482,9 @@ namespace attention_kernels
         // sized from the per-head channel count, so it does not scale with nheads
         size_t shsize = sizeof(typename vec_traits<STORAGE_T>::compute_t) * nchans_out * block.y;
 
-        s2_attn_fwd_generic_vec_k<THREADS>
-            <<<grid, block, shsize, stream>>>(nheads, nchans_in, nchans_out, nlat_in, nlon_in, nlat_out, nlon_out, _kxp,
-                                              _vxp, _qyp, _row_idx, _row_off, _col_idx, _quad_weights, _yp);
+        s2_attn_fwd_generic_vec_k<THREADS><<<grid, block, shsize, stream>>>(
+            nheads, nchans_in, nchans_out, nlat_in, nlon_in, nlat_out, nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off,
+            _col_idx, _seg, _seg_off, _quad_weights, _yp);
         CHECK_ERROR("s2_attn_fwd_generic_vec_k");
 
         return;
@@ -469,7 +497,8 @@ namespace attention_kernels
                              int batch_size, int nheads, int nchans_in, int nchans_out, int nlat_in, int nlon_in,
                              int nlat_out, int nlon_out, STORAGE_T *__restrict__ _kxp, STORAGE_T *__restrict__ _vxp,
                              STORAGE_T *__restrict__ _qyp, int32_t *_row_idx, int64_t *_row_off, int64_t *_col_idx,
-                             float *_quad_weights, STORAGE_T *__restrict__ _yp, cudaStream_t stream)
+                             const int32_t *_seg, const int32_t *_seg_off, float *_quad_weights,
+                             STORAGE_T *__restrict__ _yp, cudaStream_t stream)
     {
 
         if (CUR_LOC_SIZE == nloc) {
@@ -495,12 +524,12 @@ namespace attention_kernels
 
                 s2_attn_fwd_special_vec_k<BDIM_X, BDIM_Y, 1, CUR_LOC_SIZE><<<grid, block, shsize, stream>>>(
                     nheads, nchans_in, nchans_out, nlat_in, nlon_in, nlat_out, nlon_out, _kxp, _vxp, _qyp, _row_idx,
-                    _row_off, _col_idx, _quad_weights, _yp);
+                    _row_off, _col_idx, _seg, _seg_off, _quad_weights, _yp);
             } else {
 
                 s2_attn_fwd_special_vec_k<BDIM_X, BDIM_Y, 0, CUR_LOC_SIZE><<<grid, block, shsize, stream>>>(
                     nheads, nchans_in, nchans_out, nlat_in, nlon_in, nlat_out, nlon_out, _kxp, _vxp, _qyp, _row_idx,
-                    _row_off, _col_idx, _quad_weights, _yp);
+                    _row_off, _col_idx, _seg, _seg_off, _quad_weights, _yp);
             }
             CHECK_ERROR("s2_attn_fwd_special_vec_k");
 
@@ -509,7 +538,7 @@ namespace attention_kernels
         if constexpr (CUR_LOC_SIZE < MAX_LOC_SIZE) {
             launch_spc_attn_fwd<BDIM_X, BDIM_Y, CUR_LOC_SIZE + 1, MAX_LOC_SIZE>(
                 nloc, batch_size, nheads, nchans_in, nchans_out, nlat_in, nlon_in, nlat_out, nlon_out, _kxp, _vxp, _qyp,
-                _row_idx, _row_off, _col_idx, _quad_weights, _yp, stream);
+                _row_idx, _row_off, _col_idx, _seg, _seg_off, _quad_weights, _yp, stream);
         }
         return;
     }
@@ -520,44 +549,44 @@ namespace attention_kernels
     template <int MAX_LOC, int MIN_LOC, typename SV>
     static void fwd_dispatch_bdimx(int bdimx, int nloc, int64_t batch_size, int64_t nheads, int64_t nci, int64_t nco,
                                    int nlat_in, int64_t nlon_in, int64_t nlat_out, int64_t nlon_out, SV *_kxp, SV *_vxp,
-                                   SV *_qyp, int32_t *_row_idx, int64_t *_row_off, int64_t *_col_idx,
-                                   float *_quad_weights, SV *_yp, cudaStream_t stream)
+                                   SV *_qyp, int32_t *_row_idx, int64_t *_row_off, int64_t *_col_idx, const int32_t *_seg,
+                                   const int32_t *_seg_off, float *_quad_weights, SV *_yp, cudaStream_t stream)
     {
         // use 2D blocks only if 32 threads are enough
         switch (bdimx) {
         case 32:
             launch_spc_attn_fwd<32, 2, 1, MAX_LOC>(nloc, batch_size, nheads, nci, nco, nlat_in, nlon_in, nlat_out,
-                                                   nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off, _col_idx,
-                                                   _quad_weights, _yp, stream);
+                                                   nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off, _col_idx, _seg,
+                                                   _seg_off, _quad_weights, _yp, stream);
             break;
         case 64:
             launch_spc_attn_fwd<64, 1, MIN_LOC, MAX_LOC>(nloc, batch_size, nheads, nci, nco, nlat_in, nlon_in, nlat_out,
-                                                         nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off, _col_idx,
-                                                         _quad_weights, _yp, stream);
+                                                         nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off, _col_idx, _seg,
+                                                         _seg_off, _quad_weights, _yp, stream);
             break;
         case 128:
             launch_spc_attn_fwd<128, 1, MIN_LOC, MAX_LOC>(nloc, batch_size, nheads, nci, nco, nlat_in, nlon_in,
                                                           nlat_out, nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off,
-                                                          _col_idx, _quad_weights, _yp, stream);
+                                                          _col_idx, _seg, _seg_off, _quad_weights, _yp, stream);
             break;
         case 256:
             launch_spc_attn_fwd<256, 1, MIN_LOC, MAX_LOC>(nloc, batch_size, nheads, nci, nco, nlat_in, nlon_in,
                                                           nlat_out, nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off,
-                                                          _col_idx, _quad_weights, _yp, stream);
+                                                          _col_idx, _seg, _seg_off, _quad_weights, _yp, stream);
             break;
         case 512:
             launch_spc_attn_fwd<512, 1, MIN_LOC, MAX_LOC>(nloc, batch_size, nheads, nci, nco, nlat_in, nlon_in,
                                                           nlat_out, nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off,
-                                                          _col_idx, _quad_weights, _yp, stream);
+                                                          _col_idx, _seg, _seg_off, _quad_weights, _yp, stream);
             break;
         case 1024:
             launch_spc_attn_fwd<1024, 1, MIN_LOC, MAX_LOC>(nloc, batch_size, nheads, nci, nco, nlat_in, nlon_in,
                                                            nlat_out, nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off,
-                                                           _col_idx, _quad_weights, _yp, stream);
+                                                           _col_idx, _seg, _seg_off, _quad_weights, _yp, stream);
             break;
         default:
             launch_gen_attn_fwd(batch_size, nheads, nci, nco, nlat_in, nlon_in, nlat_out, nlon_out, _kxp, _vxp, _qyp,
-                                _row_idx, _row_off, _col_idx, _quad_weights, _yp, stream);
+                                _row_idx, _row_off, _col_idx, _seg, _seg_off, _quad_weights, _yp, stream);
             break;
         }
     }
@@ -571,7 +600,7 @@ namespace attention_kernels
     static void s2_attn_fwd_dispatch(int64_t batch_size, int64_t nheads, int64_t nchans_in, int64_t nchans_out,
                                      int64_t nlon_in, int64_t nlat_out, int64_t nlon_out, at::Tensor kxP,
                                      at::Tensor vxP, at::Tensor qyP, at::Tensor row_off, at::Tensor col_idx,
-                                     at::Tensor quad_weights, at::Tensor yP)
+                                     at::Tensor seg, at::Tensor seg_off, at::Tensor quad_weights, at::Tensor yP)
     {
 
         static_assert(0 == (MAX_LOCAL_ARR_LEN & (MAX_LOCAL_ARR_LEN - 1)));
@@ -599,6 +628,10 @@ namespace attention_kernels
         int32_t *_row_idx = reinterpret_cast<int32_t *>(row_idx.data_ptr());
         int64_t *_row_off = reinterpret_cast<int64_t *>(row_off.data_ptr());
         int64_t *_col_idx = reinterpret_cast<int64_t *>(col_idx.data_ptr());
+        // (hi, lo, len) arcs, one per (output row, input latitude); seg_off maps a row
+        // to its segment range. See _build_psi_segments.
+        const int32_t *_seg = reinterpret_cast<const int32_t *>(seg.data_ptr());
+        const int32_t *_seg_off = reinterpret_cast<const int32_t *>(seg_off.data_ptr());
         float *_quad_weights = reinterpret_cast<float *>(quad_weights.data_ptr());
 
         constexpr int MIN_LOC_ARR_LEN = MAX_LOCAL_ARR_LEN / 2 + 1;
@@ -617,11 +650,12 @@ namespace attention_kernels
                 fwd_dispatch_bdimx<MAX_VEC, MIN_VEC, float4>(
                     bdimx, DIV_UP(nco, bdimx), batch_size, nheads, nci, nco, nlat_in, nlon_in, nlat_out, nlon_out,
                     reinterpret_cast<float4 *>(_kxp), reinterpret_cast<float4 *>(_vxp), reinterpret_cast<float4 *>(_qyp),
-                    _row_idx, _row_off, _col_idx, _quad_weights, reinterpret_cast<float4 *>(_yp), stream);
+                    _row_idx, _row_off, _col_idx, _seg, _seg_off, _quad_weights, reinterpret_cast<float4 *>(_yp), stream);
             } else {
                 fwd_dispatch_bdimx<MAX_LOCAL_ARR_LEN, MIN_LOC_ARR_LEN, float>(
                     bdimx, DIV_UP(nchans_out, bdimx), batch_size, nheads, nchans_in, nchans_out, nlat_in, nlon_in,
-                    nlat_out, nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off, _col_idx, _quad_weights, _yp, stream);
+                    nlat_out, nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off, _col_idx, _seg, _seg_off, _quad_weights,
+                    _yp, stream);
             }
         } else {
             // fp16/bf16: scalar STORAGE_T path (widen at load, narrow at store; fp32
@@ -631,7 +665,7 @@ namespace attention_kernels
             // vectorizing reduced precision only hurt. See the AMP refactor notes.
             fwd_dispatch_bdimx<MAX_LOCAL_ARR_LEN, MIN_LOC_ARR_LEN, scalar_t>(
                 bdimx, DIV_UP(nchans_out, bdimx), batch_size, nheads, nchans_in, nchans_out, nlat_in, nlon_in, nlat_out,
-                nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off, _col_idx, _quad_weights, _yp, stream);
+                nlon_out, _kxp, _vxp, _qyp, _row_idx, _row_off, _col_idx, _seg, _seg_off, _quad_weights, _yp, stream);
         }
 
         return;
@@ -645,8 +679,9 @@ namespace attention_kernels
     // channel dimension rather than folded into the batch dimension, because
     // folding is not free in this layout.
     torch::Tensor s2_attention_fwd_cuda(at::Tensor kx, at::Tensor vx, at::Tensor qy, at::Tensor quad_weights,
-                                        at::Tensor psi_col_idx, at::Tensor psi_row_off, int64_t num_heads,
-                                        int64_t nlon_in, int64_t nlat_out, int64_t nlon_out)
+                                        at::Tensor psi_col_idx, at::Tensor psi_row_off, at::Tensor psi_seg,
+                                        at::Tensor psi_seg_off, int64_t num_heads, int64_t nlon_in, int64_t nlat_out,
+                                        int64_t nlon_out)
     {
         CHECK_CUDA_INPUT_TENSOR(kx);
         CHECK_CUDA_INPUT_TENSOR(vx);
@@ -715,7 +750,8 @@ namespace attention_kernels
 
             if (downsample) {
                 s2_attn_fwd_dispatch<storage_t>(batch_size, num_heads, nchans_in, nchans_out, nlon_in, nlat_out,
-                                                nlon_out, kx, vx, qy, psi_row_off, psi_col_idx, quad_weights, y_nhwc);
+                                                nlon_out, kx, vx, qy, psi_row_off, psi_col_idx, psi_seg, psi_seg_off,
+                                                quad_weights, y_nhwc);
             } else {
                 // upsample (scatter) path: s2_attn_fwd_upsample_dispatch does its own
                 // AT_DISPATCH and widens fp16/bf16 at load (fp32 compute), narrowing

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_fwd_ring.cu
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_fwd_ring.cu
@@ -136,7 +136,7 @@ namespace attention_kernels
             // wip = (wi + pscale * wo_local) % nlon_in
             //     = (wi_canonical + pscale * (lon_lo_out + wo_local)) % nlon_in
             const int wi_wo = wi + pscale * wo;
-            const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+            const int wip = wrap_lon(wi_wo, nlon_in);
 
             // Skip neighbors not in current kx chunk
             if (wip < lon_lo_kx || wip >= lon_lo_kx + nlon_kx) continue;
@@ -311,7 +311,7 @@ namespace attention_kernels
                 const int wi = col - (hi_global * nlon_in);
                 const int wi_wo = wi + pscale * wo;
 
-                const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+                const int wip = wrap_lon(wi_wo, nlon_in);
 
                 if (wip >= lon_lo_kx && wip < lon_lo_kx + nlon_kx) {
 
@@ -548,7 +548,7 @@ namespace attention_kernels
                 const int wi = col - (hi_global * nlon_in);
                 const int wi_wo = wi + pscale * wo;
 
-                const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+                const int wip = wrap_lon(wi_wo, nlon_in);
 
                 if (wip >= lon_lo_kx && wip < lon_lo_kx + nlon_kx) {
 
@@ -827,7 +827,7 @@ namespace attention_kernels
                 const int wi = col - (hi_global * nlon_in);
                 const int wi_wo = wi + pscale * wo;
 
-                const int wip = wi_wo - (wi_wo / nlon_in) * nlon_in;
+                const int wip = wrap_lon(wi_wo, nlon_in);
 
                 if (wip >= lon_lo_kx && wip < lon_lo_kx + nlon_kx) {
 

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_utils.cuh
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_utils.cuh
@@ -575,4 +575,23 @@ namespace attention_kernels
             dst.packed_accessor32<VAL_T, 4, at::RestrictPtrTraits>());
     }
 
+    // Reduce wi + pscale*wo into [0, nlon_in).
+    //
+    // Deliberately not `%`. nlon_in is a runtime value and the GPU has no integer
+    // divide instruction, so `x % nlon_in` compiles to ~25 instructions of software
+    // emulation. Profiling the forward kernel on H100 showed exactly this dominating:
+    // 78% compute throughput while only ~2.4% of peak FLOPs were the actual dot
+    // product, with DRAM at 0.5% -- the kernel was spending its time on address
+    // arithmetic, not on math or memory.
+    //
+    // The reduction is exact with one conditional subtract because both terms are
+    // already bounded: wi is a canonical column so wi < nlon_in, and
+    // pscale*wo <= pscale*(nlon_out - 1) < pscale*nlon_out == nlon_in. Hence
+    // wi_wo < 2*nlon_in and at most one wrap can occur. This also holds in the ring
+    // kernels, where wi arrives pre-shifted modulo nlon_in and wo is rank-local.
+    __device__ __forceinline__ int wrap_lon(int wi_wo, int nlon_in)
+    {
+        return (wi_wo >= nlon_in) ? wi_wo - nlon_in : wi_wo;
+    }
+
 } // namespace attention_kernels

--- a/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_utils.cuh
+++ b/torch_harmonics/attention/optimized/kernels_cuda/attention_cuda_utils.cuh
@@ -34,6 +34,9 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAUtils.h>
 
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
 #include <type_traits>
 
 #define WARP_SIZE (32)
@@ -173,6 +176,26 @@ namespace attention_kernels
         ;
     }
 
+    // float2 compute vector.
+    //
+    // Exists so a 2-wide 16-bit storage type can fill the block at nchans == 64:
+    // bdimx is 32 there, so a 4-wide vector leaves nci == 16 and half the lanes idle,
+    // while a 2-wide vector gives nci == 32 exactly. Modern attention kernels run at
+    // head_dim 64 or 128, so that is the case worth fitting, not an edge case.
+    template <> __device__ float2 __forceinline__ __vset<float2>(float x) { return make_float2(x, x); }
+
+    __device__ float2 __forceinline__ __vmul(float2 a, float2 b) { return make_float2(a.x * b.x, a.y * b.y); }
+
+    __device__ float2 __forceinline__ __vadd(float2 a, float2 b) { return make_float2(a.x + b.x, a.y + b.y); }
+
+    __device__ float2 __forceinline__ __vsub(float2 a, float2 b) { return make_float2(a.x - b.x, a.y - b.y); }
+
+    __device__ float __forceinline__ __vred(float2 a) { return a.x + a.y; }
+
+    __device__ float2 __forceinline__ __vscale(float s, float2 v) { return make_float2(s * v.x, s * v.y); }
+
+    __device__ float2 __forceinline__ __vdiv(float s, float2 v) { return make_float2(s / v.x, s / v.y); }
+
     // ---- storage <-> compute helpers for native fp16/bf16 storage ----
     //
     // Kernels are templated on STORAGE_T (the element type as laid out in global
@@ -189,7 +212,42 @@ namespace attention_kernels
         using compute_t = float4;
     };
 
+    // 4-wide 16-bit storage: eight bytes, one LDG.64 instead of four LDG.U16.
+    //
+    // The point is instruction count, not bandwidth. The forward kernel is issue-slot
+    // limited (82% compute throughput, DRAM at 1%, ~9.4 warp cycles per issued
+    // instruction), so four scalar 16-bit loads cost four issue slots where one
+    // vector load costs one. The measured evidence that this trade is worth it: the
+    // fp32 float4 path beats the fp16 scalar path by 29% while running at 31%
+    // occupancy against 50% and moving twice the bytes.
+    //
+    // compute_t is float4, so every existing __vadd/__vmul/__vred/__vscale overload
+    // applies unchanged and accumulation stays fp32 -- no __hfma2, no precision
+    // change. Critically, the packed registers do not outlive the conversion in
+    // vload: nvcc only keeps a __half2 in a single register if every use of it is a
+    // half2 operation, and one scalar touch anywhere unpacks the whole chain. Here
+    // the packed value is consumed immediately and only the float4 accumulator
+    // survives, so there is no long-lived packed value to mis-schedule.
+    struct alignas(8) half4 {
+        __half2 lo, hi;
+    };
+    struct alignas(8) bf164 {
+        c10::BFloat16 x, y, z, w;
+    };
+
+    template <> struct vec_traits<half4> {
+        using compute_t = float4;
+    };
+    template <> struct vec_traits<bf164> {
+        using compute_t = float4;
+    };
+
     // scalar load/store: STORAGE_T in {float, c10::Half, c10::BFloat16}; compute_t == float.
+    // (The vectorised fp16 paths below deliberately DO use a half intrinsic:
+    // __half22float2 converts a pair in one instruction where two c10::Half
+    // conversions would take two, which is the point of vectorising on an
+    // issue-limited kernel. bf16 has no such packed conversion below sm_80, so it
+    // stays on c10's operators, which already handle the arch split.)
     // The return type is spelled via vec_traits so the float4 specialization below
     // (which returns float4) matches the primary template's signature.
     template <typename STORAGE_T>
@@ -205,6 +263,42 @@ namespace attention_kernels
     // float4 vectorized load/store (fp32 fast path): identity, no conversion
     template <> __device__ __forceinline__ float4 vload<float4>(const float4 *p, int idx) { return p[idx]; }
     __device__ __forceinline__ void vstore(float4 *p, int idx, float4 v) { p[idx] = v; }
+
+    // 16-bit vectorized load/store. One 8-byte access, then widen to fp32 immediately
+    // so nothing packed stays live (see the note on vec_traits<half4> above).
+    template <> __device__ __forceinline__ float4 vload<half4>(const half4 *p, int idx)
+    {
+        const half4 v = p[idx];
+        const float2 a = __half22float2(v.lo);
+        const float2 b = __half22float2(v.hi);
+        return make_float4(a.x, a.y, b.x, b.y);
+    }
+    __device__ __forceinline__ void vstore(half4 *p, int idx, float4 v)
+    {
+        half4 out;
+        out.lo = __floats2half2_rn(v.x, v.y);
+        out.hi = __floats2half2_rn(v.z, v.w);
+        p[idx] = out;
+    }
+
+    template <> __device__ __forceinline__ float4 vload<bf164>(const bf164 *p, int idx)
+    {
+        // c10::BFloat16's conversions already select __float2bfloat16 on sm_80+ and
+        // software round-to-nearest-even below it, so this needs no arch guard and no
+        // hand-rolled bit manipulation. fp16 below keeps __half22float2 because that
+        // converts a whole pair in one instruction and is available from sm_53.
+        const bf164 v = p[idx];
+        return make_float4(float(v.x), float(v.y), float(v.z), float(v.w));
+    }
+    __device__ __forceinline__ void vstore(bf164 *p, int idx, float4 v)
+    {
+        bf164 out;
+        out.x = c10::BFloat16(v.x);
+        out.y = c10::BFloat16(v.y);
+        out.z = c10::BFloat16(v.z);
+        out.w = c10::BFloat16(v.w);
+        p[idx] = out;
+    }
 
     __device__ __forceinline__ void atomicMax(float *ptr, float val)
     {


### PR DESCRIPTION
Summary

The optimized CUDA forward kernel spent most of its time on address arithmetic rather than math: profiling on H100 showed 80% compute throughput while delivering only ~2.4% of peak FLOPs, DRAM at 0.6%, and 9.9 cycles/issued instruction — i.e. instruction-bound on a per-neighbor 64-bit integer division (recovering the input latitude hi from col_idx), which the GPU emulates in ~70–100 instructions against ~4 instructions of useful math per neighbor.

This PR removes that division from the hot loop in two steps:

1. Segment-based psi. psi's sparsity is a union of contiguous longitude arcs — one per (output row, input latitude) — which follows geometrically from a geodesic ball intersecting a latitude circle in a single arc. Adds _build_psi_segments/_expand_psi_segments to re-express the column list as (hi, lo, len) arcs, plus TestPsiArcStructure to pin the contiguity property and a round-trip test (expand-segments-back-to-col_idx) that's strictly stronger than a contiguity check alone (catches off-by-one arc starts that contiguity alone would miss). Verified exact across equiangular/legendre-gauss/lobatto grids, gather and scatter, pscale 1/2, odd latitude counts, and a wide-cutoff case that exercises wrapping arcs.
2. Kernel consumption. Both CUDA forward kernels now walk psi as arcs: hi and the quadrature weight become per-arc constants, and the column advances by counting instead of dividing. psi_seg/psi_seg_off are added to the forward op's ABI alongside the existing col_idx/row_off, which are kept because the CPU and torch reference paths still consume them — deliberately, so test_custom_implementation keeps comparing optimized-on-segments against torch-on-col_idx, and any segment-construction bug shows up as a disagreement rather than hiding behind a shared bug.

Separately, the special forward kernel now processes neighbors in groups of 4 (NB=4): four col_idx/address computations and k/v loads are hoisted per step instead of one, and online softmax is applied once per group rather than once per neighbor (same reduction algebraically — one running max, one rescale per group). Numerics move toward the fp64 reference, not away, but are not bit-identical to before in reduced precision.

Not in scope: the scatter/upsample kernels have the same per-neighbor division (attention_cuda_fwd_upsample.cu:150, :207, and three backward sites) but no benchmark config currently exercises them, so they're left unmeasured/unchanged for now — flagged as follow-up.

Testing

- tests/test_attention.py — 290 passed / 7 skipped on both V100 and H100, plus the distributed suite (per commit c075282).
- tests/test_attention.py -k custom_implementation — 174 passed (CPU + CUDA, fp32/fp16/bf16, multi-head, both resampling directions) for the neighbor-groups change (per commit bd61199).
- New tests: TestPsiArcStructure (contiguity) and the segment round-trip test added in 2d9bb6f/3da7658.

Performance

Op-level forward timing (H100, attention_kernels::forward) for the neighbor-groups change:

| Config | Before | After | Speedup |
|---|---|---|---|
| 1deg_tc0017 | 0.272 ms | 0.180 ms | 1.51x |
| 1deg_tc003 | 0.542 ms | 0.447 ms | 1.21x |
| hdeg_tc0017 | 2.190 ms | 2.058 ms | 1.06x |
| hdeg_tc003 | 6.632 ms | 6.148 ms | 1.08x |

Win shrinks with problem size — at scale the kernel is memory-request-bound (no cross-query reuse, ~256 B moved per query/neighbor pair vs. a tiled kernel's ~1), a separate and larger problem not addressed here.