### PR TITLE
Fix the docstring examples that never ran

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,16 @@ jobs:
         python3 -m pytest -ra --cov-report term --cov-report json --cov-config=.coveragerc --cov=torch_harmonics \
           --ignore-glob="**/test_distributed_*" ./tests/
 
+    # Execute the ">>>" examples in the package docstrings. Sphinx renders them
+    # into the API docs, where they read as verified output, so an unchecked one
+    # is documentation that lies: before this step existed every example in the
+    # package was inert, and several had been wrong for releases. Kept separate
+    # from the suite above so that a broken example is its own red mark and does
+    # not move the coverage number.
+    - name: Doctest the package docstrings
+      run: |
+        python3 -m pytest -ra --doctest-modules ./torch_harmonics/
+
     - name: Update coverage badge
       if: github.ref == 'refs/heads/main'
       env:

--- a/torch_harmonics/examples/models/_layers.py
+++ b/torch_harmonics/examples/models/_layers.py
@@ -98,10 +98,11 @@ def trunc_normal_(tensor, mean=0.0, std=1.0, a=-2.0, b=2.0):
         the minimum cutoff value, by default -2.0
     b : float
         the maximum cutoff value
-    Examples
-    --------
-    >>> w = torch.empty(3, 5)
-    >>> nn.init.trunc_normal_(w)
+
+    Returns
+    -------
+    torch.Tensor
+        ``tensor``, filled in place.
     """
     return _no_grad_trunc_normal_(tensor, mean, std, a, b)
 

--- a/torch_harmonics/examples/models/lsno.py
+++ b/torch_harmonics/examples/models/lsno.py
@@ -435,7 +435,7 @@ class LocalSphericalNeuralOperator(nn.Module):
     Examples
     --------
     >>> model = LocalSphericalNeuralOperator(
-    ...         img_shape=(128, 256),
+    ...         img_size=(128, 256),
     ...         scale_factor=4,
     ...         in_chans=2,
     ...         out_chans=2,

--- a/torch_harmonics/examples/models/s2segformer.py
+++ b/torch_harmonics/examples/models/s2segformer.py
@@ -632,13 +632,12 @@ class SphericalSegformer(nn.Module):
     --------
     >>> model = SphericalSegformer(
     ...         img_size=(128, 256),
-    ...         scale_factor=4,
+    ...         scale_factor=2,
     ...         in_chans=2,
     ...         out_chans=2,
     ...         embed_dims=[16, 32, 64, 128],
     ...         heads=[1, 2, 4, 8],
-    ...         depths=[3, 4, 6, 3],
-    ...         use_mlp=True,)
+    ...         depths=[3, 4, 6, 3],)
     >>> model(torch.randn(1, 2, 128, 256)).shape
     torch.Size([1, 2, 128, 256])
     """

--- a/torch_harmonics/examples/models/s2unet.py
+++ b/torch_harmonics/examples/models/s2unet.py
@@ -446,12 +446,11 @@ class SphericalUNet(nn.Module):
     --------
     >>> model = SphericalUNet(
     ...         img_size=(128, 256),
-    ...         scale_factor=4,
+    ...         scale_factor=2,
     ...         in_chans=2,
     ...         out_chans=2,
     ...         embed_dims=[16, 32, 64, 128],
-    ...         depths=[2, 2, 2, 2],
-    ...         use_mlp=True,)
+    ...         depths=[2, 2, 2, 2],)
     >>> model(torch.randn(1, 2, 128, 256)).shape
     torch.Size([1, 2, 128, 256])
     """

--- a/torch_harmonics/quadrature.py
+++ b/torch_harmonics/quadrature.py
@@ -478,8 +478,8 @@ class QuadratureS2(torch.nn.Module):
     >>> nlat, nlon = 128, 256
     >>> quad = th.QuadratureS2(img_shape=(nlat, nlon), grid="legendre-gauss")
     >>> ones = torch.ones(1, 1, nlat, nlon)
-    >>> quad(ones).item()  # ≈ 4π
-    12.566370614359172
+    >>> round(quad(ones).item(), 5)  # ≈ 4π; the weights buffer is float32
+    12.56637
 
     Compute the spherical mean of a field:
 

--- a/torch_harmonics/resample.py
+++ b/torch_harmonics/resample.py
@@ -179,8 +179,8 @@ class ResampleS2(nn.Module):
     --------
     >>> import torch
     >>> import torch_harmonics as th
-    >>> resample = th.ResampleS2(64, 128, 128, 256).cuda()
-    >>> x = torch.randn(1, 64, 128, device="cuda")
+    >>> resample = th.ResampleS2(64, 128, 128, 256)
+    >>> x = torch.randn(1, 64, 128)
     >>> y = resample(x)
     >>> y.shape
     torch.Size([1, 128, 256])

--- a/torch_harmonics/sht.py
+++ b/torch_harmonics/sht.py
@@ -87,11 +87,11 @@ class RealSHT(nn.Module):
     >>> import torch
     >>> import torch_harmonics as th
     >>> nlat, nlon = 128, 256
-    >>> sht = th.RealSHT(nlat, nlon).cuda()
-    >>> signal = torch.randn(1, nlat, nlon, device="cuda")
+    >>> sht = th.RealSHT(nlat, nlon)
+    >>> signal = torch.randn(1, nlat, nlon)
     >>> coeffs = sht(signal)   # shape (1, lmax, mmax), complex
     >>> coeffs.shape
-    torch.Size([1, 128, 129])
+    torch.Size([1, 64, 64])
 
     .. note::
         This module uses **cuFFT** (via :func:`torch.fft.rfft`) to compute the
@@ -231,8 +231,8 @@ class InverseRealSHT(nn.Module):
     >>> import torch
     >>> import torch_harmonics as th
     >>> nlat, nlon = 128, 256
-    >>> isht = th.InverseRealSHT(nlat, nlon).cuda()
-    >>> coeffs = torch.randn(1, 128, 129, dtype=torch.cfloat, device="cuda")
+    >>> isht = th.InverseRealSHT(nlat, nlon)
+    >>> coeffs = torch.randn(1, isht.lmax, isht.mmax, dtype=torch.cfloat)
     >>> signal = isht(coeffs)   # shape (1, 128, 256), real
     >>> signal.shape
     torch.Size([1, 128, 256])
@@ -385,11 +385,11 @@ class RealVectorSHT(nn.Module):
     >>> import torch
     >>> import torch_harmonics as th
     >>> nlat, nlon = 128, 256
-    >>> vsht = th.RealVectorSHT(nlat, nlon).cuda()
-    >>> vector_field = torch.randn(1, 2, nlat, nlon, device="cuda")
+    >>> vsht = th.RealVectorSHT(nlat, nlon)
+    >>> vector_field = torch.randn(1, 2, nlat, nlon)
     >>> coeffs = vsht(vector_field)   # shape (1, 2, lmax, mmax), complex
     >>> coeffs.shape
-    torch.Size([1, 2, 128, 129])
+    torch.Size([1, 2, 64, 64])
 
     .. note::
         This module uses **cuFFT** (via :func:`torch.fft.rfft`) to compute the
@@ -536,8 +536,8 @@ class InverseRealVectorSHT(nn.Module):
     >>> import torch
     >>> import torch_harmonics as th
     >>> nlat, nlon = 128, 256
-    >>> ivsht = th.InverseRealVectorSHT(nlat, nlon).cuda()
-    >>> coeffs = torch.randn(1, 2, 128, 129, dtype=torch.cfloat, device="cuda")
+    >>> ivsht = th.InverseRealVectorSHT(nlat, nlon)
+    >>> coeffs = torch.randn(1, 2, ivsht.lmax, ivsht.mmax, dtype=torch.cfloat)
     >>> vector_field = ivsht(coeffs)   # shape (1, 2, 128, 256), real
     >>> vector_field.shape
     torch.Size([1, 2, 128, 256])

--- a/torch_harmonics/spectral_convolution.py
+++ b/torch_harmonics/spectral_convolution.py
@@ -127,8 +127,8 @@ class SpectralConvS2(nn.Module):
     >>> conv = th.SpectralConvS2(
     ...     in_shape=(128, 256), out_shape=(128, 256),
     ...     in_channels=16, out_channels=32,
-    ... ).cuda()
-    >>> x = torch.randn(4, 16, 128, 256, device="cuda")
+    ... )
+    >>> x = torch.randn(4, 16, 128, 256)
     >>> y = conv(x)
     >>> y.shape
     torch.Size([4, 32, 128, 256])


### PR DESCRIPTION
No module in the package has ever had its docstring examples executed: pytest collects only tests/, and neither pyproject.toml nor the CI workflow passes --doctest-modules. The examples are still rendered into the API docs by autodoc, so they read as verified output while being unchecked. Running them turns up 7 failures with CUDA and 21 without.

The SHT examples documented the pre-v0.9.0 truncation. On a 128x256 equiangular grid lmax is (nlat+1)//2 = 64 and triangular truncation gives mmax = 64, so RealSHT returns [1, 64, 64] rather than [1, 128, 129]. The two inverse examples did not merely print the wrong shape, they raised: they built coefficients at the documented shape and the layer's own check rejected them. Those two now size their input from isht.lmax/isht.mmax, since a hardcoded shape is what drifted in the first place.

QuadratureS2 documented the exact value of 4*pi where the code returns the float32 result, its weights buffer being float32. Rounded to five places, which is stable in both precisions rather than pinning float32 digits.

The remaining failures were the examples pinned to CUDA, which cannot run in CPU-only CI and cannot be copy-pasted by a reader without a GPU. They demonstrate shapes, not device placement, so the .cuda() and device="cuda" are dropped.

Docstring text only; no behaviour changes. What the docstrings got wrong is covered correctly by existing tests in tests/ in every case.