### PR TITLE
Potential Security Vulnerabilities Fixes

### DIFF
--- a/Dockerfile.examples
+++ b/Dockerfile.examples
@@ -45,10 +45,21 @@ RUN pip install cartopy
 RUN pip install h5py
 
 # natten
+# Pinned to an immutable commit rather than tracking the default branch: an
+# unpinned clone resolves to whatever upstream HEAD happens to be at build time,
+# so two builds of the same Dockerfile can ship different code, and a compromise
+# of the upstream repository would land in the image unreviewed. A commit SHA is
+# used instead of the tag alone because a tag can be moved; git verifies the
+# object hash on checkout, so the SHA fixes the tree exactly.
+#
+# This SHA is v0.21.7, which is what HEAD resolved to when the pin was added, so
+# it does not change what this image builds today. Bump both values together.
+ARG NATTEN_VERSION=v0.21.7
+ARG NATTEN_COMMIT=39375ea1d2f3b1bb284315fa5f79f6ecbebb6382
 RUN cd /opt && git clone https://github.com/SHI-Labs/NATTEN natten  && \
     cd natten && \
-    make WITH_CUDA=1 \
-        CUDA_ARCH="8.0;8.6;8.7;9.0a;10.0a" \
+    git checkout ${NATTEN_COMMIT} && \
+    make CUDA_ARCH="8.0;8.6;8.7;9.0a;10.0a" \
         WORKERS=4
 
 # install torch harmonics

--- a/examples/depth/train.py
+++ b/examples/depth/train.py
@@ -491,7 +491,7 @@ def main(
             os.makedirs(exp_dir, exist_ok=True)
 
         if load_checkpoint:
-            model.load_state_dict(torch.load(os.path.join(exp_dir, "checkpoint.pt")))
+            model.load_state_dict(torch.load(os.path.join(exp_dir, "checkpoint.pt"), weights_only=True))
 
         # run the training
         if train:

--- a/examples/segmentation/train.py
+++ b/examples/segmentation/train.py
@@ -513,7 +513,7 @@ def main(
             os.makedirs(exp_dir, exist_ok=True)
 
         if load_checkpoint:
-            model.load_state_dict(torch.load(os.path.join(exp_dir, "checkpoint.pt")))
+            model.load_state_dict(torch.load(os.path.join(exp_dir, "checkpoint.pt"), weights_only=True))
 
         # run the training
         if train:

--- a/examples/shallow_water_equations/train.py
+++ b/examples/shallow_water_equations/train.py
@@ -426,7 +426,7 @@ def main(root_path, pretrain_epochs=100, finetune_epochs=10, batch_size=1, learn
             os.makedirs(exp_dir, exist_ok=True)
 
         if load_checkpoint:
-            model.load_state_dict(torch.load(os.path.join(exp_dir, "checkpoint.pt")))
+            model.load_state_dict(torch.load(os.path.join(exp_dir, "checkpoint.pt"), weights_only=True))
 
         # run the training
         if train:

--- a/torch_harmonics/disco/optimized/disco_helpers.cpp
+++ b/torch_harmonics/disco/optimized/disco_helpers.cpp
@@ -41,6 +41,11 @@ torch::Tensor preprocess_psi(const int64_t K, const int64_t Ho, torch::Tensor ke
     CHECK_CONTIGUOUS_TENSOR(col_idx);
     CHECK_CONTIGUOUS_TENSOR(val);
 
+    TORCH_CHECK(ker_idx.dtype() == torch::kInt64, "ker_idx must be int64");
+    TORCH_CHECK(row_idx.dtype() == torch::kInt64, "row_idx must be int64");
+    TORCH_CHECK(col_idx.dtype() == torch::kInt64, "col_idx must be int64");
+    TORCH_CHECK(K > 0 && Ho > 0, "K and Ho must be positive");
+
     // get the input device and make sure all tensors are on the same device
     auto device = ker_idx.device();
     TORCH_INTERNAL_ASSERT(device.type() == row_idx.device().type() && (device.type() == col_idx.device().type())
@@ -53,6 +58,27 @@ torch::Tensor preprocess_psi(const int64_t K, const int64_t Ho, torch::Tensor ke
     val = val.to(torch::kCPU);
 
     int64_t nnz = val.size(0);
+
+    // The kernel below walks all four buffers to nnz and uses ker_idx as an index into a
+    // K-sized histogram, so both the lengths and the value range have to be established
+    // here: unchecked, a short index tensor reads past its allocation and an out-of-range
+    // ker_idx writes past the histogram, corrupting the heap rather than raising.
+    TORCH_CHECK(ker_idx.dim() == 1 && row_idx.dim() == 1 && col_idx.dim() == 1 && val.dim() == 1,
+                "ker_idx, row_idx, col_idx and val must be 1-D");
+    TORCH_CHECK(ker_idx.size(0) == nnz && row_idx.size(0) == nnz && col_idx.size(0) == nnz,
+                "ker_idx, row_idx and col_idx must all have the same length as val (got ", ker_idx.size(0), ", ",
+                row_idx.size(0), ", ", col_idx.size(0), " vs nnz=", nnz, ")");
+
+    if (nnz > 0) {
+        const auto ker_min = ker_idx.min().item<int64_t>();
+        const auto ker_max = ker_idx.max().item<int64_t>();
+        TORCH_CHECK(ker_min >= 0 && ker_max < K, "ker_idx values must lie in [0, K) (got [", ker_min, ", ", ker_max,
+                    "] for K=", K, ")");
+        const auto row_min = row_idx.min().item<int64_t>();
+        const auto row_max = row_idx.max().item<int64_t>();
+        TORCH_CHECK(row_min >= 0 && row_max < Ho, "row_idx values must lie in [0, Ho) (got [", row_min, ", ", row_max,
+                    "] for Ho=", Ho, ")");
+    }
     int64_t *ker_h = ker_idx.data_ptr<int64_t>();
     int64_t *row_h = row_idx.data_ptr<int64_t>();
     int64_t *col_h = col_idx.data_ptr<int64_t>();

--- a/torch_harmonics/disco/optimized/disco_helpers.h
+++ b/torch_harmonics/disco/optimized/disco_helpers.h
@@ -86,13 +86,14 @@ void preprocess_psi_kernel(int64_t nnz, int64_t K, int64_t Ho, int64_t *ker_h, i
     for (int64_t i = 1; i < nnz; i++) {
 
         if (row_h[i - 1] == row_h[i]) continue;
-        roff_h[nrows++] = i;
 
-        if (nrows > Ho * K) {
-            fprintf(stderr, "%s:%d: error, found more rows in the K COOs than Ho*K (%ld)\n", __FILE__, __LINE__,
-                    int64_t(Ho) * K);
-            exit(EXIT_FAILURE);
-        }
+        // Checked before the store, not after: roff_h holds Ho*K+1 entries, so writing at
+        // index Ho*K is the last legal slot and anything beyond it is out of bounds. Raise
+        // rather than exit() -- this runs inside a Python extension, and terminating the
+        // interpreter over malformed input takes the caller's process down with it.
+        TORCH_CHECK(nrows <= Ho * K, "found more rows in the K COOs than Ho*K (", int64_t(Ho) * K,
+                    "); row_idx is expected to be grouped by (ker_idx, row_idx)");
+        roff_h[nrows++] = i;
     }
     roff_h[nrows] = nnz;
 


### PR DESCRIPTION
Three findings from a security scan. Two are hardening with no behaviour change; the third fixes a genuine memory-safety bug.
  
  weights_only=True for example checkpoints — examples/{depth,segmentation,shallow_water_equations}/train.py. Each script saves model.state_dict(), so the stricter loader accepts existing
  checkpoints unchanged and --resume still works. Note this is already the default on torch>=2.6, which pyproject.toml requires, so the flag is explicit rather than newly protective.
  
  Pin NATTEN in Dockerfile.examples to 39375ea1d2f3b1bb284315fa5f79f6ecbebb6382 (v0.21.7) instead of cloning the default branch. A SHA rather than the tag alone, since a tag can be moved;
  git verifies the object hash on checkout. That SHA is what upstream HEAD resolved to when the pin was added, so the image builds identically today. Also dropped make WITH_CUDA=1 —
  NATTEN's Makefile never reads that variable; CUDA_ARCH is what selects the CUDA build.
  
  Validate index tensors in preprocess_psi — disco_helpers.{cpp,h}. Koff[ker_h[i]]++ indexed a K-sized heap buffer with unchecked values, and nnz was taken from val.size(0) while the
  index tensors' lengths were never checked. It now validates dtype, K, Ho > 0, matching 1-D lengths, and ker_idx ∈ [0,K), row_idx ∈ [0,Ho) — mirroring what the sibling pack_psi_dense
  already did. The Ho*K overflow path also called exit(EXIT_FAILURE), terminating the host interpreter from inside a Python extension; it now raises via TORCH_CHECK.
  
  Testing: pytest tests/test_convolution.py tests/test_distributed_convolution.py — every DiscreteContinuousConvS2 construction goes through preprocess_psi, so a too-strict check surfaces
  there. Before the fix, crafted inputs produced SIGSEGV, SIGBUS, and malloc(): invalid next size (heap metadata corruption); after, each raises a RuntimeError, and valid plus empty
  (nnz=0) inputs are unaffected.
  
  On severity: the preprocess_psi issue crosses no trust boundary. It is only called from __init__ with indices computed by _precompute_convolution_tensor_s2, never with deserialized or
  user-supplied data, and anyone able to call it with crafted tensors already executes Python in the process. Worth fixing as robustness — a caller mistake should raise rather than
  corrupt the heap — but not an exploitable vulnerability.
