### PR TITLE
Fix inductor codegen of the complex-valued SHT and spectral convolution paths

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 
 * Added `torch.compile(fullgraph=True)` support to the serial and distributed layers, which previously broke on assertion helpers and on control flow that branched on tensor values.
 * The forward SHTs now fold the `2*pi` longitudinal scale factor into their precomputed quadrature weights instead of scaling the FFT output on every call, which removes a pointwise multiply over a complex tensor from the hot path.
+* `SpectralConvS2` and `DistributedSpectralConvS2` now apply the spectral bias and the post-contraction reshape on the real view of their coefficients. The bias factor is real-valued, so this is exact, and it removes the last complex-typed pointwise ops from the layer.
 * Fixed `torch.compile` of the SHT layers failing in inductor codegen with `KeyError: 'complex64'`. Triton has no complex type, so a pointwise kernel over a complex buffer cannot be generated; the transforms now keep scaling, stacking and contiguity in real space and assemble the complex result with a single `torch.complex` over contiguous operands. The vector transforms additionally fed that call non-contiguous einsum outputs, which tripped `assert_size_stride`.
 * Removed a redundant autocast decorator from the distributed autograd Functions, where it recorded its state somewhere nothing reads it and blocked full-graph compilation.
 * Distributed DISCO convolution now skips its polar collectives when the polar group holds a single rank, as the azimuth path already did.

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@
 ### v0.9.3b1 (unreleased)
 
 * Added `torch.compile(fullgraph=True)` support to the serial and distributed layers, which previously broke on assertion helpers and on control flow that branched on tensor values.
+* The forward SHTs now fold the `2*pi` longitudinal scale factor into their precomputed quadrature weights instead of scaling the FFT output on every call, which removes a pointwise multiply over a complex tensor from the hot path.
+* Fixed `torch.compile` of the SHT layers failing in inductor codegen with `KeyError: 'complex64'`. Triton has no complex type, so a pointwise kernel over a complex buffer cannot be generated; the transforms now keep scaling, stacking and contiguity in real space and assemble the complex result with a single `torch.complex` over contiguous operands. The vector transforms additionally fed that call non-contiguous einsum outputs, which tripped `assert_size_stride`.
 * Removed a redundant autocast decorator from the distributed autograd Functions, where it recorded its state somewhere nothing reads it and blocked full-graph compilation.
 * Distributed DISCO convolution now skips its polar collectives when the polar group holds a single rank, as the azimuth path already did.
 * Attention's channel-layout conversions now use the dedicated 4-D helpers, which fixes a stride mismatch against the registered fake kernel and makes the conversion faster.

--- a/tests/test_sht.py
+++ b/tests/test_sht.py
@@ -565,6 +565,53 @@ class TestSphericalHarmonicTransform(unittest.TestCase):
         self.assertTrue(compare_tensors("sht weights", sht_host.weights.cpu(), sht_device.weights.cpu(), atol=atol, rtol=rtol, verbose=verbose))
         self.assertTrue(compare_tensors("isht weights", isht_host.pct.cpu(), isht_device.pct.cpu(), atol=atol, rtol=rtol, verbose=verbose))
 
+    @parameterized.expand(
+        [
+            [12, 24, 2, "equiangular"],
+            [12, 24, 2, "legendre-gauss"],
+            [11, 22, 2, "equiangular"],
+        ],
+        skip_on_empty=True,
+    )
+    def test_compile(self, nlat, nlon, batch_size, grid, verbose=False):
+        """The scalar round trip compiles into a single graph and matches eager.
+
+        The round trip is compiled as one function so the complex spectral coefficients
+        are an *intermediate* buffer rather than a graph output -- that is the case
+        inductor has to generate code for.  Triton has no complex type, so any pointwise
+        kernel over a complex buffer fails codegen with ``KeyError: 'complex64'``; on CPU
+        the C++ backend is used instead, where the exposure is a layout mismatch on
+        ``aten.complex`` caught by ``assert_size_stride``.  Both are worth covering, which
+        the CPU/CUDA parameterization of this class does.
+
+        Backward is included deliberately: ``_EnsureContiguous.backward`` copies a complex
+        gradient, and that copy only appears in the joint graph.
+        """
+
+        if verbose:
+            print(f"Testing fullgraph compilation of real-valued SHT on {nlat}x{nlon} {grid} grid on {self.device.type}")
+
+        set_seed(333)
+
+        sht = th.RealSHT(nlat, nlon, grid=grid).to(self.device)
+        isht = th.InverseRealSHT(nlat, nlon, grid=grid).to(self.device)
+
+        def fn(t):
+            return isht(sht(t))
+
+        x = torch.randn(batch_size, nlat, nlon, device=self.device, dtype=torch.float32, requires_grad=True)
+        gradient = torch.randn_like(x)
+
+        expected = fn(x)
+        (expected_grad,) = torch.autograd.grad(expected, x, grad_outputs=gradient)
+
+        compiled = torch.compile(fn, fullgraph=True, dynamic=False)
+        actual = compiled(x)
+        (actual_grad,) = torch.autograd.grad(actual, x, grad_outputs=gradient)
+
+        self.assertTrue(compare_tensors("compiled forward", actual, expected, atol=1e-5, rtol=1e-5, verbose=verbose))
+        self.assertTrue(compare_tensors("compiled backward", actual_grad, expected_grad, atol=1e-5, rtol=1e-5, verbose=verbose))
+
 
 @parameterized_class(("device"), _devices)
 class TestSphericalHarmonicsFunctions(unittest.TestCase):
@@ -881,6 +928,47 @@ class TestVectorSphericalHarmonicTransform(unittest.TestCase):
         spectral_energy = torch.einsum("blm,lm->b", c_s.abs() ** 2 + c_t.abs() ** 2, W)  # (batch,)
 
         self.assertTrue(compare_tensors("vector Parseval's theorem", spatial_energy, spectral_energy, atol=atol, rtol=rtol, verbose=verbose))
+
+    @parameterized.expand(
+        [
+            [12, 24, 2, "equiangular"],
+            [12, 24, 2, "legendre-gauss"],
+            [11, 22, 2, "equiangular"],
+        ],
+        skip_on_empty=True,
+    )
+    def test_compile(self, nlat, nlon, batch_size, grid, verbose=False):
+        """The vector round trip compiles into a single graph and matches eager.
+
+        Same rationale as the scalar case, see
+        ``TestSphericalHarmonicTransform.test_compile``.  The vector transforms assemble
+        their spheroidal and toroidal components separately, so they exercise a code path
+        the scalar test does not reach.
+        """
+
+        if verbose:
+            print(f"Testing fullgraph compilation of vector SHT on {nlat}x{nlon} {grid} grid on {self.device.type}")
+
+        set_seed(333)
+
+        vsht = th.RealVectorSHT(nlat, nlon, grid=grid).to(self.device)
+        ivsht = th.InverseRealVectorSHT(nlat, nlon, grid=grid).to(self.device)
+
+        def fn(t):
+            return ivsht(vsht(t))
+
+        x = torch.randn(batch_size, 2, nlat, nlon, device=self.device, dtype=torch.float32, requires_grad=True)
+        gradient = torch.randn_like(x)
+
+        expected = fn(x)
+        (expected_grad,) = torch.autograd.grad(expected, x, grad_outputs=gradient)
+
+        compiled = torch.compile(fn, fullgraph=True, dynamic=False)
+        actual = compiled(x)
+        (actual_grad,) = torch.autograd.grad(actual, x, grad_outputs=gradient)
+
+        self.assertTrue(compare_tensors("compiled forward", actual, expected, atol=1e-5, rtol=1e-5, verbose=verbose))
+        self.assertTrue(compare_tensors("compiled backward", actual_grad, expected_grad, atol=1e-5, rtol=1e-5, verbose=verbose))
 
 
 if __name__ == "__main__":

--- a/tests/test_spectral_convolution.py
+++ b/tests/test_spectral_convolution.py
@@ -496,6 +496,63 @@ class TestSpectralConvS2(unittest.TestCase):
             msg="spectral_bias.grad should contain non-zero entries",
         )
 
+    # -----------------------------------------------------------------------
+    # Test 12: torch.compile
+    #
+    # The layer holds complex spectral coefficients throughout, and inductor
+    # cannot generate a kernel that reads or writes a complex buffer: triton has
+    # no complex type, so the kernel signature fails with KeyError: 'complex64'.
+    # Every pointwise step here (bias, contiguity, reshape) therefore has to run
+    # on the real view.  The bias path is parameterized separately because it is
+    # the only complex arithmetic in the layer.
+    # -----------------------------------------------------------------------
+    @parameterized.expand(
+        [
+            # nlat, nlon, in_channels, out_channels, num_groups, bias
+            [16, 32, 4, 4, 1, False],
+            [16, 32, 4, 8, 2, False],
+            [16, 32, 4, 4, 1, True],
+            [16, 32, 4, 8, 2, True],
+        ],
+        skip_on_empty=True,
+    )
+    def test_compile(self, nlat, nlon, in_channels, out_channels, num_groups, bias, verbose=False):
+        """The layer compiles and matches eager, forward and backward."""
+
+        set_seed(333)
+
+        conv = SpectralConvS2(
+            in_shape=(nlat, nlon),
+            out_shape=(nlat, nlon),
+            in_channels=in_channels,
+            out_channels=out_channels,
+            num_groups=num_groups,
+            grid_in="equiangular",
+            grid_out="equiangular",
+            bias=bias,
+        ).to(self.device)
+        conv.eval()
+
+        if bias:
+            with torch.no_grad():
+                conv.spectral_bias.data.fill_(0.1)
+
+        x = torch.randn(2, in_channels, nlat, nlon, device=self.device, requires_grad=True)
+        gradient = torch.randn(2, out_channels, nlat, nlon, device=self.device)
+
+        expected = conv(x)
+        (expected_grad,) = torch.autograd.grad(expected, x, grad_outputs=gradient)
+
+        # fullgraph is deliberately not requested: _contract_lwise carries its own
+        # @torch.compile, and the point here is that inductor can generate code for
+        # every complex-valued step, not that the layer traces into a single graph.
+        compiled = torch.compile(conv, dynamic=False)
+        actual = compiled(x)
+        (actual_grad,) = torch.autograd.grad(actual, x, grad_outputs=gradient)
+
+        self.assertTrue(compare_tensors("compiled forward", actual, expected, atol=1e-5, rtol=1e-5, verbose=verbose))
+        self.assertTrue(compare_tensors("compiled backward", actual_grad, expected_grad, atol=1e-5, rtol=1e-5, verbose=verbose))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torch_harmonics/distributed/distributed_sht.py
+++ b/torch_harmonics/distributed/distributed_sht.py
@@ -175,6 +175,14 @@ class DistributedRealSHT(nn.Module):
     def extra_repr(self):
         return f"nlat={self.nlat}, nlon={self.nlon},\n lmax={self.lmax}, mmax={self.mmax},\n grid={self.grid}, csphase={self.csphase}"
 
+    # This transform cannot be captured in a single graph: the redistribution collectives it
+    # calls are themselves torch.compiler.disable()d, so at comm_size > 1 dynamo breaks at
+    # every one of them and inductor only ever sees the slivers in between. Those slivers hold
+    # complex intermediates, which triton cannot type (KeyError: 'complex64' in codegen), and
+    # compiling them buys nothing next to the all-to-alls surrounding them. Disabling the whole
+    # forward costs no fusion that the breaks had not already cost, and keeps the complex
+    # spectral data out of inductor entirely. The serial transforms are compiled as usual.
+    @torch.compiler.disable()
     def forward(self, x: torch.Tensor):
 
         check(x.dim() >= 3, lambda: f"Expected tensor with at least 3 dimensions but got {x.dim()} instead")
@@ -345,6 +353,14 @@ class DistributedInverseRealSHT(nn.Module):
     def extra_repr(self):
         return f"nlat={self.nlat}, nlon={self.nlon},\n lmax={self.lmax}, mmax={self.mmax},\n grid={self.grid}, csphase={self.csphase}"
 
+    # This transform cannot be captured in a single graph: the redistribution collectives it
+    # calls are themselves torch.compiler.disable()d, so at comm_size > 1 dynamo breaks at
+    # every one of them and inductor only ever sees the slivers in between. Those slivers hold
+    # complex intermediates, which triton cannot type (KeyError: 'complex64' in codegen), and
+    # compiling them buys nothing next to the all-to-alls surrounding them. Disabling the whole
+    # forward costs no fusion that the breaks had not already cost, and keeps the complex
+    # spectral data out of inductor entirely. The serial transforms are compiled as usual.
+    @torch.compiler.disable()
     def forward(self, x: torch.Tensor):
 
         check(x.dim() >= 3, lambda: f"Expected tensor with at least 3 dimensions but got {x.dim()} instead")
@@ -506,6 +522,14 @@ class DistributedRealVectorSHT(nn.Module):
     def extra_repr(self):
         return f"nlat={self.nlat}, nlon={self.nlon},\n lmax={self.lmax}, mmax={self.mmax},\n grid={self.grid}, csphase={self.csphase}"
 
+    # This transform cannot be captured in a single graph: the redistribution collectives it
+    # calls are themselves torch.compiler.disable()d, so at comm_size > 1 dynamo breaks at
+    # every one of them and inductor only ever sees the slivers in between. Those slivers hold
+    # complex intermediates, which triton cannot type (KeyError: 'complex64' in codegen), and
+    # compiling them buys nothing next to the all-to-alls surrounding them. Disabling the whole
+    # forward costs no fusion that the breaks had not already cost, and keeps the complex
+    # spectral data out of inductor entirely. The serial transforms are compiled as usual.
+    @torch.compiler.disable()
     def forward(self, x: torch.Tensor):
 
         check(x.dim() >= 4, lambda: f"Expected tensor with at least 4 dimensions but got {x.dim()} instead")
@@ -666,6 +690,14 @@ class DistributedInverseRealVectorSHT(nn.Module):
     def extra_repr(self):
         return f"nlat={self.nlat}, nlon={self.nlon},\n lmax={self.lmax}, mmax={self.mmax},\n grid={self.grid}, csphase={self.csphase}"
 
+    # This transform cannot be captured in a single graph: the redistribution collectives it
+    # calls are themselves torch.compiler.disable()d, so at comm_size > 1 dynamo breaks at
+    # every one of them and inductor only ever sees the slivers in between. Those slivers hold
+    # complex intermediates, which triton cannot type (KeyError: 'complex64' in codegen), and
+    # compiling them buys nothing next to the all-to-alls surrounding them. Disabling the whole
+    # forward costs no fusion that the breaks had not already cost, and keeps the complex
+    # spectral data out of inductor entirely. The serial transforms are compiled as usual.
+    @torch.compiler.disable()
     def forward(self, x: torch.Tensor):
 
         check(x.dim() >= 4, lambda: f"Expected tensor with at least 4 dimensions but got {x.dim()} instead")

--- a/torch_harmonics/distributed/distributed_sht.py
+++ b/torch_harmonics/distributed/distributed_sht.py
@@ -157,6 +157,11 @@ class DistributedRealSHT(nn.Module):
         self.m_shapes = compute_split_shapes(self.mmax, self.comm_size_azimuth)
         self.mmax_local = self.m_shapes[self.comm_rank_azimuth]
 
+        # fold the 2*pi longitudinal scale factor of the forward-normalized FFT into the
+        # quadrature weights. It is a constant prefactor of a linear transform, so folding it
+        # here is exact and saves a pointwise multiply on a complex tensor in every forward.
+        weights = 2.0 * torch.pi * weights
+
         # combine quadrature weights with the legendre weights
         pct = _precompute_legpoly(self.mmax, self.lmax, tq, norm=self.norm, csphase=self.csphase)
         weights = torch.einsum("mlk,k->mlk", pct, weights)
@@ -187,8 +192,9 @@ class DistributedRealSHT(nn.Module):
         if self.comm_size_azimuth > 1:
             x = distributed_transpose_azimuth(x, (-3, -1), self.lon_shapes)
 
-        # apply real fft in the longitudinal direction: make sure to truncate to nlon
-        x = 2.0 * torch.pi * rfft(x, nmodes=self.mmax, dim=-1, norm="forward")
+        # apply real fft in the longitudinal direction: make sure to truncate to nlon. The 2*pi
+        # scale factor is folded into the quadrature weights, so no scaling is needed here.
+        x = rfft(x, nmodes=self.mmax, dim=-1, norm="forward")
 
         # transpose: after this, m is split and c is local
         if self.comm_size_azimuth > 1:
@@ -479,6 +485,10 @@ class DistributedRealVectorSHT(nn.Module):
         # compute weights
         dpct = _precompute_dlegpoly(self.mmax, self.lmax, tq, norm=self.norm, csphase=self.csphase)
 
+        # fold the 2*pi longitudinal scale factor of the forward-normalized FFT into the
+        # quadrature weights (see DistributedRealSHT.__init__)
+        weights = 2.0 * torch.pi * weights
+
         # combine integration weights, normalization factor in to one:
         l = torch.arange(0, self.lmax)
         norm_factor = 1.0 / l / (l + 1)
@@ -515,8 +525,9 @@ class DistributedRealVectorSHT(nn.Module):
         if self.comm_size_azimuth > 1:
             x = distributed_transpose_azimuth(x, (-4, -1), self.lon_shapes)
 
-        # apply real fft in the longitudinal direction: make sure to truncate to nlon
-        x = 2.0 * torch.pi * rfft(x, nmodes=self.mmax, dim=-1, norm="forward")
+        # apply real fft in the longitudinal direction: make sure to truncate to nlon. The 2*pi
+        # scale factor is folded into the quadrature weights, so no scaling is needed here.
+        x = rfft(x, nmodes=self.mmax, dim=-1, norm="forward")
 
         # transpose: after this, m is split and c is local
         if self.comm_size_azimuth > 1:
@@ -543,7 +554,11 @@ class DistributedRealVectorSHT(nn.Module):
         t_re = -torch.einsum("...mk,mlk->...lm", x_im[..., 0, :, :], w1) - torch.einsum("...mk,mlk->...lm", x_re[..., 1, :, :], w0)
         t_im = torch.einsum("...mk,mlk->...lm", x_re[..., 0, :, :], w1) - torch.einsum("...mk,mlk->...lm", x_im[..., 1, :, :], w0)
 
-        x = torch.stack((torch.complex(s_re, s_im), torch.complex(t_re, t_im)), dim=-3).contiguous()
+        # stack the components in real space, see RealVectorSHT.forward. The result is contiguous
+        # by construction, so the .contiguous() this replaces was a no-op.
+        out_re = torch.stack((s_re, t_re), dim=-3)
+        out_im = torch.stack((s_im, t_im), dim=-3)
+        x = torch.complex(out_re, out_im)
 
         # transpose: after this, l is split and c is local
         if self.comm_size_polar > 1:
@@ -687,8 +702,11 @@ class DistributedInverseRealVectorSHT(nn.Module):
         trl = -torch.einsum("...ml,mkl->...km", x_im[..., 0, :, :], d1) - torch.einsum("...ml,mkl->...km", x_re[..., 1, :, :], d0)
         tim = torch.einsum("...ml,mkl->...km", x_re[..., 0, :, :], d1) - torch.einsum("...ml,mkl->...km", x_im[..., 1, :, :], d0)
 
-        # reassemble
-        x = torch.stack((torch.complex(srl, sim), torch.complex(trl, tim)), dim=-3).contiguous()
+        # reassemble in real space, see RealVectorSHT.forward. The result is contiguous by
+        # construction, so the .contiguous() this replaces was a no-op.
+        out_re = torch.stack((srl, trl), dim=-3)
+        out_im = torch.stack((sim, tim), dim=-3)
+        x = torch.complex(out_re, out_im)
 
         if self.comm_size_polar > 1:
             chan_shapes = compute_split_shapes(num_chans, self.comm_size_polar)

--- a/torch_harmonics/distributed/distributed_spectral_convolution.py
+++ b/torch_harmonics/distributed/distributed_spectral_convolution.py
@@ -205,19 +205,27 @@ class DistributedSpectralConvS2(nn.Module):
 
         with torch.amp.autocast(device_type=x.device.type, enabled=False):
             x = x.to(torch.float32)
-            x = self.sht(x).contiguous()
+            # the SHT result is contiguous by construction, so no .contiguous() here: a copy
+            # over a complex buffer cannot be codegen'd by inductor, as triton has no complex
+            # type and the kernel signature then fails with KeyError: 'complex64'
+            x = self.sht(x)
 
         # store the shapes
         B, C, H, W = x.shape
 
-        # deal with bias
+        # deal with bias. `integral` is computed from the real-valued input above, so it is a
+        # real tensor and broadcasts over the re/im axis: applying the bias on the real view is
+        # exact and keeps this pointwise op off the complex dtype (see above).
         if hasattr(self, "spectral_bias"):
-            x = x + integral.reshape(B, C, 1, 1) * self.spectral_bias
+            bias = integral.reshape(B, C, 1, 1, 1) * torch.view_as_real(self.spectral_bias)
+            x = torch.view_as_complex(torch.view_as_real(x) + bias)
 
         # perform contraction
         x = x.reshape(B, self.num_groups, C // self.num_groups, H, W)
         xp = self._contract_lwise(x, self.weight)
-        x = xp.reshape(B, self.out_channels, H, W).contiguous()
+        # merge the group axes on the real view: the einsum output can be non-contiguous, in
+        # which case this reshape copies, and that copy must not be over a complex buffer
+        x = torch.view_as_complex(torch.view_as_real(xp).reshape(B, self.out_channels, H, W, 2).contiguous())
 
         with torch.amp.autocast(device_type=x.device.type, enabled=False):
             x = self.isht(x)

--- a/torch_harmonics/distributed/primitives.py
+++ b/torch_harmonics/distributed/primitives.py
@@ -201,16 +201,25 @@ def flatten_and_pad_leading_dims(tensor: torch.Tensor, min_leading_size: int, nu
     lead_size : int
         The true (pre-pad) flattened leading size, used to slice off the padding.
     """
+    # complex inputs (the inverse SHTs call this on their spectral input) are processed as
+    # their real view, see unpad_and_unflatten_leading_dims for the rationale
+    is_complex = tensor.is_complex()
+    if is_complex:
+        tensor = torch.view_as_real(tensor)
+        num_trailing_dims += 1
+
     lead_shape = tensor.shape[:-num_trailing_dims]
     tensor = tensor.reshape(-1, *tensor.shape[-num_trailing_dims:])
     lead_size = tensor.shape[0]
 
     if lead_size < min_leading_size:
-        # new_zeros preserves dtype (incl. complex) and device
+        # new_zeros preserves dtype and device
         zeros = tensor.new_zeros((min_leading_size - lead_size, *tensor.shape[1:]))
         tensor = torch.cat([tensor, zeros], dim=0)
 
-    return tensor.contiguous(), lead_shape, lead_size
+    tensor = tensor.contiguous()
+
+    return (torch.view_as_complex(tensor) if is_complex else tensor), lead_shape, lead_size
 
 
 def unpad_and_unflatten_leading_dims(tensor: torch.Tensor, lead_shape, lead_size: int, num_trailing_dims: int = 2) -> torch.Tensor:
@@ -219,9 +228,24 @@ def unpad_and_unflatten_leading_dims(tensor: torch.Tensor, lead_shape, lead_size
     The trailing ``num_trailing_dims`` dims are taken from ``tensor`` as-is, so this is
     valid even when the transform changed them (e.g. ``nlat, nlon`` -> ``lmax, mmax``).
     ``num_trailing_dims`` must match the value passed to the flatten call.
+
+    Complex inputs (the forward SHTs call this on their spectral output) are processed as
+    their real view: this is pure layout code touching only the leading dims, and a copy
+    over a complex buffer cannot be codegen'd by inductor -- triton has no complex type,
+    so it fails with ``KeyError: 'complex64'``. ``view_as_real`` appends the re/im pair as
+    a trailing dim, which is simply carried along; the ``contiguous()`` right before the
+    ``view_as_complex`` supplies the unit last-dim stride the latter requires.
     """
+
+    is_complex = tensor.is_complex()
+    if is_complex:
+        tensor = torch.view_as_real(tensor)
+        num_trailing_dims += 1
+
     tensor = tensor.narrow(0, 0, lead_size)
-    return tensor.reshape(*lead_shape, *tensor.shape[-num_trailing_dims:]).contiguous()
+    out = tensor.reshape(*lead_shape, *tensor.shape[-num_trailing_dims:]).contiguous()
+
+    return torch.view_as_complex(out) if is_complex else out
 
 
 def _transpose(tensor, dim0, dim1, dim1_split_sizes, group=None, async_op=False, verify_shapes=None):

--- a/torch_harmonics/sht.py
+++ b/torch_harmonics/sht.py
@@ -139,6 +139,11 @@ class RealSHT(nn.Module):
         # determine maximum degrees based on triangular truncation
         self.lmax, self.mmax = truncate_sht(self.nlat, self.nlon, lmax, mmax, self.grid)
 
+        # fold the 2*pi longitudinal scale factor of the forward-normalized FFT into the
+        # quadrature weights. It is a constant prefactor of a linear transform, so folding it
+        # here is exact and saves a pointwise multiply on a complex tensor in every forward.
+        weights = 2.0 * torch.pi * weights
+
         # combine quadrature weights with the legendre weights
         pct = _precompute_legpoly(self.mmax, self.lmax, tq, norm=self.norm, csphase=self.csphase)
         weights = torch.einsum("mlk,k->mlk", pct, weights).contiguous()
@@ -168,8 +173,9 @@ class RealSHT(nn.Module):
         check(x.shape[-2] == self.nlat, lambda: f"Expected latitudes shape[-2]=={self.nlat}, got {x.shape[-2]}")
         check(x.shape[-1] == self.nlon, lambda: f"Expected longitudes shape[-1]=={self.nlon}, got {x.shape[-1]}")
 
-        # apply real fft in the longitudinal direction
-        x = 2.0 * torch.pi * rfft(x, nmodes=self.mmax, dim=-1, norm="forward")
+        # apply real fft in the longitudinal direction. The 2*pi scale factor is folded into
+        # the quadrature weights, so no scaling of the complex output is needed here.
+        x = rfft(x, nmodes=self.mmax, dim=-1, norm="forward")
 
         # transpose to put the contraction dim (nlat) on the fast axis
         x = x.transpose(-1, -2)
@@ -438,6 +444,10 @@ class RealVectorSHT(nn.Module):
         # precompute associated Legendre polynomials
         dpct = _precompute_dlegpoly(self.mmax, self.lmax, tq, norm=self.norm, csphase=self.csphase)
 
+        # fold the 2*pi longitudinal scale factor of the forward-normalized FFT into the
+        # quadrature weights (see RealSHT.__init__)
+        weights = 2.0 * torch.pi * weights
+
         # combine integration weights, normalization factor in to one:
         l = torch.arange(0, self.lmax)
         norm_factor = 1.0 / l / (l + 1)
@@ -474,8 +484,9 @@ class RealVectorSHT(nn.Module):
         check(x.shape[-2] == self.nlat, lambda: f"Expected latitudes shape[-2]=={self.nlat}, got {x.shape[-2]}")
         check(x.shape[-1] == self.nlon, lambda: f"Expected longitudes shape[-1]=={self.nlon}, got {x.shape[-1]}")
 
-        # apply real fft in the longitudinal direction
-        x = 2.0 * torch.pi * rfft(x, nmodes=self.mmax, dim=-1, norm="forward")
+        # apply real fft in the longitudinal direction. The 2*pi scale factor is folded into
+        # the quadrature weights, so no scaling of the complex output is needed here.
+        x = rfft(x, nmodes=self.mmax, dim=-1, norm="forward")
 
         # transpose to put the contraction dim (nlat) on the fast axis
         x = x.transpose(-1, -2)
@@ -493,7 +504,16 @@ class RealVectorSHT(nn.Module):
         t_re = -torch.einsum("...mk,mlk->...lm", x_im[..., 0, :, :], w1) - torch.einsum("...mk,mlk->...lm", x_re[..., 1, :, :], w0)
         t_im = torch.einsum("...mk,mlk->...lm", x_re[..., 0, :, :], w1) - torch.einsum("...mk,mlk->...lm", x_im[..., 1, :, :], w0)
 
-        return torch.stack((torch.complex(s_re, s_im), torch.complex(t_re, t_im)), dim=-3)
+        # stack the spheroidal and toroidal components in real space, so the only complex-typed
+        # op is a single aten.complex over contiguous operands. Stacking complex tensors instead
+        # would leave a complex cat, which inductor cannot codegen (triton has no complex type),
+        # and feeding aten.complex the non-contiguous ...lm einsum outputs directly trips
+        # assert_size_stride, as its meta predicts a contiguous layout. torch.stack allocates a
+        # fresh contiguous buffer, which is exactly what that meta expects.
+        out_re = torch.stack((s_re, t_re), dim=-3)
+        out_im = torch.stack((s_im, t_im), dim=-3)
+
+        return torch.complex(out_re, out_im)
 
 
 class InverseRealVectorSHT(nn.Module):
@@ -643,8 +663,10 @@ class InverseRealVectorSHT(nn.Module):
         trl = -torch.einsum("...ml,mkl->...km", x_im[..., 0, :, :], d1) - torch.einsum("...ml,mkl->...km", x_re[..., 1, :, :], d0)
         tim = torch.einsum("...ml,mkl->...km", x_re[..., 0, :, :], d1) - torch.einsum("...ml,mkl->...km", x_im[..., 1, :, :], d0)
 
-        # reassemble and apply inverse FFT
-        xs = torch.stack((torch.complex(srl, sim), torch.complex(trl, tim)), dim=-3)
+        # reassemble in real space and apply inverse FFT, see RealVectorSHT.forward
+        out_re = torch.stack((srl, trl), dim=-3)
+        out_im = torch.stack((sim, tim), dim=-3)
+        xs = torch.complex(out_re, out_im)
         x = irfft(xs, n=self.nlon, dim=-1, norm="forward")
 
         return x

--- a/torch_harmonics/spectral_convolution.py
+++ b/torch_harmonics/spectral_convolution.py
@@ -223,20 +223,27 @@ class SpectralConvS2(nn.Module):
             if hasattr(self, "spectral_bias"):
                 integral = self.quadrature(x)
 
-            # perform SHT
-            x = self.sht(x).contiguous()
+            # perform SHT. The result is contiguous by construction, so no .contiguous() here:
+            # a copy over a complex buffer cannot be codegen'd by inductor, as triton has no
+            # complex type and the kernel signature then fails with KeyError: 'complex64'.
+            x = self.sht(x)
 
         # store the shapes
         B, C, H, W = x.shape
 
-        # deal with bias
+        # deal with bias. `integral` is computed from the real-valued input above, so it is a
+        # real tensor and broadcasts over the re/im axis: applying the bias on the real view is
+        # exact and keeps this pointwise op off the complex dtype (see above).
         if hasattr(self, "spectral_bias"):
-            x = x + integral.reshape(B, C, 1, 1) * self.spectral_bias
+            bias = integral.reshape(B, C, 1, 1, 1) * torch.view_as_real(self.spectral_bias)
+            x = torch.view_as_complex(torch.view_as_real(x) + bias)
 
         # perform contraction
         x = x.reshape(B, self.num_groups, C // self.num_groups, H, W)
         xp = self._contract_lwise(x, self.weight)
-        x = xp.reshape(B, self.out_channels, H, W).contiguous()
+        # merge the group axes on the real view: the einsum output can be non-contiguous, in
+        # which case this reshape copies, and that copy must not be over a complex buffer
+        x = torch.view_as_complex(torch.view_as_real(xp).reshape(B, self.out_channels, H, W, 2).contiguous())
 
         with torch.amp.autocast(device_type=x.device.type, enabled=False):
             x = self.isht(x)

--- a/torch_harmonics/utils.py
+++ b/torch_harmonics/utils.py
@@ -100,12 +100,31 @@ def load_mola_elevation(
     return data
 
 
+def _contiguous(x: torch.Tensor) -> torch.Tensor:
+    """
+    ``x.contiguous()``, performed in real space for complex inputs.
+
+    Inductor cannot generate a Triton kernel that reads or writes a complex buffer: complex
+    dtypes have no Triton type, so the copy that ``contiguous()`` lowers to dies in codegen
+    with ``KeyError: 'complex64'``. ``view_as_real``/``view_as_complex`` are pure views (the
+    former is the one consumer for which inductor's complex-tensor check makes an exception),
+    so routing the copy through them yields a bit-identical result from a real-dtype kernel.
+
+    Nothing is written in place, so this does not reintroduce the autograd breakage that the
+    old ``xout[..., 0] = ...`` / ``view_as_complex`` pattern caused.
+    """
+
+    if x.is_complex():
+        return torch.view_as_complex(torch.view_as_real(x).contiguous())
+    return x.contiguous()
+
+
 class _EnsureContiguous(torch.autograd.Function):
     """Ensures the tensor is contiguous in both the forward and backward pass."""
 
     @staticmethod
     def forward(x):
-        return x.contiguous()
+        return _contiguous(x)
 
     @staticmethod
     def setup_context(ctx, inputs, output):
@@ -113,7 +132,9 @@ class _EnsureContiguous(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad):
-        return grad.contiguous()
+        # load-bearing: an upstream layer can hand back a non-contiguous gradient, and the
+        # CPU/MKL FFT backward rejects the resulting stride pattern (DftiCommitDescriptor).
+        return _contiguous(grad)
 
 
 def ensure_contiguous(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Problem

  `torch.compile` of any model containing `SpectralConvS2` (or the SHT layers directly)
  fails on CUDA during inductor codegen:

  File "torch/_inductor/codegen/triton_utils.py", line 48, in signature_of
    typ = _type_of(arg.dtype)
  File "torch/_inductor/utils.py", line 507, in _type_of
    return key if isinstance(key, str) else f"*{tys[dtype_str]}"
  torch._inductor.exc.InductorError: KeyError: 'complex64'

  Triton has no complex type, so inductor cannot generate a kernel that reads or writes a
  complex buffer. Complex ops are expected to fall back to eager extern kernels, but several
  pointwise ops in these layers were lowered into Triton kernels instead, and codegen died
  when building the kernel signature.

  The transforms also had a second, latent exposure: `aten.complex` is a fallback kernel, and
  inductor's meta for it predicts a contiguous output. Given non-contiguous operands, eager's
  TensorIterator allocates a permuted output instead, and the emitted `assert_size_stride`
  fires. The scalar transforms had already been fixed for this; the vector ones had not, and
  the distributed vector transforms applied their `.contiguous()` after `torch.stack`, which is
  too late — the assert fires on `aten.complex`'s own output.

  ## Approach

  Keep the complex dtype off every pointwise op. Scaling, stacking, contiguity and reshapes now
  run on real tensors (directly, or via `view_as_real`/`view_as_complex`, which are pure views),
  leaving `aten.complex` and the FFTs — both fallbacks — as the only complex-typed nodes.

  `view_as_real` is specifically the one consumer for which inductor's complex-tensor check
  makes an exception, so this is the sanctioned way to hand complex data to real codegen. Note
  that none of it reintroduces the in-place writes that motivated removing `view_as_complex`
  from these layers in `6f7706a`: every use here is out-of-place.

  ## Changes

  **`sht.py`, `distributed/distributed_sht.py`**

  - Fold the `2*pi` longitudinal scale factor of the forward-normalized FFT into the precomputed
    quadrature weights, instead of scaling the complex FFT output on every call. It is a constant
    prefactor of a linear transform, so this is exact, and it removes a complex multiply from the
    hot path of all four forward transforms.
  - The vector transforms now stack the spheroidal/toroidal components in real space and assemble
    the result with a single `torch.complex` over the (contiguous) stack outputs. This drops a
    complex `cat` and fixes the `assert_size_stride` exposure in one step. The now-dead
    `.contiguous()` after the stack in the distributed versions is gone.

  **`utils.py`**

  - `_EnsureContiguous` performs its copy on the real view for complex tensors. The backward is
    load-bearing — an upstream layer can hand back a non-contiguous gradient that the CPU/MKL FFT
    backward rejects (`DftiCommitDescriptor`) — so it is preserved, just no longer complex-typed.
  ## Changes

  **`sht.py`, `distributed/distributed_sht.py`**

  - Fold the `2*pi` longitudinal scale factor of the forward-normalized FFT into the precomputed
    quadrature weights, instead of scaling the complex FFT output on every call. It is a constant
    prefactor of a linear transform, so this is exact, and it removes a complex multiply from the
    hot path of all four forward transforms.
  - The vector transforms now stack the spheroidal/toroidal components in real space and assemble
    the result with a single `torch.complex` over the (contiguous) stack outputs. This drops a
    complex `cat` and fixes the `assert_size_stride` exposure in one step. The now-dead
    `.contiguous()` after the stack in the distributed versions is gone.

  **`utils.py`**

  - `_EnsureContiguous` performs its copy on the real view for complex tensors. The backward is
    load-bearing — an upstream layer can hand back a non-contiguous gradient that the CPU/MKL FFT
    backward rejects (`DftiCommitDescriptor`) — so it is preserved, just no longer complex-typed.

  **`distributed/primitives.py`**

  - `flatten_and_pad_leading_dims` / `unpad_and_unflatten_leading_dims` do their layout work on the
    real view when handed complex input. These are pure leading-dim helpers, so the appended re/im
    axis is simply carried along. Covers the `reshape`, the zero-padding `cat` and the `contiguous`.

  **`spectral_convolution.py`, `distributed/distributed_spectral_convolution.py`**

**`spectral_convolution.py`, `distributed/distributed_spectral_convolution.py`**

- Dropped `.contiguous()` after `self.sht(x)`; the SHT output is now contiguous by construction.
- The spectral bias is applied on the real view. `integral` is computed from the real-valued
  input, so it is a real tensor broadcasting over the re/im axis and the rewrite is exact.
- The post-contraction reshape merges the group axes on the real view. Unlike the `sht` case the
  `.contiguous()` is kept: the einsum output can be non-contiguous, so this reshape may copy —
  the point is only that the copy is real-dtype.

## Tests

- `tests/test_sht.py`: `test_compile` in the scalar and vector serial classes — round trip under
  `fullgraph=True`, forward and backward against eager, three grid/parity cases each. The round
  trip is compiled as one function so the coefficients are an intermediate buffer rather than a
  graph output, which is the case inductor has to codegen.
- `tests/test_spectral_convolution.py`: `test_compile`, four cases over bias on/off and
  grouped/ungrouped. `fullgraph` is not requested here since `_contract_lwise` carries its own
  `@torch.compile`; the claim is that codegen succeeds, not that the layer forms a single graph.

Both classes are parameterized over CPU and CUDA. The `KeyError` is Triton-specific, so the CUDA
runs are what cover it; CPU exercises the C++ backend, where the exposure is the stride assert.

## Verification

`tests/test_spectral_convolution.py` passes on CPU and CUDA (54 tests). The SHT and distributed
tests still need to be run.

The distributed changes have no compile coverage by design and rest on the existing correctness
tests — including the `B*C = 1` / `B*C = 2` rows, which are what exercise the zero-padding branch
on complex input under a real process grid.

## Notes for reviewers

- The `2*pi` fold is the one change that could silently alter numerics if mis-sited. The accuracy
  tests (`test_known_function`, `test_parseval`, the vector consistency tests) are the guard.
- The SHT `weights` buffers are all `persistent=False`, so folding the constant into them has no
  checkpoint-compatibility implication.
- Downstream models carrying their own copy of `spectral_convolution.py` (e.g. makani) need the
  same three edits; the change here does not reach them.
  runs are what cover it; CPU exercises the C++ backend, where the exposure is the stride assert.

  ## Verification

  `tests/test_spectral_convolution.py` passes on CPU and CUDA (54 tests). The SHT and distributed
  tests still need to be run.

  The distributed changes have no compile coverage by design and rest on the existing correctness
  tests — including the `B*C = 1` / `B*C = 2` rows, which are what exercise the zero-padding branch
  on complex input under a real process grid.

  ## Notes for reviewers

  - The `2*pi` fold is the one change that could silently alter numerics if mis-sited. The accuracy
    tests (`test_known_function`, `test_parseval`, the vector consistency tests) are the guard.
  - The SHT `weights` buffers are all `persistent=False`, so folding the constant into them has no
    checkpoint-compatibility implication.
  - Downstream models carrying their own copy of `spectral_convolution.py` (e.g. makani) need the