### PR TITLE
Register AutocastCPU for the attention and DISCO custom ops

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 * Added fused distributed DISCO convolution variant which reduces activation storage.
 * Adding WGMMA (tensor core) support to DISCO forward kernels on H100 (SM90) architectures. The kernel will be selected automatically if shapes allow, no specific action from the user is required.
 * Improved performance for CPU based attention kernels.
+* Fixed autocast on CPU for attention and DISCO: the custom ops registered an autocast kernel only at the `AutocastCUDA` dispatch key, so under `torch.autocast("cpu", ...)` nothing reconciled the inputs. For attention this could hand the kernel an fp32 query alongside fp16/bf16 keys and values, tripping the kernel's dtype check (`v dtype (Half) must match q dtype (Float)`); for DISCO it silently meant CPU autocast had no effect at all. Both now register `AutocastCPU` alongside `AutocastCUDA`. Whether the mismatch surfaced depended on the PyTorch version, so it was invisible on newer builds.
 * Fixed stride problems in SHT under torch.compile on CPU.
 * Converted all Python assert statements to torch._check for better torch.compile friendliness. All asserts in cosntructors were converted into ValueErrors for streamlined and clear error handling. In C++ and CUDA compiled code, all dynamic asserts were changed to TORCH_CHECK calls.
 * Improved performance of distributed attention kernels achieved by splitting the kernel into two different ones for dense and less dense rows. This happens behind the scenes and the distributed attention API is unchanged.

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -342,6 +342,53 @@ class TestNeighborhoodAttentionS2(unittest.TestCase):
             f"Attention output dtype {out.dtype} != autocast dtype {autocast_dtype}",
         )
 
+    @parameterized.expand([[torch.float16], [torch.bfloat16]], skip_on_empty=True)
+    @unittest.skipUnless(optimized_kernels_is_available(), "skipping test because optimized kernels are not available")
+    def test_autocast_normalizes_mixed_input_dtypes(self, autocast_dtype):
+        """Autocast must reconcile k/v/q dtypes before they reach the kernel.
+
+        The kernels dispatch once on q's scalar type and then reinterpret every
+        activation pointer as that type, so they require k, v and q to share a dtype
+        and check it explicitly. Autocast does not guarantee that by itself: it casts
+        some ops and not others, so a module that mixes projections with normalization
+        can hand the op an fp32 q next to an fp16 v. The Autocast{CUDA,CPU} registrations
+        are what make the requirement hold.
+
+        This is a direct op-level test rather than a module-level one because at module
+        level the mismatch only appears on some torch versions -- it was found on
+        torch 2.6 (CPU) while newer builds happened to produce consistent dtypes and
+        passed. Constructing the mismatch here makes the regression detectable
+        everywhere. The negative control is implicit: without autocast active the same
+        inputs raise "must match q dtype".
+        """
+        if (self.device.type == "cuda") and (not cuda_kernels_is_available()):
+            raise unittest.SkipTest("skipping test because CUDA kernels are not available")
+
+        set_seed(333)
+        nlat, nlon, channels = 6, 12, 4
+
+        model = NeighborhoodAttentionS2(
+            in_channels=channels,
+            num_heads=1,
+            in_shape=(nlat, nlon),
+            out_shape=(nlat, nlon),
+            grid_in="equiangular",
+            grid_out="equiangular",
+            bias=False,
+            optimized_kernel=True,
+        ).to(self.device)
+
+        # NHWC, as the op expects. q is deliberately left fp32 while k/v are reduced
+        # precision -- the exact shape of the failure observed on torch 2.6.
+        kw = torch.randn(2, nlat, nlon, channels, device=self.device, dtype=autocast_dtype)
+        vw = torch.randn(2, nlat, nlon, channels, device=self.device, dtype=autocast_dtype)
+        qw = torch.randn(2, nlat, nlon, channels, device=self.device, dtype=torch.float32)
+
+        with torch.autocast(self.device.type, dtype=autocast_dtype):
+            out = torch.ops.attention_kernels._neighborhood_s2_attention_optimized(kw, vw, qw, model.quad_weights, model.psi_col_idx, model.psi_roff_idx, 1, nlon, nlat, nlon)
+
+        self.assertEqual(out.dtype, autocast_dtype, f"autocast output dtype {out.dtype} != {autocast_dtype}")
+
     @parameterized.expand(
         [
             # Format: [in_shape, out_shape, frozen]  -- which of {k, v, q} has no requires_grad

--- a/torch_harmonics/attention/kernels_torch/attention_torch.py
+++ b/torch_harmonics/attention/kernels_torch/attention_torch.py
@@ -538,14 +538,25 @@ def _neighborhood_s2_attention_bwd_torch(ctx, grad_output):
 torch.library.register_autograd("attention_kernels::_neighborhood_s2_attention_torch", _neighborhood_s2_attention_bwd_torch, setup_context=_setup_context_attention_backward)
 
 
-# Autocast: register at the dispatcher's AutocastCUDA key (not via
+# Autocast: register at the dispatcher's Autocast{CUDA,CPU} keys (not via
 # register_autocast — that API hard-codes ``cast_inputs`` and can't follow the
 # active autocast dtype). Index tensors and quad_weights pass through.
-@torch.library.impl("attention_kernels::_neighborhood_s2_attention_torch", "AutocastCUDA")
-def _(kw, vw, qw, quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out):
-    cast_dtype = torch.get_autocast_dtype("cuda")
-    with torch.amp.autocast("cuda", enabled=False):
-        return _neighborhood_s2_attention_torch(kw.to(cast_dtype), vw.to(cast_dtype), qw.to(cast_dtype), quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out)
+#
+# The reference path mirrors the optimized one so the two stay comparable under
+# autocast on either device; see the note in attention_optimized.py for why CPU
+# needs its own key.
+def _make_autocast_impl(device_type):
+    @torch.library.impl("attention_kernels::_neighborhood_s2_attention_torch", f"Autocast{device_type.upper()}")
+    def _(kw, vw, qw, quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out):
+        cast_dtype = torch.get_autocast_dtype(device_type)
+        with torch.amp.autocast(device_type, enabled=False):
+            return _neighborhood_s2_attention_torch(kw.to(cast_dtype), vw.to(cast_dtype), qw.to(cast_dtype), quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out)
+
+    return _
+
+
+_make_autocast_impl("cuda")
+_make_autocast_impl("cpu")
 
 
 # =====================================================================================

--- a/torch_harmonics/attention/optimized/attention_optimized.py
+++ b/torch_harmonics/attention/optimized/attention_optimized.py
@@ -297,11 +297,26 @@ if optimized_kernels_is_available():
         "attention_kernels::_neighborhood_s2_attention_optimized", _neighborhood_s2_attention_bwd_optimized, setup_context=_setup_context_attention_backward
     )
 
-    # Autocast: register at the dispatcher's AutocastCUDA key (not via
+    # Autocast: register at the dispatcher's Autocast{CUDA,CPU} keys (not via
     # register_autocast — that API hard-codes ``cast_inputs`` and can't follow
     # the active autocast dtype). Index tensors and quad_weights pass through.
-    @torch.library.impl("attention_kernels::_neighborhood_s2_attention_optimized", "AutocastCUDA")
-    def _(kw, vw, qw, quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out):
-        cast_dtype = torch.get_autocast_dtype("cuda")
-        with torch.amp.autocast("cuda", enabled=False):
-            return _neighborhood_s2_attention_optimized(kw.to(cast_dtype), vw.to(cast_dtype), qw.to(cast_dtype), quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out)
+    #
+    # Both keys are needed. The kernels dispatch once on q's scalar type and then
+    # reinterpret every activation pointer as that type, so they require k, v and q
+    # to share a dtype and check it explicitly. Autocast does not guarantee that on
+    # its own: it casts some ops and not others, so a module mixing projections with
+    # normalization can hand the op an fp32 q next to an fp16 v. Normalizing here is
+    # what makes the requirement hold.
+    def _make_autocast_impl(device_type):
+        @torch.library.impl("attention_kernels::_neighborhood_s2_attention_optimized", f"Autocast{device_type.upper()}")
+        def _(kw, vw, qw, quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out):
+            cast_dtype = torch.get_autocast_dtype(device_type)
+            with torch.amp.autocast(device_type, enabled=False):
+                return _neighborhood_s2_attention_optimized(
+                    kw.to(cast_dtype), vw.to(cast_dtype), qw.to(cast_dtype), quad_weights, col_idx, row_off, nh, nlon_in, nlat_out, nlon_out
+                )
+
+        return _
+
+    _make_autocast_impl("cuda")
+    _make_autocast_impl("cpu")

--- a/torch_harmonics/disco/optimized/disco_optimized.py
+++ b/torch_harmonics/disco/optimized/disco_optimized.py
@@ -408,11 +408,22 @@ if optimized_kernels_is_available():
     # excludes the AutocastCUDA key from the dispatch set so the inner call
     # routes to the regular CUDA kernel (the op body) instead of recursing
     # back into this autocast kernel.
-    @torch.library.impl("disco_kernels::_disco_s2_contraction_optimized", "AutocastCUDA")
-    def _(inp, roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out):
-        cast_dtype = torch.get_autocast_dtype("cuda")
-        with torch.amp.autocast("cuda", enabled=False):
-            return _disco_s2_contraction_optimized(inp.to(cast_dtype), roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out)
+    # Registered for CPU as well as CUDA. Without the CPU key, torch.autocast("cpu")
+    # is silently a no-op for DISCO: the op runs at whatever dtype it was handed
+    # rather than the autocast dtype. That is quieter than the attention case (the
+    # CPU kernel normalizes dtypes itself, in disco_cpu_fwd.cpp, so nothing errors),
+    # but it means CPU AMP did not actually apply here.
+    def _make_contraction_autocast(device_type):
+        @torch.library.impl("disco_kernels::_disco_s2_contraction_optimized", f"Autocast{device_type.upper()}")
+        def _(inp, roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out):
+            cast_dtype = torch.get_autocast_dtype(device_type)
+            with torch.amp.autocast(device_type, enabled=False):
+                return _disco_s2_contraction_optimized(inp.to(cast_dtype), roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out)
+
+        return _
+
+    _make_contraction_autocast("cuda")
+    _make_contraction_autocast("cpu")
 
 
 # Transpose convolution related
@@ -439,11 +450,17 @@ if optimized_kernels_is_available():
         "disco_kernels::_disco_s2_transpose_contraction_optimized", _disco_s2_transpose_contraction_bwd_optimized, setup_context=_setup_context_conv_backward
     )
 
-    @torch.library.impl("disco_kernels::_disco_s2_transpose_contraction_optimized", "AutocastCUDA")
-    def _(inp, roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out):
-        cast_dtype = torch.get_autocast_dtype("cuda")
-        with torch.amp.autocast("cuda", enabled=False):
-            return _disco_s2_transpose_contraction_optimized(inp.to(cast_dtype), roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out)
+    def _make_transpose_contraction_autocast(device_type):
+        @torch.library.impl("disco_kernels::_disco_s2_transpose_contraction_optimized", f"Autocast{device_type.upper()}")
+        def _(inp, roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out):
+            cast_dtype = torch.get_autocast_dtype(device_type)
+            with torch.amp.autocast(device_type, enabled=False):
+                return _disco_s2_transpose_contraction_optimized(inp.to(cast_dtype), roff_idx, ker_idx, row_idx, col_idx, vals, kernel_size, nlat_out, nlon_out)
+
+        return _
+
+    _make_transpose_contraction_autocast("cuda")
+    _make_transpose_contraction_autocast("cpu")
 
 
 # Fused convolution + weight contraction.


### PR DESCRIPTION
Both op families registered an autocast kernel only at the AutocastCUDA dispatch key, so under torch.autocast("cpu", ...) nothing reconciled their inputs. The two symptoms differ:

- Attention hard-fails. The kernels dispatch once on q's scalar type and then reinterpret every activation pointer as that type, so they require k, v and q to share a dtype and check it explicitly. Autocast casts some ops and not others, so a module mixing projections with normalization can hand the op an fp32 q next to an fp16 v, tripping the check: RuntimeError: v dtype (Half) must match q dtype (Float)

- DISCO fails quietly. Its CPU kernel normalizes dtypes itself (disco_cpu_fwd.cpp upcasts reduced-precision inp and vals to fp32), so nothing errors -- but the op ran at whatever dtype it was handed rather than the autocast dtype, i.e. CPU autocast simply had no effect on DISCO layers.

Both now register AutocastCPU alongside AutocastCUDA, via one closure per op so the two keys cannot drift apart again.

Found on nvcr.io/nvidia/pytorch:24.12-py3 (torch ~2.6), where six CPU AMP rows of test_custom_implementation failed. It was invisible on newer PyTorch, on CI and on two other containers, because those happen to produce consistent dtypes for this graph -- the missing registration was latent there, not absent.

The new test is therefore at op level rather than module level: it constructs the mismatch directly (fp32 q, reduced-precision k/v) so the regression is detectable on any torch version. Without autocast active the same inputs raise, which makes the test discriminating rather than vacuous.

Suite: 596 passed, 15 skipped (attention + convolution).