### PR TITLE
Unify the theta_cutoff heuristic and derive it from the grid

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,10 @@
 
 ## Versioning
 
-### v0.9.3
+### v0.9.3b1 (unreleased)
 
+* Unified the default `theta_cutoff` heuristic for DISCO convolutions and neighborhood attention into `torch_harmonics.quadrature.compute_theta_cutoff`, backed by the new `compute_latitude_spacing`. The cutoff was previously computed as `pi / (nlat - 1)` in six independent places; that expression is the exact latitudinal node spacing of an equiangular grid, but not of the others. Gauss-Lobatto nodes cluster towards the equator (polar spacing ~21% larger) and `"equiangular-trapezoidal"` nodes are equispaced in `cos(theta)` rather than in `theta` (polar spacing ~5x larger), so on both grids the old default under-covered the poles: at `nlat = 129`, 6 of 129 output latitudes on a lobatto grid and 30 of 129 on an equiangular-trapezoidal grid saw only the single latitude ring they sit on, silently degenerating the stencil there. The cutoff is now taken from the grid's actual node distribution.
+* **Breaking**: the default `theta_cutoff` of `DiscreteContinuousConvS2`, `DiscreteContinuousConvTransposeS2`, `NeighborhoodAttentionS2`, and their distributed counterparts now depends on the grid's node distribution rather than on `nlat` alone. Equiangular grids, which are the default, are unaffected in practice — the value moves by ~1e-15 and the resulting `psi` has an identical sparsity pattern — but `"lobatto"` widens by ~21%, `"equiangular-trapezoidal"` by ~5x, and `"legendre-gauss"` narrows by ~2.3%. Models trained on non-equiangular grids will see a different stencil unless `theta_cutoff` is passed explicitly. A `UserWarning` is emitted on the grids whose default changed, following the `truncate_sht` precedent from v0.9.0.
 * Fixed `trapezoidal_weights` returning float32 weights alongside float64 nodes, because the underlying `torch.ones(n)` inherited the default dtype. It was the only rule in `torch_harmonics.quadrature` doing so, and it capped the accuracy of everything derived from it at roughly 1e-7, including the latitude weights of the `"equiangular-trapezoidal"` grid. Weights are now float64 like the other rules, and the tolerances of the affected tests have been tightened to match the other grids.
 
 ### v0.9.2

--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -8,15 +8,20 @@ torch-harmonics supports several quadrature rules for the latitudinal
 direction. Each corresponds to a `grid` keyword accepted by the SHT and
 convolution layers:
 
-| Grid string                 | Quadrature rule | Nodes                                           | Key properties                                                                                      |
-| --------------------------- | --------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `"equiangular"`             | Clenshaw–Curtis | Equally spaced in $\theta$ (including poles)    | Default grid. Exact for polynomials up to degree $N-1$. Simple, FFT-friendly.                       |
-| `"legendre-gauss"`          | Gauss–Legendre  | Roots of $P_N(\cos\theta)$                      | Exact for polynomials up to degree $2N-1$. Optimal accuracy per node, but nodes are non-uniform.    |
-| `"lobatto"`                 | Gauss–Lobatto   | Roots of $P'_{N-1}(\cos\theta)$, plus endpoints | Exact for polynomials up to degree $2N-3$. Includes both poles, useful when pole values are needed. |
-| `"equiangular-trapezoidal"` | Trapezoidal     | Equally spaced                                  | Supports periodic grids. Lower-order accuracy but simplest structure.                               |
+| Grid string                 | Quadrature rule | Nodes                                            | Key properties                                                                                                                                                                                                                                                                                                        |
+| --------------------------- | --------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"equiangular"`             | Clenshaw–Curtis | Equally spaced in $\theta$ (including poles)     | Default grid. Exact for polynomials up to degree $N-1$. Simple, FFT-friendly.                                                                                                                                                                                                                                         |
+| `"legendre-gauss"`          | Gauss–Legendre  | Roots of $P_N(\cos\theta)$                       | Exact for polynomials up to degree $2N-1$. Optimal accuracy per node, but nodes are non-uniform.                                                                                                                                                                                                                      |
+| `"lobatto"`                 | Gauss–Lobatto   | Roots of $P'_{N-1}(\cos\theta)$, plus endpoints  | Exact for polynomials up to degree $2N-3$. Includes both poles, useful when pole values are needed.                                                                                                                                                                                                                   |
+| `"equiangular-trapezoidal"` | Trapezoidal     | Equally spaced in $\cos\theta$ (including poles) | Supports periodic grids. Lower-order accuracy but simplest structure. Despite the name, the nodes are *not* equiangular in $\theta$: the rule is applied on the $\cos\theta$ interval $[-1, 1]$, so the spacing in $\theta$ is strongly non-uniform and roughly $5\times$ coarser near the poles than at the equator. |
 
 The longitudinal direction always uses equispaced nodes (see
 `precompute_longitudes`).
+
+Because only `"equiangular"` has uniform spacing in $\theta$, quantities derived
+from "one latitudinal grid spacing" must come from the grid's actual node
+distribution rather than from $\pi / (N_\theta - 1)$; see
+`compute_latitude_spacing` and `compute_theta_cutoff`.
 
 ```{eval-rst}
 .. currentmodule:: torch_harmonics.quadrature
@@ -27,6 +32,8 @@ The longitudinal direction always uses equispaced nodes (see
 
    precompute_longitudes
    precompute_latitudes
+   compute_latitude_spacing
+   compute_theta_cutoff
    legendre_gauss_weights
    lobatto_weights
    clenshaw_curtiss_weights

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -46,7 +46,7 @@ from torch_harmonics.disco.convolution import (
     _precompute_convolution_tensor_s2,
 )
 from torch_harmonics.filter_basis import get_filter_basis
-from torch_harmonics.quadrature import precompute_latitudes, precompute_longitudes
+from torch_harmonics.quadrature import compute_theta_cutoff, precompute_latitudes, precompute_longitudes
 
 if not optimized_kernels_is_available():
     print("Warning: Couldn't import optimized disco convolution kernels")
@@ -293,6 +293,14 @@ class TestDiscreteContinuousConvolution(unittest.TestCase):
             # mixed grid
             [(16, 32), (8, 16), (3, 3), "harmonic", "mean", "legendre-gauss", "equiangular"],
             [(16, 32), (8, 16), (3, 3), "harmonic", "mean", "equiangular", "legendre-gauss"],
+            # non-equiangular output grids, where the default theta_cutoff is driven by a
+            # node distribution that is not uniform in theta (lobatto clusters towards the
+            # equator, equiangular-trapezoidal is equispaced in cos(theta))
+            [(16, 32), (16, 32), (3, 3), "harmonic", "mean", "lobatto", "lobatto"],
+            [(16, 32), (8, 16), (3, 3), "harmonic", "mean", "lobatto", "lobatto"],
+            [(16, 32), (8, 16), (3, 3), "harmonic", "mean", "equiangular", "lobatto"],
+            [(16, 32), (16, 32), (3, 3), "harmonic", "mean", "equiangular-trapezoidal", "equiangular-trapezoidal"],
+            [(16, 32), (8, 16), (3, 3), "harmonic", "mean", "equiangular", "equiangular-trapezoidal"],
         ],
         skip_on_empty=True,
     )
@@ -310,7 +318,9 @@ class TestDiscreteContinuousConvolution(unittest.TestCase):
 
         filter_basis = get_filter_basis(kernel_shape=kernel_shape, basis_type=basis_type)
 
-        theta_cutoff = torch.pi / float(nlat_out - 1)
+        # use the same default DiscreteContinuousConvS2 would pick, rather than a
+        # hardcoded pi/(nlat_out-1), which is only the node spacing of an equiangular grid
+        theta_cutoff = compute_theta_cutoff(nlat_out, grid=grid_out)
 
         idx, vals, _ = _precompute_convolution_tensor_s2(
             in_shape=in_shape,

--- a/tests/test_distributed_convolution.py
+++ b/tests/test_distributed_convolution.py
@@ -205,6 +205,19 @@ class TestDistributedDiscreteContinuousConvolution(unittest.TestCase):
             [64, 128, 32, 64, 32, 8, (3), "piecewise linear", "mean", 1, "equiangular", "equiangular", torch.float64, False, False, 1e-6, 1e-6],
             [64, 128, 64, 128, 32, 8, (3, 2), "piecewise linear", "mean", 1, "equiangular", "equiangular", torch.float64, True, False, 1e-6, 1e-6],
             [65, 128, 65, 128, 32, 8, (3, 4), "harmonic", "mean", 1, "equiangular", "equiangular", torch.float64, False, False, 1e-6, 1e-6],
+            # non-equiangular grids at regular resolution. These are the rows where the
+            # default theta_cutoff is derived from a node distribution that is not uniform
+            # in theta, so the polar halo differs from the pi/(nlat-1) assumption. The only
+            # other non-equiangular case in this file is ERA5-sized and slow-gated, which
+            # left the distributed halo/split bookkeeping untested on these grids.
+            [64, 128, 64, 128, 32, 8, (3), "piecewise linear", "mean", 1, "lobatto", "lobatto", torch.float32, False, False, 1e-6, 1e-5],
+            [64, 128, 32, 64, 32, 8, (3), "piecewise linear", "mean", 1, "lobatto", "lobatto", torch.float32, False, False, 1e-6, 1e-5],
+            [64, 128, 32, 64, 32, 8, (3), "piecewise linear", "mean", 1, "equiangular", "legendre-gauss", torch.float32, False, False, 1e-6, 1e-5],
+            [64, 128, 128, 256, 32, 8, (3), "piecewise linear", "mean", 1, "lobatto", "lobatto", torch.float32, True, False, 1e-6, 1e-5],
+            # equiangular-trapezoidal is equispaced in cos(theta), so its default cutoff is
+            # ~5x wider than the other grids at the same nlat and psi is correspondingly
+            # denser. batch_size/num_chan dialed down to keep the working set bounded.
+            [64, 128, 64, 128, 2, 8, (3), "piecewise linear", "mean", 1, "equiangular-trapezoidal", "equiangular-trapezoidal", torch.float32, False, False, 1e-6, 1e-5],
             # ERA5-like grids, gated behind TORCH_HARMONICS_RUN_SLOW_TESTS=1.
             # batch_size and num_chan dialed down (2, 8) vs the rest of the suite (32, 8)
             # to keep the working set under a few GB at these resolutions.

--- a/tests/test_grid_assumptions.py
+++ b/tests/test_grid_assumptions.py
@@ -1,0 +1,294 @@
+# coding=utf-8
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 The torch-harmonics Authors. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+"""
+Contract tests for grid-dependent quantities that are currently derived from
+``nlat`` plus a grid *string*, in several places independently.
+
+These pin down the invariants that a future grid descriptor is meant to own as
+properties, so that the refactor can be validated against them:
+
+* the default angular cutoff, which must follow the grid's actual latitudinal node
+  spacing rather than ``nlat`` alone (:func:`compute_theta_cutoff`),
+* whether the nodes of a grid are equispaced in :math:`\\theta` or in
+  :math:`\\cos\\theta`,
+* the pole symmetry of nodes and weights, which is what currently makes the
+  differing flip conventions of ``precompute_latitudes`` and ``QuadratureS2``
+  agree by accident.
+"""
+
+import math
+import unittest
+import warnings
+
+import torch
+from parameterized import parameterized
+from testutils import compare_tensors
+
+from torch_harmonics.disco.convolution import _precompute_convolution_tensor_s2
+from torch_harmonics.filter_basis import get_filter_basis
+from torch_harmonics.quadrature import compute_latitude_spacing, compute_theta_cutoff, precompute_latitudes
+
+_ALL_GRIDS = ["equiangular", "legendre-gauss", "lobatto", "equiangular-trapezoidal"]
+
+# grids on which the superseded pi / (nlat - 1) heuristic was too narrow near the poles
+_IRREGULAR_THETA_GRIDS = ["lobatto", "equiangular-trapezoidal"]
+
+_NLATS = [33, 65, 129]
+
+
+def _legacy_theta_cutoff(nlat: int) -> float:
+    """The nlat-only heuristic that compute_theta_cutoff replaced."""
+    return math.pi / float(nlat - 1)
+
+
+def _default_theta_cutoff(nlat: int, grid: str) -> float:
+    """The cutoff actually used by DiscreteContinuousConvS2 and NeighborhoodAttentionS2."""
+    return compute_theta_cutoff(nlat, grid=grid)
+
+
+def _min_latitude_rings_in_cutoff(nlat: int, grid: str) -> int:
+    """
+    Minimum number of input latitude rings that fall within the default cutoff of
+    any output latitude, for a same-in/same-out grid.
+
+    The great-circle distance between ``(theta_out, 0)`` and ``(theta_in, phi)`` is
+    bounded below by ``|theta_out - theta_in|``, so a latitude ring outside the
+    cutoff in ``theta`` cannot contribute to the psi row for any ``phi``. A value of
+    1 therefore means the neighborhood of that output point degenerates to the
+    single ring it sits on.
+    """
+    lats, _ = precompute_latitudes(nlat, grid=grid)
+    cutoff = _default_theta_cutoff(nlat, grid)
+    # count ties: an input latitude exactly at the cutoff is a boundary artifact of
+    # the strict comparison in _precompute_convolution_tensor_s2, not a real gap
+    within = (lats.unsqueeze(0) - lats.unsqueeze(1)).abs() <= cutoff * (1.0 + 1e-9)
+    return int(within.sum(dim=1).min().item())
+
+
+class TestThetaCutoffContract(unittest.TestCase):
+    """
+    ``theta_cutoff`` defaults to :func:`compute_theta_cutoff`, which takes one
+    latitudinal grid spacing from the grid's actual node distribution. It replaced
+    a hardcoded ``pi / (nlat - 1)``, which is the exact node spacing of an
+    *equiangular* (Clenshaw-Curtis) grid but a significant underestimate near the
+    poles for ``lobatto`` and ``equiangular-trapezoidal``.
+    """
+
+    @parameterized.expand([[nlat, grid] for nlat in _NLATS for grid in _ALL_GRIDS])
+    def test_default_cutoff_covers_latitude_spacing(self, nlat, grid):
+        cutoff = _default_theta_cutoff(nlat, grid)
+        dlat_max = compute_latitude_spacing(nlat, grid=grid)
+        self.assertGreaterEqual(
+            cutoff * (1.0 + 1e-9),
+            dlat_max,
+            msg=f"grid={grid} nlat={nlat}: default theta_cutoff {cutoff:.6f} < max latitude spacing {dlat_max:.6f}",
+        )
+
+    @parameterized.expand([[nlat, grid] for nlat in _NLATS for grid in _ALL_GRIDS])
+    def test_default_cutoff_gives_multi_ring_neighborhood(self, nlat, grid):
+        rings = _min_latitude_rings_in_cutoff(nlat, grid)
+        self.assertGreaterEqual(
+            rings,
+            2,
+            msg=f"grid={grid} nlat={nlat}: some output latitude sees only its own ring within the default cutoff",
+        )
+
+    @parameterized.expand([[nlat] for nlat in _NLATS])
+    def test_equiangular_cutoff_is_unchanged_by_the_fix(self, nlat):
+        """
+        Regression guard: the equiangular grid is the default and by far the most
+        used one, so switching to the node-distribution-based cutoff must not
+        perturb it. The two agree to ~1e-13 relative, not bit-identically, since the
+        new value comes back through ``arccos`` of the Clenshaw-Curtis nodes.
+
+        See :meth:`TestThetaCutoffPsiRegression.test_equiangular_psi_is_unchanged`
+        for the consequence that actually matters.
+        """
+        self.assertAlmostEqual(_default_theta_cutoff(nlat, "equiangular") / _legacy_theta_cutoff(nlat), 1.0, places=12)
+
+    @parameterized.expand([[nlat, grid] for nlat in _NLATS for grid in _IRREGULAR_THETA_GRIDS])
+    def test_irregular_grids_get_a_wider_cutoff_than_the_legacy_heuristic(self, nlat, grid):
+        """
+        The actual fix: on these two grids the legacy heuristic was too narrow, so
+        the new cutoff must be strictly wider. Lobatto by ~21%, and
+        equiangular-trapezoidal by ~5x since its nodes are equispaced in cos(theta).
+        """
+        self.assertGreater(_default_theta_cutoff(nlat, grid), _legacy_theta_cutoff(nlat))
+
+    @parameterized.expand([[nlat, grid] for nlat in _NLATS for grid in _ALL_GRIDS])
+    def test_scale_is_applied_linearly(self, nlat, grid):
+        self.assertAlmostEqual(compute_theta_cutoff(nlat, grid=grid, scale=2.5), 2.5 * compute_theta_cutoff(nlat, grid=grid), places=15)
+
+    @parameterized.expand([[nlat, grid] for nlat in _NLATS for grid in _IRREGULAR_THETA_GRIDS + ["legendre-gauss"]])
+    def test_changed_default_warns(self, nlat, grid):
+        """
+        Mirrors the ``truncate_sht`` precedent: grids whose default moved must say
+        so, since a silently different cutoff would silently change existing models.
+        """
+        with self.assertWarns(UserWarning):
+            compute_theta_cutoff(nlat, grid=grid)
+
+    @parameterized.expand([[nlat] for nlat in _NLATS])
+    def test_unchanged_default_does_not_warn(self, nlat):
+        """The equiangular default is unchanged, so warning there would be noise."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            compute_theta_cutoff(nlat, grid="equiangular")
+
+
+class TestThetaCutoffPsiRegression(unittest.TestCase):
+    """
+    The cutoff only matters through the convolution tensor it produces, so check
+    that directly: on the equiangular grid, swapping the legacy ``pi / (nlat - 1)``
+    for :func:`compute_theta_cutoff` must leave the sparsity pattern of psi
+    untouched and its values equal to well within float32 resolution. Existing
+    equiangular models are therefore unaffected by the fix.
+    """
+
+    @parameterized.expand([[nlat, nlon] for (nlat, nlon) in [(33, 64), (65, 128), (129, 256)]])
+    def test_equiangular_psi_is_unchanged(self, nlat, nlon, verbose=False):
+        filter_basis = get_filter_basis(kernel_shape=(3, 3), basis_type="piecewise linear")
+
+        def _psi(theta_cutoff):
+            idx, vals, _ = _precompute_convolution_tensor_s2(
+                (nlat, nlon),
+                (nlat, nlon),
+                filter_basis,
+                grid_in="equiangular",
+                grid_out="equiangular",
+                theta_cutoff=theta_cutoff,
+                transpose_normalization=False,
+                basis_norm_mode="mean",
+                merge_quadrature=True,
+            )
+            return idx, vals
+
+        idx_legacy, vals_legacy = _psi(_legacy_theta_cutoff(nlat))
+        idx_new, vals_new = _psi(_default_theta_cutoff(nlat, "equiangular"))
+
+        self.assertEqual(idx_legacy.shape, idx_new.shape, msg=f"nlat={nlat}: psi nnz changed, {idx_legacy.shape[1]} -> {idx_new.shape[1]}")
+        self.assertTrue(compare_tensors(f"psi sparsity pattern (nlat={nlat})", idx_legacy, idx_new, verbose=verbose))
+        # float32 eps is ~1.2e-7, so 1e-10 leaves several orders of headroom
+        self.assertTrue(compare_tensors(f"psi values (nlat={nlat})", vals_legacy, vals_new, atol=1e-10, rtol=1e-10, verbose=verbose))
+
+
+class TestGridNodeDistribution(unittest.TestCase):
+    """
+    Characterization tests for *where* the nodes of each grid actually sit. These
+    encode facts that are currently implicit in the grid string and that a
+    descriptor should expose explicitly.
+    """
+
+    @parameterized.expand([[nlat] for nlat in _NLATS])
+    def test_equiangular_nodes_are_equispaced_in_theta(self, nlat, verbose=False):
+        lats, _ = precompute_latitudes(nlat, grid="equiangular")
+        dlat = lats[1:] - lats[:-1]
+        self.assertTrue(compare_tensors(f"equiangular dtheta (nlat={nlat})", dlat, dlat.mean().expand_as(dlat), atol=1e-12, rtol=0.0, verbose=verbose))
+
+    @parameterized.expand([[nlat] for nlat in _NLATS])
+    def test_equiangular_trapezoidal_nodes_are_equispaced_in_cos_theta(self, nlat, verbose=False):
+        """
+        Despite its name, ``equiangular-trapezoidal`` is *not* equiangular in theta:
+        ``precompute_latitudes`` builds it via ``trapezoidal_weights`` on the
+        cos(theta) interval [-1, 1], so the nodes are equispaced in cos(theta)
+        instead. This is the root cause of the polar under-coverage above, and it is
+        exactly the kind of fact a grid descriptor should carry rather than a name.
+        """
+        lats, _ = precompute_latitudes(nlat, grid="equiangular-trapezoidal")
+        cost = torch.cos(lats)
+        dcos = cost[1:] - cost[:-1]
+        self.assertTrue(compare_tensors(f"equiangular-trapezoidal dcos(theta) (nlat={nlat})", dcos, dcos.mean().expand_as(dcos), atol=1e-12, rtol=0.0, verbose=verbose))
+
+        # ... and correspondingly it is strongly non-uniform in theta
+        dlat = lats[1:] - lats[:-1]
+        self.assertGreater(dlat.max().item() / dlat.min().item(), 4.0)
+
+    @parameterized.expand([[nlat, grid] for nlat in _NLATS for grid in _ALL_GRIDS])
+    def test_latitudes_are_ascending_colatitudes(self, nlat, grid):
+        """All grids must return colatitudes in [0, pi], strictly ascending (north pole first)."""
+        lats, _ = precompute_latitudes(nlat, grid=grid)
+        self.assertGreaterEqual(lats[0].item(), 0.0)
+        self.assertLessEqual(lats[-1].item(), math.pi)
+        self.assertTrue(bool(((lats[1:] - lats[:-1]) > 0).all()), msg=f"grid={grid} nlat={nlat}: latitudes are not strictly ascending")
+
+
+class TestQuadratureOrderingContract(unittest.TestCase):
+    """
+    ``precompute_latitudes`` flips both nodes and weights out of the cos(theta)
+    domain, whereas ``QuadratureS2`` (``quadrature.py:403``) uses the *unflipped*
+    weights directly against data indexed by the flipped latitudes. Both are
+    correct today only because every currently supported quadrature rule has nodes
+    and weights that are symmetric about the equator, which makes the discrepancy
+    invisible.
+
+    A grid descriptor hands out ``lats`` and ``quad_weights`` as a pair, so this
+    coincidence has to become an explicit, checked property: any newly added rule
+    that is not pole-symmetric would silently break ``QuadratureS2`` today.
+    """
+
+    @parameterized.expand([[nlat, grid] for nlat in [64, 65] for grid in _ALL_GRIDS])
+    def test_quadrature_weights_are_pole_symmetric(self, nlat, grid, verbose=False):
+        _, w = precompute_latitudes(nlat, grid=grid)
+        self.assertTrue(compare_tensors(f"weight pole symmetry (grid={grid}, nlat={nlat})", w, torch.flip(w, dims=(0,)), atol=1e-12, rtol=0.0, verbose=verbose))
+
+    @parameterized.expand([[nlat, grid] for nlat in [64, 65] for grid in _ALL_GRIDS])
+    def test_latitudes_are_pole_symmetric(self, nlat, grid, verbose=False):
+        """Companion to the above: ``theta_k + theta_{n-1-k} == pi``."""
+        lats, _ = precompute_latitudes(nlat, grid=grid)
+        self.assertTrue(
+            compare_tensors(
+                f"latitude pole symmetry (grid={grid}, nlat={nlat})",
+                lats,
+                math.pi - torch.flip(lats, dims=(0,)),
+                atol=1e-12,
+                rtol=0.0,
+                verbose=verbose,
+            )
+        )
+
+    @parameterized.expand([[nlat, grid] for nlat in [65, 129] for grid in _ALL_GRIDS])
+    def test_weights_integrate_asymmetric_field(self, nlat, grid, verbose=False):
+        r"""
+        :math:`\int_{S^2} e^{\cos\theta}\,dA = 2\pi \int_{-1}^{1} e^x dx = 2\pi(e - e^{-1})`.
+
+        A pole-asymmetric, monotone integrand, so this exercises the node/weight
+        pairing rather than just the total mass. The tolerance is loose because
+        equiangular-trapezoidal is only second-order accurate here.
+        """
+        lats, w = precompute_latitudes(nlat, grid=grid)
+        integral = 2.0 * math.pi * torch.sum(w * torch.exp(torch.cos(lats)))
+        expected = torch.full_like(integral, 2.0 * math.pi * (math.e - 1.0 / math.e))
+        self.assertTrue(compare_tensors(f"exp(cos theta) integral (grid={grid}, nlat={nlat})", integral, expected, atol=0.0, rtol=1e-3, verbose=verbose))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torch_harmonics/attention/attention.py
+++ b/torch_harmonics/attention/attention.py
@@ -43,7 +43,7 @@ from torch_harmonics.attention.kernels_torch.attention_torch import _neighborhoo
 from torch_harmonics.attention.optimized.attention_optimized import _neighborhood_s2_attention_optimized
 from torch_harmonics.disco.convolution import _precompute_convolution_tensor_s2
 from torch_harmonics.filter_basis import get_filter_basis
-from torch_harmonics.quadrature import precompute_latitudes
+from torch_harmonics.quadrature import compute_theta_cutoff, precompute_latitudes
 
 
 class AttentionS2(nn.Module):
@@ -298,7 +298,8 @@ class NeighborhoodAttentionS2(nn.Module):
         Angular radius of the geodesic neighborhood disk, in radians. Input points
         farther than this from an output location are excluded from its attention.
         If None (default), it is set to one latitudinal grid spacing of the coarser
-        of the input and output grids, i.e. ``pi / (nlat - 1)``. Must be positive.
+        of the input and output grids, see
+        :func:`torch_harmonics.quadrature.compute_theta_cutoff`. Must be positive.
     k_channels : int
         number of dimensions for interior inner product in the attention matrix (corresponds to kdim in MHA in PyTorch)
     out_channels : int, optional
@@ -351,9 +352,9 @@ class NeighborhoodAttentionS2(nn.Module):
         # convention and use the coarser (input) grid spacing.
         if theta_cutoff is None:
             if self.upsample:
-                self.theta_cutoff = torch.pi / float(self.nlat_in - 1)
+                self.theta_cutoff = compute_theta_cutoff(self.nlat_in, grid=grid_in)
             else:
-                self.theta_cutoff = torch.pi / float(self.nlat_out - 1)
+                self.theta_cutoff = compute_theta_cutoff(self.nlat_out, grid=grid_out)
         else:
             self.theta_cutoff = theta_cutoff
 

--- a/torch_harmonics/disco/convolution.py
+++ b/torch_harmonics/disco/convolution.py
@@ -40,7 +40,7 @@ from disco_helpers import optimized_kernels_is_available, pack_psi_dense, prepro
 
 from torch_harmonics.cache import lru_cache
 from torch_harmonics.filter_basis import FilterBasis, get_filter_basis
-from torch_harmonics.quadrature import precompute_latitudes, precompute_longitudes
+from torch_harmonics.quadrature import compute_theta_cutoff, precompute_latitudes, precompute_longitudes
 
 from ._disco_utils import _get_psi
 from .kernels_torch.disco_torch import _disco_s2_contraction_torch, _disco_s2_transpose_contraction_torch
@@ -561,7 +561,7 @@ class DiscreteContinuousConvS2(DiscreteContinuousConv):
 
         # heuristic to compute theta cutoff based on the bandlimit of the input field and overlaps of the basis functions
         if theta_cutoff is None:
-            self.theta_cutoff = torch.pi / float(self.nlat_out - 1)
+            self.theta_cutoff = compute_theta_cutoff(self.nlat_out, grid=grid_out)
         else:
             self.theta_cutoff = theta_cutoff
 
@@ -923,7 +923,7 @@ class DiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
 
         # bandlimit
         if theta_cutoff is None:
-            self.theta_cutoff = torch.pi / float(self.nlat_in - 1)
+            self.theta_cutoff = compute_theta_cutoff(self.nlat_in, grid=grid_in)
         else:
             self.theta_cutoff = theta_cutoff
 

--- a/torch_harmonics/distributed/distributed_convolution.py
+++ b/torch_harmonics/distributed/distributed_convolution.py
@@ -43,6 +43,7 @@ from torch_harmonics.disco.convolution import (
 )
 from torch_harmonics.disco.kernels_torch.disco_torch import _disco_s2_transpose_contraction_torch
 from torch_harmonics.disco.optimized.disco_optimized import _build_kernel_split_csr, _disco_s2_transpose_contraction_optimized, _maybe_kpack_psi, _split_csr_python_offsets
+from torch_harmonics.quadrature import compute_theta_cutoff
 
 # a2a forward orchestration: standard (fused=False) and reordered (fused=True).
 from .kernels import (
@@ -239,7 +240,7 @@ class DistributedDiscreteContinuousConvS2(DiscreteContinuousConv):
 
         # compute theta cutoff based on the bandlimit of the input field
         if theta_cutoff is None:
-            self.theta_cutoff = torch.pi / float(self.nlat_out - 1)
+            self.theta_cutoff = compute_theta_cutoff(self.nlat_out, grid=grid_out)
         else:
             self.theta_cutoff = theta_cutoff
 
@@ -520,7 +521,7 @@ class DistributedDiscreteContinuousConvTransposeS2(DiscreteContinuousConv):
 
         # bandlimit
         if theta_cutoff is None:
-            self.theta_cutoff = torch.pi / float(self.nlat_in - 1)
+            self.theta_cutoff = compute_theta_cutoff(self.nlat_in, grid=grid_in)
         else:
             self.theta_cutoff = theta_cutoff
 

--- a/torch_harmonics/quadrature.py
+++ b/torch_harmonics/quadrature.py
@@ -30,6 +30,7 @@
 #
 
 import math
+import warnings
 from typing import Optional, Tuple
 
 import numpy as np
@@ -135,6 +136,98 @@ def precompute_latitudes(nlat: int, grid: Optional[str] = "equiangular") -> Tupl
     wlg = torch.flip(wlg, dims=(0,)).clone()
 
     return lats, wlg
+
+
+@lru_cache(typed=True, copy=False)
+def compute_latitude_spacing(nlat: int, grid: Optional[str] = "equiangular") -> float:
+    r"""
+    Return the largest gap between adjacent latitude nodes of a grid.
+
+    This is the grid's own notion of "one latitudinal grid spacing". Only the
+    ``equiangular`` grid has uniform spacing, in which case this reduces to the
+    familiar :math:`\pi / (N_\theta - 1)`. Gauss--Lobatto nodes cluster towards
+    the equator, and ``equiangular-trapezoidal`` nodes are equispaced in
+    :math:`\cos\theta` rather than in :math:`\theta`, so both are considerably
+    coarser near the poles than a node count alone would suggest.
+
+    Parameters
+    ----------
+    nlat : int
+        Number of latitudinal nodes.
+    grid : str, optional
+        Quadrature grid type, by default ``"equiangular"``.
+
+    Returns
+    -------
+    float
+        Maximum spacing :math:`\max_k (\theta_{k+1} - \theta_k)` in radians.
+    """
+    lats, _ = precompute_latitudes(nlat, grid=grid)
+    return (lats[1:] - lats[:-1]).max().item()
+
+
+def compute_theta_cutoff(nlat: int, grid: Optional[str] = "equiangular", scale: Optional[float] = 1.0) -> float:
+    r"""
+    Default angular cutoff for localized operators on the sphere.
+
+    Both the DISCO convolutions and neighborhood attention need a support radius
+    for their filter basis. The heuristic is to take one latitudinal grid
+    spacing of the coarser of the two grids involved, so that the basis functions
+    of adjacent output points overlap and every output point sees more than the
+    single latitude ring it sits on.
+
+    The spacing is taken from the grid's actual node distribution
+    (:func:`compute_latitude_spacing`) rather than from ``nlat`` alone. Using
+    :math:`\pi / (N_\theta - 1)` is only correct for equiangular grids; on
+    ``lobatto`` and ``equiangular-trapezoidal`` grids it underestimates the polar
+    spacing by ~21% and ~5x respectively, which collapses the stencil of the
+    polar output latitudes to a single latitude ring.
+
+    Parameters
+    ----------
+    nlat : int
+        Number of latitudinal nodes of the grid that sets the cutoff. This is the
+        output grid for a forward transform and the input grid for a transpose
+        one, mirroring which of the two is the coarser.
+    grid : str, optional
+        Quadrature grid type, by default ``"equiangular"``.
+    scale : float, optional
+        Multiplier on the grid spacing, by default 1.0.
+
+    Returns
+    -------
+    float
+        Cutoff angle in radians.
+
+    Warns
+    -----
+    UserWarning
+        On grids whose node spacing is not uniform in :math:`\theta`, where this
+        returns a different value than the ``pi / (N_\theta - 1)`` heuristic used
+        before v0.9.3. Equiangular grids are unaffected and do not warn.
+
+    Notes
+    -----
+    This routine is the single place where the cutoff heuristic lives; it is
+    intended to take a grid descriptor once the descriptor-based API lands, at
+    which point ``nlat`` and ``grid`` collapse into a single argument.
+    """
+    dlat_max = compute_latitude_spacing(nlat, grid=grid)
+
+    # only the equiangular grid is uniform in theta, so only there does the
+    # superseded heuristic still agree (up to arccos roundoff)
+    legacy = math.pi / float(nlat - 1)
+    if abs(dlat_max - legacy) > 1e-9 * legacy:
+        consequence = "the previous value under-covered the poles" if dlat_max > legacy else "the previous value was slightly wider than the grid warrants"
+        warnings.warn(
+            f"Default theta_cutoff changed in v0.9.3: the '{grid}' grid is not uniform in theta, so the cutoff is now "
+            f"its maximum latitudinal node spacing ({dlat_max:.6f}) rather than pi/(nlat-1) ({legacy:.6f}); "
+            f"{consequence}. Specify theta_cutoff explicitly to override.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    return scale * dlat_max
 
 
 def trapezoidal_weights(n: int, a: Optional[float] = -1.0, b: Optional[float] = 1.0, periodic: Optional[bool] = False) -> Tuple[torch.Tensor, torch.Tensor]:


### PR DESCRIPTION
### Problem
     
  The default angular cutoff for DISCO convolutions and neighborhood attention was
  computed as `pi / (nlat - 1)` in six independent places:
     
  - `disco/convolution.py:564` (forward), `:926` (transpose)
  - `distributed/distributed_convolution.py:243` (forward), `:524` (transpose)
  - `attention/attention.py:355`, `:357`
     
  That expression is the exact latitudinal node spacing of an **equiangular**
  (Clenshaw-Curtis) grid, but not of the others:
     
  | grid | `pi/(nlat-1)` | actual max spacing | ratio |
  |---|---|---|---|
  | equiangular | 0.049087 | 0.049087 | 1.00 |
  | legendre-gauss | 0.049087 | 0.047962 | 0.98 |
  | lobatto | 0.049087 | 0.059408 | **1.21** |
  | equiangular-trapezoidal | 0.049087 | 0.250656 | **5.11** |
  
  (nlat = 65, same grid in/out.)
  
  The root cause of the last row is that `"equiangular-trapezoidal"` is a misnomer:
  `precompute_latitudes` builds it via `trapezoidal_weights` on the `cos(theta)`
  interval `[-1, 1]`, so its nodes are equispaced in `cos(theta)`, not in `theta`.
  
  The consequence is a silently degenerate polar stencil. Since the great-circle
  distance between `(theta_o, 0)` and `(theta_i, phi)` is bounded below by
  `|theta_o - theta_i|`, a latitude ring outside the cutoff in `theta` cannot
  contribute to the psi row for any `phi`. Counting rings within the old default:

| grid | `pi/(nlat-1)` | actual max spacing | ratio |
  |---|---|---|---|
  | equiangular | 0.049087 | 0.049087 | 1.00 |
  | legendre-gauss | 0.049087 | 0.047962 | 0.98 |
  | lobatto | 0.049087 | 0.059408 | **1.21** |
  | equiangular-trapezoidal | 0.049087 | 0.250656 | **5.11** |
     
  (nlat = 65, same grid in/out.)
     
  The root cause of the last row is that `"equiangular-trapezoidal"` is a misnomer:
  `precompute_latitudes` builds it via `trapezoidal_weights` on the `cos(theta)`
  interval `[-1, 1]`, so its nodes are equispaced in `cos(theta)`, not in `theta`.
     
  The consequence is a silently degenerate polar stencil. Since the great-circle
  distance between `(theta_o, 0)` and `(theta_i, phi)` is bounded below by
  `|theta_o - theta_i|`, a latitude ring outside the cutoff in `theta` cannot
  contribute to the psi row for any `phi`. Counting rings within the old default:
  
  | grid | nlat=33 | nlat=65 | nlat=129 |
  |---|---|---|---|
  | equiangular | 0 | 0 | 0 |
  | legendre-gauss | 0 | 0 | 0 |
  | lobatto | 2 | 4 | 6 |
  | equiangular-trapezoidal | 8 | 14 | **30** | 
  
  (output latitudes whose neighborhood collapses to the single ring they sit on.)
  
  ### Change
  
  All six sites now call `torch_harmonics.quadrature.compute_theta_cutoff`, backed by
  `compute_latitude_spacing`, which takes one latitudinal grid spacing from the grid's
  actual node distribution. Which grid sets the cutoff is unchanged at every call site:
  output grid for a forward transform, input grid for a transpose one.
  
  This is the single place the heuristic now lives, and it is written to take a grid
  descriptor once the descriptor-based API lands, at which point `nlat` and `grid`
  collapse into one argument.

### Numerical behavior change
  
  **Equiangular is unaffected in practice.** Its cutoff moves by ~1e-15 (the new value
  comes back through `arccos` of the Clenshaw-Curtis nodes), and the resulting psi has a
  bit-identical sparsity pattern with values agreeing to 1e-13 in float64 — far below
  float32 resolution. `TestThetaCutoffPsiRegression` asserts exactly this.
  
  Other grids do change: lobatto widens ~21%, equiangular-trapezoidal ~5x, legendre-gauss
  narrows ~2.3%. Legendre-gauss narrowing is deliberate — the node spacing is the
  definition we want, not a floor on the old expression. Models trained on non-equiangular
  grids see a different stencil unless `theta_cutoff` is passed explicitly.
  
  Following the `truncate_sht` precedent from v0.9.0, a `UserWarning` is emitted on grids
  whose default changed. Equiangular does not warn. The message is direction-aware, since
  legendre-gauss narrows rather than under-covering.

### Tests
  
  New `tests/test_grid_assumptions.py` pins the invariants this relies on: the cutoff
  covers each grid's maximum node spacing and yields a multi-ring neighborhood; equiangular
  psi is unchanged; where each grid's nodes are equispaced; and the pole symmetry of nodes
  and weights — which is what currently makes the differing flip conventions of
  `precompute_latitudes` and `QuadratureS2` (`quadrature.py:403`) agree by accident.
  
  `test_convolution.py::test_convolution_tensor_integrity` computed its own
  `pi / (nlat_out - 1)` and passed it explicitly, so it pinned the old behavior instead of
  exercising the module default — including on its legendre-gauss rows. It now uses
  `compute_theta_cutoff`.
  
  Added lobatto and equiangular-trapezoidal rows to both the serial and distributed conv
  parameterizations. Neither grid appeared in any conv test before, so the grids whose
  default actually changed had no module-level coverage.
  
  **Test runs** (H100, NGC 26.04 / torch 2.12.0a0):
  
  | suite | result |
  |---|---|
  | full serial suite | 1590 passed, 18 skipped |
  | `test_distributed_attention.py`, 8 ranks | 68 passed × 8 |
  | `test_distributed_convolution.py`, 8 ranks | 48 passed × 8 |
  
  The distributed runs are on a real multi-rank split, not 1×1, so the new 
  non-equiangular rows exercise the polar halo and split bookkeeping.

### Performance note
  
  Not a kernel rewrite, so no benchmark table. One consequence worth flagging: on
  `"equiangular-trapezoidal"` the ~5x wider cutoff makes psi substantially denser, so
  DISCO and neighborhood attention on that grid get correspondingly slower and use more 
  memory. That is the cost of covering the poles it was previously missing. Given the name
  is misleading for a `cos(theta)`-equispaced grid, deprecating it may be worth a separate
  discussion.